### PR TITLE
fix: correct version display and add upgrade to help text

### DIFF
--- a/ix-cli/src/cli/commands/upgrade.ts
+++ b/ix-cli/src/cli/commands/upgrade.ts
@@ -18,7 +18,7 @@ interface VersionCache {
 function getCurrentVersion(): string {
   try {
     const pkg = JSON.parse(
-      readFileSync(join(__dirname, "../../package.json"), "utf-8")
+      readFileSync(join(__dirname, "../../../package.json"), "utf-8")
     );
     return pkg.version || "0.0.0";
   } catch {

--- a/ix-cli/src/cli/help-text.ts
+++ b/ix-cli/src/cli/help-text.ts
@@ -26,6 +26,7 @@ System:
   doctor                Check system health
   docker <action>       Manage the IX backend containers
   reset                 Wipe all graph data for a clean re-ingest
+  upgrade               Upgrade ix CLI and backend to the latest version
 `;
 
 const FOOTER = `Use "ix help advanced" for low-level graph commands.

--- a/ix-cli/src/cli/main.ts
+++ b/ix-cli/src/cli/main.ts
@@ -10,7 +10,7 @@ import { join } from "path";
 
 let cliVersion = "0.0.0";
 try {
-  const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf-8"));
+  const pkg = JSON.parse(readFileSync(join(__dirname, "../../package.json"), "utf-8"));
   cliVersion = pkg.version || "0.0.0";
 } catch {}
 


### PR DESCRIPTION
## Summary
- Fixed package.json path in main.ts and upgrade.ts — version was showing 0.0.0 because the path was wrong relative to compiled dist/ output
- Added upgrade command to ix help text

## Test plan
- [ ] ix --version shows correct version
- [ ] ix upgrade --check shows correct current version
- [ ] ix help shows upgrade command