### PR TITLE
fix: restore architecture edges for visualizer

### DIFF
--- a/memory-layer/src/main/scala/ix/memory/api/MapEncoder.scala
+++ b/memory-layer/src/main/scala/ix/memory/api/MapEncoder.scala
@@ -3,7 +3,7 @@ package ix.memory.api
 import io.circe.Json
 import io.circe.syntax._
 
-import ix.memory.map.{ArchitectureMap, MapPreflightResult, PersistenceEstimate, Region, RegionMatch, ScopedSubsystemView}
+import ix.memory.map.{ArchitectureEdge, ArchitectureMap, MapPreflightResult, PersistenceEstimate, Region, RegionMatch, ScopedSubsystemView}
 import ix.memory.model.NodeId
 
 /** Shared JSON encoding for ArchitectureMap, used by MapRoutes and SubsystemRoutes. */
@@ -18,6 +18,7 @@ object MapEncoder {
       "map_rev"      -> m.mapRev.asJson,
       "outcome"      -> m.outcome.label.asJson,
       "regions"      -> m.regions.sortBy(r => (r.level, r.label)).map(encodeRegion).asJson,
+      "edges"        -> m.edges.sortBy(e => (e.level, e.src.value.toString, e.dst.value.toString)).map(encodeEdge).asJson,
       "hierarchy"    -> buildHierarchyTree(m).asJson
     )
 
@@ -49,6 +50,17 @@ object MapEncoder {
       "crosscut_score"       -> r.crosscutScore.asJson,
       "dominant_signals"     -> r.dominantSignals.asJson,
       "interface_node_count" -> r.interfaceNodeCount.asJson
+    )
+
+  def encodeEdge(edge: ArchitectureEdge): Json =
+    Json.obj(
+      "id" -> edge.id.asJson,
+      "src" -> edge.src.value.toString.asJson,
+      "dst" -> edge.dst.value.toString.asJson,
+      "level" -> edge.level.asJson,
+      "weight" -> edge.weight.asJson,
+      "dominant_signal" -> edge.dominantSignal.asJson,
+      "predicate_counts" -> edge.predicateCounts.asJson
     )
 
   def encodeScopedView(view: ScopedSubsystemView, isCrossCutting: Region => Boolean): Json =

--- a/memory-layer/src/main/scala/ix/memory/map/MapService.scala
+++ b/memory-layer/src/main/scala/ix/memory/map/MapService.scala
@@ -608,6 +608,102 @@ class MapService(
       case other                   => other.toLowerCase
     }
 
+  // ── Architecture edge computation ──────────────────────────────────
+
+  private def computeArchitectureEdges(
+    regions: Vector[Region],
+    graph:   WeightedFileGraph
+  ): Vector[ArchitectureEdge] = {
+    if (regions.isEmpty || graph.predicatePairs.isEmpty) return Vector.empty
+
+    def buildEdge(
+      idSeed: String,
+      src: NodeId,
+      dst: NodeId,
+      level: Int,
+      predicateCounts: Map[String, Int]
+    ): Option[ArchitectureEdge] = {
+      val signalScores = predicateCounts.toVector
+        .map { case (predicate, count) =>
+          signalCategory(predicate) -> (SignalWeights.getOrElse(predicate, 0.0) * math.log1p(count.toDouble))
+        }
+        .groupBy(_._1)
+        .view
+        .mapValues(_.map(_._2).sum)
+        .toMap
+
+      val weight = signalScores.values.sum
+      if (weight <= 0.0) None
+      else {
+        val dominantSignal = signalScores.toVector
+          .sortBy { case (signal, score) => (-score, signal) }
+          .headOption
+          .map(_._1)
+          .getOrElse("path")
+
+        Some(ArchitectureEdge(
+          id = UUID.nameUUIDFromBytes(idSeed.getBytes("UTF-8")).toString,
+          src = src,
+          dst = dst,
+          level = level,
+          weight = weight,
+          dominantSignal = dominantSignal,
+          predicateCounts = predicateCounts
+        ))
+      }
+    }
+
+    // File-level edges (level 0)
+    val fileEdges = graph.predicatePairs.toVector.flatMap { case ((src, dst), predicateCounts) =>
+      buildEdge(
+        idSeed = s"map:file-edge:${src.value}:${dst.value}",
+        src = src,
+        dst = dst,
+        level = 0,
+        predicateCounts = predicateCounts.filter(_._2 > 0)
+      )
+    }
+
+    // Region-level edges: aggregate file pairs into region pairs per level
+    val fileToRegionByLevel: Map[Int, Map[NodeId, Region]] = regions.groupBy(_.level).view.mapValues { levelRegions =>
+      levelRegions.toVector.flatMap(region =>
+        region.memberFiles.toVector.map(fileId => fileId -> region)
+      ).toMap
+    }.toMap
+
+    val aggregated = scala.collection.mutable.Map.empty[(Int, NodeId, NodeId), scala.collection.mutable.Map[String, Int]]
+
+    for {
+      ((srcFile, dstFile), predicateCounts) <- graph.predicatePairs
+      (level, byFile) <- fileToRegionByLevel
+      srcRegion <- byFile.get(srcFile)
+      dstRegion <- byFile.get(dstFile)
+      if srcRegion.id != dstRegion.id
+    } {
+      val (srcRegionId, dstRegionId) = canonicalRegionPair(srcRegion.id, dstRegion.id)
+      val bucket = aggregated.getOrElseUpdate(
+        (level, srcRegionId, dstRegionId),
+        scala.collection.mutable.Map.empty[String, Int]
+      )
+      predicateCounts.foreach { case (predicate, count) =>
+        bucket.update(predicate, bucket.getOrElse(predicate, 0) + count)
+      }
+    }
+
+    val regionEdges = aggregated.toVector.flatMap { case ((level, src, dst), predicateCountsMut) =>
+      val predicateCounts = predicateCountsMut.toMap.filter(_._2 > 0)
+      buildEdge(
+        idSeed = s"map:region-edge:$level:${src.value}:${dst.value}",
+        src = src,
+        dst = dst,
+        level = level,
+        predicateCounts = predicateCounts
+      )
+    }
+
+    (regionEdges ++ fileEdges).sortBy(edge => (edge.level, edge.src.value.toString, edge.dst.value.toString))
+  }
+
   // ── Confidence scoring ──────────────────────────────────────────────
 
   private def computeConfidence(
@@ -643,8 +739,10 @@ class MapService(
       levels         <- IO.blocking(LouvainClustering.cluster(graph, maxLevels = 3, minCommunitySize = 3))
       t3             <- IO(System.currentTimeMillis())
       regions        <- IO.blocking(buildRegions(graph, levels, crosscutScores, inputRev))
+      edges          <- IO.blocking(computeArchitectureEdges(regions, rawGraph))
       fresh           = ArchitectureMap(
                           regions = regions,
+                          edges = edges,
                           fileCount = rawGraph.vertices.size,
                           mapRev = inputRev.value,
                           preflight = Some(preflightEval),
@@ -677,9 +775,12 @@ class MapService(
       decoded = rows.flatMap(decodePersistedRegion(_, inputRev)).toVector
       regions  = rehydrateRelationships(decoded)
       fileCount <- if (regions.isEmpty) IO.pure(0) else fullBuilder.liveFileCount()
+      rawGraphOpt <- if (regions.isEmpty) IO.pure(None)
+                     else fullBuilder.discoverFiles().flatMap(fullBuilder.buildGraph).map(Some(_))
+      edges = rawGraphOpt.map(g => computeArchitectureEdges(regions, g)).getOrElse(Vector.empty)
     } yield {
       if (regions.isEmpty) None
-      else Some(ArchitectureMap(regions, fileCount, inputRev.value))
+      else Some(ArchitectureMap(regions, edges, fileCount, inputRev.value))
     }
 
   private def decodePersistedRegion(json: Json, inputRev: Rev): Option[Region] = {

--- a/memory-layer/src/main/scala/ix/memory/map/MapTypes.scala
+++ b/memory-layer/src/main/scala/ix/memory/map/MapTypes.scala
@@ -139,6 +139,7 @@ class MapCapacityException(
 /** The full multi-level architecture map returned by MapService. */
 final case class ArchitectureMap(
   regions:              Vector[Region],
+  edges:                Vector[ArchitectureEdge] = Vector.empty,
   fileCount:            Int,
   mapRev:               Long,
   preflight:            Option[MapPreflightResult] = None,


### PR DESCRIPTION
## Summary
- Restores inter-region `ArchitectureEdge` computation that was dropped when PR #60 (large-repo-map-perf) rewrote MapService
- PR #56 (sam/visualizer-integration) added these edges for the system compass visualizer, but the rewrite lost them

## Changes
- **MapTypes.scala**: Re-add `edges: Vector[ArchitectureEdge]` field to `ArchitectureMap` (default `Vector.empty` for backwards compat)
- **MapService.scala**: Restore `computeArchitectureEdges()` — aggregates file-level predicate pairs into weighted, signal-scored edges at both file and region levels
- **MapEncoder.scala**: Restore `encodeEdge()` and add `edges` array to the map JSON response

## Validation
- `sbt memoryLayer/compile` — clean
- `sbt memoryLayer/test` — 107 tests pass, 0 failures
- Existing tests unaffected (edges field has a default value)

## Test plan
- [x] Scala compilation passes
- [x] All 107 unit tests pass
- [ ] End-to-end: `ix map --format json` includes `edges` array with region-level and file-level edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)