### PR TITLE
fix: POSIX sh compatible install script with clean output

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Pick one method. All install the same thing: the `ix` CLI + a local Docker backe
 
 ### curl (macOS / Linux)
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/ix-infrastructure/Ix/main/install.sh | bash
+```sh
+curl -fsSL https://raw.githubusercontent.com/ix-infrastructure/Ix/main/install.sh | sh
 ```
 
 ### PowerShell (Windows)

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Ix — Standalone Installer
 #
 # Installs everything needed to run Ix without cloning the repo:
@@ -8,14 +8,14 @@
 #   4. Claude Code hooks (if Claude Code is installed)
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/ix-infrastructure/Ix/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/ix-infrastructure/Ix/main/install.sh | sh
 #
 # Options (env vars):
 #   IX_VERSION=0.2.0          Override version (default: latest)
 #   IX_SKIP_BACKEND=1         Skip Docker backend setup
 #   IX_SKIP_HOOKS=1           Skip Claude Code hook installation
 
-set -euo pipefail
+set -eu
 
 # -- Config --
 
@@ -24,7 +24,6 @@ GITHUB_REPO="Ix"
 GITHUB_RAW="https://raw.githubusercontent.com/${GITHUB_ORG}/${GITHUB_REPO}/main"
 
 IX_HOME="${IX_HOME:-$HOME/.ix}"
-IX_DATA="$IX_HOME/data"
 COMPOSE_DIR="$IX_HOME/backend"
 
 HEALTH_URL="http://localhost:8090/v1/health"
@@ -32,12 +31,10 @@ ARANGO_URL="http://localhost:8529/_api/version"
 
 # Pick a bin dir that's already in PATH and writable
 pick_bin_dir() {
-  # Prefer /usr/local/bin (already in PATH everywhere)
   if [ -w "/usr/local/bin" ] || [ -w "/usr/local" ]; then
     echo "/usr/local/bin"
     return
   fi
-  # Fallback to ~/.local/bin
   mkdir -p "$HOME/.local/bin"
   echo "$HOME/.local/bin"
 }
@@ -46,28 +43,44 @@ IX_BIN="$(pick_bin_dir)"
 
 # -- Helpers --
 
-info()  { printf "  \033[32m[ok]\033[0m %s\n" "$*"; }
-warn()  { printf "  \033[33m[!!]\033[0m %s\n" "$*" >&2; }
-err()   { printf "  \033[31m[error]\033[0m %s\n" "$*" >&2; exit 1; }
-step()  { printf "\n-- %s --\n" "$*"; }
+info()  { printf "  \033[32m✓\033[0m %s\n" "$*"; }
+warn()  { printf "  \033[33m!\033[0m %s\n" "$*" >&2; }
+err()   { printf "  \033[31m✗\033[0m %s\n" "$*" >&2; exit 1; }
+
+# Simple progress spinner
+spin() {
+  _msg="$1"; shift
+  printf "  %s " "$_msg"
+  "$@" >/dev/null 2>&1 &
+  _pid=$!
+  while kill -0 "$_pid" 2>/dev/null; do
+    printf "."
+    sleep 1
+  done
+  wait "$_pid"
+  _rc=$?
+  echo ""
+  return $_rc
+}
 
 ensure_path() {
-  # Only needed if using ~/.local/bin
   if [ "$IX_BIN" = "/usr/local/bin" ]; then return; fi
 
-  local path_line='export PATH="$HOME/.local/bin:$PATH"'
-  local rc_files=()
+  _path_line='export PATH="$HOME/.local/bin:$PATH"'
+  _added=false
 
-  [ -f "$HOME/.zshrc" ]  && rc_files+=("$HOME/.zshrc")
-  [ -f "$HOME/.bashrc" ] && rc_files+=("$HOME/.bashrc")
-  [ "${#rc_files[@]}" -eq 0 ] && rc_files=("$HOME/.zshrc")
-
-  for rc in "${rc_files[@]}"; do
-    [ -f "$rc" ] || touch "$rc"
-    if ! grep -Fq '.local/bin' "$rc" 2>/dev/null; then
-      printf '\n# Added by Ix installer\n%s\n' "$path_line" >> "$rc"
+  for _rc_file in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile"; do
+    if [ -f "$_rc_file" ]; then
+      if ! grep -Fq '.local/bin' "$_rc_file" 2>/dev/null; then
+        printf '\n# Added by Ix installer\n%s\n' "$_path_line" >> "$_rc_file"
+        _added=true
+      fi
     fi
   done
+
+  if [ "$_added" = false ] && [ ! -f "$HOME/.zshrc" ] && [ ! -f "$HOME/.bashrc" ]; then
+    printf '# Added by Ix installer\n%s\n' "$_path_line" >> "$HOME/.profile"
+  fi
 }
 
 # -- Resolve version --
@@ -79,11 +92,10 @@ resolve_version() {
   fi
 
   if command -v curl >/dev/null 2>&1; then
-    local latest
-    latest=$(curl -fsSL "https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/releases/latest" 2>/dev/null \
+    _latest=$(curl -fsSL "https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/releases/latest" 2>/dev/null \
       | grep '"tag_name"' | head -1 | sed 's/.*"v\(.*\)".*/\1/' || true)
-    if [ -n "$latest" ]; then
-      echo "$latest"
+    if [ -n "$_latest" ]; then
+      echo "$_latest"
       return
     fi
   fi
@@ -94,23 +106,22 @@ resolve_version() {
 # -- Detect platform --
 
 detect_platform() {
-  local os arch
-  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
-  arch="$(uname -m)"
+  _os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  _arch="$(uname -m)"
 
-  case "$os" in
-    darwin) os="darwin" ;;
-    linux)  os="linux" ;;
-    *)      err "Unsupported OS: $os" ;;
+  case "$_os" in
+    darwin) _os="darwin" ;;
+    linux)  _os="linux" ;;
+    *)      err "Unsupported OS: $_os" ;;
   esac
 
-  case "$arch" in
-    x86_64|amd64) arch="amd64" ;;
-    arm64|aarch64) arch="arm64" ;;
-    *)             err "Unsupported architecture: $arch" ;;
+  case "$_arch" in
+    x86_64|amd64) _arch="amd64" ;;
+    arm64|aarch64) _arch="arm64" ;;
+    *)             err "Unsupported architecture: $_arch" ;;
   esac
 
-  echo "${os}-${arch}"
+  echo "${_os}-${_arch}"
 }
 
 # ==============================================================================
@@ -118,43 +129,32 @@ detect_platform() {
 # ==============================================================================
 
 echo ""
-echo "╔══════════════════════════════════════════╗"
-echo "║       Ix — Install                ║"
-echo "╚══════════════════════════════════════════╝"
+echo "  Ix — Install"
 echo ""
 
 VERSION=$(resolve_version)
 PLATFORM=$(detect_platform)
 echo "  Version:  $VERSION"
 echo "  Platform: $PLATFORM"
+echo ""
 
-# -- Step 1: Check / Install Docker --
-
-step "1. Docker"
+# -- Step 1: Check Docker --
 
 if [ "${IX_SKIP_BACKEND:-}" = "1" ]; then
-  echo "  (skipped via IX_SKIP_BACKEND=1)"
+  : # skip
 else
-  if command -v docker >/dev/null 2>&1; then
-    info "Docker is installed"
-  else
+  if ! command -v docker >/dev/null 2>&1; then
     echo ""
-    echo "  Docker is required to run the IX backend (ArangoDB + Memory Layer)."
+    echo "  Docker is required to run the Ix backend."
     echo ""
     case "$(uname -s)" in
       Darwin)
-        echo "  Install Docker Desktop for macOS:"
-        echo "    https://docs.docker.com/desktop/install/mac-install/"
-        echo ""
-        echo "  Or via Homebrew:"
-        echo "    brew install --cask docker"
+        echo "  Install: https://docs.docker.com/desktop/install/mac-install/"
+        echo "  Or:      brew install --cask docker"
         ;;
       Linux)
-        echo "  Install Docker Engine:"
-        echo "    https://docs.docker.com/engine/install/"
-        echo ""
-        echo "  Quick install:"
-        echo "    curl -fsSL https://get.docker.com | sh"
+        echo "  Install: https://docs.docker.com/engine/install/"
+        echo "  Or:      curl -fsSL https://get.docker.com | sh"
         ;;
     esac
     echo ""
@@ -162,18 +162,17 @@ else
   fi
 
   if ! docker info >/dev/null 2>&1; then
-    echo ""
-    echo "  Docker is installed but not running."
     case "$(uname -s)" in
       Darwin)
-        echo "  Trying to start Docker Desktop..."
         if [ -d "/Applications/Docker.app" ]; then
           open -a Docker
-          echo "  Waiting for Docker to start (this can take 30-60 seconds)..."
-          for i in $(seq 1 30); do
+          printf "  Waiting for Docker to start "
+          _i=0
+          while [ "$_i" -lt 30 ]; do
             if docker info >/dev/null 2>&1; then break; fi
             printf "."
             sleep 2
+            _i=$((_i + 1))
           done
           echo ""
         fi
@@ -184,167 +183,141 @@ else
       err "Docker is not running. Start Docker and re-run this installer."
     fi
   fi
-  info "Docker is running"
+  info "Docker"
 fi
 
 # -- Step 2: Start Backend --
 
-step "2. Backend (ArangoDB + Memory Layer)"
-
 if [ "${IX_SKIP_BACKEND:-}" = "1" ]; then
-  echo "  (skipped via IX_SKIP_BACKEND=1)"
+  : # skip
 else
   if curl -sf "$HEALTH_URL" >/dev/null 2>&1 && curl -sf "$ARANGO_URL" >/dev/null 2>&1; then
-    info "Backend is already running and healthy"
+    info "Backend (already running)"
   else
-    stale_pid=$(lsof -ti :8090 2>/dev/null || true)
-    if [ -n "$stale_pid" ]; then
-      stale_cmd=$(ps -p "$stale_pid" -o comm= 2>/dev/null || true)
-      if [ "$stale_cmd" != "com.docker.ba" ] && [ "$stale_cmd" != "docker" ]; then
-        warn "Killing stale process on port 8090 (PID $stale_pid: $stale_cmd)"
-        kill "$stale_pid" 2>/dev/null || true
+    _stale_pid=$(lsof -ti :8090 2>/dev/null || true)
+    if [ -n "$_stale_pid" ]; then
+      _stale_cmd=$(ps -p "$_stale_pid" -o comm= 2>/dev/null || true)
+      if [ "$_stale_cmd" != "com.docker.ba" ] && [ "$_stale_cmd" != "docker" ]; then
+        kill "$_stale_pid" 2>/dev/null || true
         sleep 1
       fi
     fi
 
     mkdir -p "$COMPOSE_DIR"
-
     curl -fsSL "${GITHUB_RAW}/docker-compose.standalone.yml" -o "$COMPOSE_DIR/docker-compose.yml"
-    info "Downloaded docker-compose.yml"
 
-    echo "  Starting backend services (this may take a minute on first run)..."
-    docker compose -f "$COMPOSE_DIR/docker-compose.yml" up -d --pull always 2>&1 | sed 's/^/  /'
+    # Pull and start with suppressed output
+    if ! spin "Pulling backend images" docker compose -f "$COMPOSE_DIR/docker-compose.yml" pull; then
+      warn "Image pull had issues, attempting to start anyway"
+    fi
 
-    echo "  Waiting for services to become healthy..."
-    for i in $(seq 1 30); do
+    docker compose -f "$COMPOSE_DIR/docker-compose.yml" up -d >/dev/null 2>&1
+
+    # Wait for health
+    printf "  Waiting for backend "
+    _i=0
+    while [ "$_i" -lt 30 ]; do
       if curl -sf "$HEALTH_URL" >/dev/null 2>&1 && curl -sf "$ARANGO_URL" >/dev/null 2>&1; then
         break
       fi
       printf "."
       sleep 2
+      _i=$((_i + 1))
     done
     echo ""
 
     if curl -sf "$HEALTH_URL" >/dev/null 2>&1; then
-      info "Backend is ready"
+      info "Backend"
     else
-      warn "Backend may still be starting — check: docker compose -f $COMPOSE_DIR/docker-compose.yml logs"
+      warn "Backend may still be starting — run: ix docker logs"
     fi
   fi
-
-  echo "  Memory Layer: http://localhost:8090"
-  echo "  ArangoDB:     http://localhost:8529"
 fi
 
 # -- Step 3: Install ix CLI --
-
-step "3. ix CLI"
 
 TARBALL_NAME="ix-${VERSION}-${PLATFORM}.tar.gz"
 TARBALL_URL="https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download/v${VERSION}/${TARBALL_NAME}"
 INSTALL_DIR="$IX_HOME/cli"
 
-# Remove any stale ix from other locations
-for old_ix in "$HOME/.local/bin/ix" "/usr/local/bin/ix"; do
-  if [ "$old_ix" != "$IX_BIN/ix" ] && [ -f "$old_ix" ]; then
-    rm -f "$old_ix" 2>/dev/null || true
+# Remove stale ix from other locations
+for _old_ix in "$HOME/.local/bin/ix" "/usr/local/bin/ix"; do
+  if [ "$_old_ix" != "$IX_BIN/ix" ] && [ -f "$_old_ix" ]; then
+    rm -f "$_old_ix" 2>/dev/null || true
   fi
 done
 
-# Check if already installed at correct version
+_need_install=true
 if [ -x "$IX_BIN/ix" ]; then
-  existing_version=$("$IX_BIN/ix" --version 2>/dev/null || echo "unknown")
-  if [ "$existing_version" = "$VERSION" ]; then
-    info "ix CLI v${VERSION} is already installed"
+  _existing=$("$IX_BIN/ix" --version 2>/dev/null || echo "unknown")
+  if [ "$_existing" = "$VERSION" ]; then
+    info "CLI v${VERSION} (already installed)"
+    _need_install=false
   else
-    echo "  Upgrading ix CLI from $existing_version to $VERSION..."
     rm -rf "$INSTALL_DIR"
   fi
 fi
 
-if [ ! -x "$IX_BIN/ix" ] || [ "$("$IX_BIN/ix" --version 2>/dev/null || echo "")" != "$VERSION" ]; then
+if [ "$_need_install" = true ]; then
   mkdir -p "$INSTALL_DIR"
 
   TMP_DIR=$(mktemp -d)
   TMP_FILE="$TMP_DIR/${TARBALL_NAME}"
 
-  echo "  Downloading ix CLI v${VERSION} for ${PLATFORM}..."
-  if ! curl -fsSL "$TARBALL_URL" -o "$TMP_FILE" 2>/dev/null; then
+  if ! spin "Downloading CLI v${VERSION}" curl -fsSL "$TARBALL_URL" -o "$TMP_FILE"; then
     rm -rf "$TMP_DIR"
     echo ""
-    warn "Could not download pre-built CLI from:"
-    warn "  $TARBALL_URL"
+    warn "Could not download CLI from: $TARBALL_URL"
     echo ""
-    echo "  This likely means the release asset hasn't been uploaded yet."
-    echo "  You can build from source instead:"
-    echo ""
+    echo "  Build from source instead:"
     echo "    git clone https://github.com/${GITHUB_ORG}/${GITHUB_REPO}.git"
     echo "    cd ${GITHUB_REPO} && ./setup.sh"
     echo ""
-    err "CLI download failed. See above for alternatives."
+    err "CLI download failed."
   fi
 
-  # Extract
   tar -xzf "$TMP_FILE" -C "$INSTALL_DIR" --strip-components=1
   rm -rf "$TMP_DIR"
-  info "Extracted CLI"
 
-  # Create wrapper in bin dir
   cat > "$IX_BIN/ix" <<SHIM
-#!/usr/bin/env bash
+#!/bin/sh
 exec "$INSTALL_DIR/ix" "\$@"
 SHIM
   chmod +x "$IX_BIN/ix"
 
   ensure_path
 
-  info "Installed: $IX_BIN/ix"
+  info "CLI v${VERSION}"
 fi
 
 # -- Step 4: Claude Code Hooks --
 
-step "4. Claude Code Plugin"
-
 if [ "${IX_SKIP_HOOKS:-}" = "1" ]; then
-  echo "  (skipped via IX_SKIP_HOOKS=1)"
+  : # skip
 elif ! command -v claude >/dev/null 2>&1; then
-  echo "  (skipped — claude CLI not found)"
-  echo "  Install Claude Code and re-run, or install hooks manually:"
-  echo "    curl -fsSL ${GITHUB_RAW}/ix-plugin/install.sh | bash"
+  : # skip — claude not installed
 else
-  curl -fsSL "${GITHUB_RAW}/ix-plugin/install.sh" | bash
+  curl -fsSL "${GITHUB_RAW}/ix-plugin/install.sh" | sh 2>/dev/null
+  info "Claude Code plugin"
 fi
 
 # -- Done --
 
 echo ""
-echo "╔══════════════════════════════════════════╗"
-echo "║       Ix is ready!                ║"
-echo "╚══════════════════════════════════════════╝"
-echo ""
-echo "  Backend:  http://localhost:8090"
-echo "  ArangoDB: http://localhost:8529"
-echo ""
 
 # Verify CLI works
 if command -v ix >/dev/null 2>&1; then
-  CLI_VERSION=$(ix --version 2>/dev/null || echo "unknown")
-  info "ix CLI v${CLI_VERSION} is working"
+  _cli_ver=$(ix --version 2>/dev/null || echo "unknown")
+  info "ix v${_cli_ver} is ready"
 elif [ -x "$IX_BIN/ix" ]; then
-  CLI_VERSION=$("$IX_BIN/ix" --version 2>/dev/null || echo "unknown")
-  info "ix CLI v${CLI_VERSION} installed at $IX_BIN/ix"
+  _cli_ver=$("$IX_BIN/ix" --version 2>/dev/null || echo "unknown")
+  info "ix v${_cli_ver} installed at $IX_BIN/ix"
   if [ "$IX_BIN" != "/usr/local/bin" ]; then
     echo "  Open a new terminal for 'ix' to be in your PATH"
   fi
-else
-  warn "ix not found"
 fi
 
 echo ""
-echo "  Connect a project:"
-echo "    cd ~/my-project && ix init"
-echo "    ix map ./src"
-echo ""
-echo "  To uninstall:"
-echo "    curl -fsSL ${GITHUB_RAW}/uninstall.sh | bash"
+echo "  Get started:"
+echo "    cd ~/my-project && ix map ./src"
 echo ""


### PR DESCRIPTION
## Summary
- Changed shebang from bash to sh — works in zsh, dash, ash, any POSIX shell
- Removed bash-specific features: arrays, pipefail, local keyword
- Docker pull/compose output suppressed — shows dot progress instead of streaming every layer
- Spinner helper for long operations (pull, download)
- Cleaner, more compact output overall
- Updated README curl command to pipe to sh instead of bash

## Test plan
- [ ] `curl ... | sh` works on macOS (zsh default)
- [ ] `curl ... | bash` still works
- [ ] Docker pull shows dots instead of layer spam
- [ ] CLI download shows dots instead of silence