### PR TITLE
fix: make ix CLI available immediately after install

### DIFF
--- a/homebrew/ix.rb
+++ b/homebrew/ix.rb
@@ -9,8 +9,14 @@ class Ix < Formula
   depends_on "node@22"
 
   def install
+    # core-ingestion must be built first — the CLI build depends on it
+    cd "core-ingestion" do
+      system "npm", "install", "--silent"
+      system "npm", "run", "build"
+    end
+
     cd "ix-cli" do
-      system "npm", "install", "--production", "--silent"
+      system "npm", "install", "--silent"
       system "npm", "run", "build"
 
       # Install the compiled CLI and its dependencies

--- a/install.ps1
+++ b/install.ps1
@@ -199,6 +199,11 @@ if ($existingVersion -eq $Version) {
         [Environment]::SetEnvironmentVariable("PATH", "$IxBin;$userPath", "User")
         Write-Ok "Added $IxBin to user PATH"
     }
+
+    # Make ix available in the current session immediately
+    if ($env:Path -notlike "*$IxBin*") {
+        $env:Path = "$IxBin;$env:Path"
+    }
 }
 
 # ── Step 4: Claude Code hooks ────────────────────────────────────────────────
@@ -228,14 +233,26 @@ Write-Host "+" + ("=" * 42) + "+" -ForegroundColor Green
 Write-Host ""
 Write-Host "  Backend:  http://localhost:8090"
 Write-Host "  ArangoDB: http://localhost:8529"
-Write-Host "  CLI:      ix docker status"
 Write-Host ""
-Write-Host "  Open a new terminal to use 'ix' commands."
+
+# Verify CLI works
+$ixCmd = Get-Command ix -ErrorAction SilentlyContinue
+if ($ixCmd) {
+    try {
+        $cliVersion = & ix --version 2>&1
+        Write-Ok "ix CLI v$cliVersion is working"
+    } catch {
+        Write-Warn "ix installed but could not verify — open a new terminal to use it"
+    }
+} else {
+    Write-Warn "ix is not in PATH yet — open a new terminal to use it"
+}
+
 Write-Host ""
 Write-Host "  Connect a project:"
 Write-Host "    cd ~\my-project"
 Write-Host "    ix init"
-Write-Host "    ix ingest .\src --recursive"
+Write-Host "    ix map .\src"
 Write-Host ""
 Write-Host "  To uninstall:"
 Write-Host "    irm $GithubRaw/uninstall.ps1 | iex"

--- a/install.sh
+++ b/install.sh
@@ -283,6 +283,11 @@ SHIM
   chmod +x "$IX_BIN/ix"
 
   ensure_path
+
+  # Make ix available in the current shell immediately
+  export PATH="$IX_BIN:$PATH"
+  hash -r 2>/dev/null || true
+
   info "Installed: ~/.local/bin/ix"
 fi
 
@@ -309,9 +314,16 @@ echo "╚═══════════════════════�
 echo ""
 echo "  Backend:  http://localhost:8090"
 echo "  ArangoDB: http://localhost:8529"
-echo "  CLI:      ix status"
 echo ""
-echo "  Open a new shell (or run: export PATH=\"\$HOME/.local/bin:\$PATH\")"
+
+# Verify CLI works
+if command -v ix >/dev/null 2>&1; then
+  CLI_VERSION=$(ix --version 2>/dev/null || echo "unknown")
+  info "ix CLI v${CLI_VERSION} is working"
+else
+  warn "ix is not in PATH yet — open a new terminal to use it"
+fi
+
 echo ""
 echo "  Connect a project:"
 echo "    cd ~/my-project && ix init"


### PR DESCRIPTION
## Summary
- **install.sh**: Exports PATH and clears bash hash after install so `ix` works immediately without opening a new terminal. Adds verification step that confirms `ix` is working.
- **install.ps1**: Updates current session `$env:Path` so `ix` works immediately. Fixes `ix ingest` → `ix map` references. Adds verification step.
- **homebrew/ix.rb**: Installs `core-ingestion` dependencies before CLI build (fixes `@types/node` missing build failure).

## Test plan
- [ ] Run `curl ... | bash` install from scratch — verify `ix status` works immediately without opening new terminal
- [ ] Run `brew install ix` — verify build succeeds
- [ ] Run PowerShell install — verify `ix` works in same session