### PR TITLE
fix(install): fix version parsing from GitHub API

### DIFF
--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -81,7 +81,7 @@ resolve_version() {
   if command -v curl >/dev/null 2>&1; then
     local latest
     latest=$(curl -fsSL "https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/releases/latest" 2>/dev/null \
-      | grep '"tag_name"' | head -1 | sed 's/.*"v\(.*\)".*/\1/' || true)
+      | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"v\([^"]*\)".*/\1/p' || true)
     if [ -n "$latest" ]; then
       echo "$latest"
       return


### PR DESCRIPTION
## Summary
- Fixes `resolve_version()` in the install script — the `grep | sed` pipeline broke on compact single-line JSON from the GitHub API, leaking the entire response into the version string
- Replaced with a single `sed -n` extraction that handles single-line JSON correctly

## Test plan
- [x] Tested locally: `bash scripts/install/install.sh` — resolves `0.4.7` cleanly and installs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)