### PR TITLE
feat: auto-merge release-please PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,6 +35,20 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      # Auto-merge the release PR when CI passes.
+      # Requires: repo Settings → General → "Allow auto-merge" enabled,
+      # and github-actions[bot] added as bypass actor in branch ruleset.
+      # This ONLY merges PRs created by release-please — not human PRs.
+      - name: Auto-merge release PR
+        if: steps.rp.outputs.pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(echo '${{ steps.rp.outputs.pr }}' | jq -r '.number')
+          if [ "$PR_NUMBER" != "null" ] && [ -n "$PR_NUMBER" ]; then
+            gh pr merge "$PR_NUMBER" --squash --auto --repo ${{ github.repository }}
+          fi
+
   build-and-release:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'


### PR DESCRIPTION
## Summary
Enables auto-merge on release-please PRs so the full pipeline runs without manual intervention:

push to main → release-please opens PR → auto-merge after CI passes → tag + release created → build-and-release job uploads tarballs + Docker image

## Requirement
Auto-merge must be enabled in the repo settings (Settings → General → Allow auto-merge). This uses gh pr merge --auto which queues the merge to happen once required checks pass.