### PR TITLE
fix(release): use --legacy-peer-deps for compass build

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -115,15 +115,23 @@ jobs:
 
       # ── 3b. Build System Compass (optional — needs COMPASS_TOKEN secret) ─
       - name: Build System Compass
-        if: ${{ secrets.COMPASS_TOKEN != '' }}
         continue-on-error: true
         env:
           COMPASS_TOKEN: ${{ secrets.COMPASS_TOKEN }}
         run: |
+          if [ -z "$COMPASS_TOKEN" ]; then
+            echo "COMPASS_TOKEN not set — skipping compass build"
+            exit 0
+          fi
           git clone https://x-access-token:${COMPASS_TOKEN}@github.com/ix-infrastructure/system-compass.git
           cd system-compass
-          npm ci --silent
+          npm ci --legacy-peer-deps
           npm run build
+          # Verify the build produced output
+          if [ ! -f dist/index.html ]; then
+            echo "::error::Compass build did not produce dist/index.html"
+            exit 1
+          fi
 
       # ── 3c. Write version manifest ─────────────────────────────────────
       - name: Write version manifest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,8 +117,13 @@ jobs:
           fi
           git clone https://x-access-token:${COMPASS_TOKEN}@github.com/ix-infrastructure/system-compass.git
           cd system-compass
-          npm ci --silent
+          npm ci --legacy-peer-deps
           npm run build
+          # Verify the build produced output
+          if [ ! -f dist/index.html ]; then
+            echo "::error::Compass build did not produce dist/index.html"
+            exit 1
+          fi
 
       # ── 4. Package CLI tarballs ─────────────────────────────────────────
       - name: Package CLI (linux-amd64)


### PR DESCRIPTION
## Summary
- **Root cause:** `npm ci` fails because `lovable-tagger@1.1.13` requires `vite <8.0.0` but system-compass uses `vite@8.0.0`. npm's strict peer resolution rejects this, `--silent` hid the error, and `continue-on-error: true` let releases ship with an empty `compass/` directory — causing `ix view` to fail with "Compass UI not found".
- **Fix:** `npm ci --silent` → `npm ci --legacy-peer-deps` in both `release.yml` and `release-please.yml` (matches bun's lenient resolution used in local dev)
- **Guard:** Added post-build verification that `dist/index.html` exists so future build failures surface immediately via `::error::` annotation

## Test plan
- [x] Verified locally: `npm ci --legacy-peer-deps && npm run build` succeeds and produces `dist/index.html`
- [x] Trigger a release and confirm the tarball includes compass files (not just an empty dir)
- [ ] Install via `curl -fsSL https://ix-infra.com/install.sh | sh` and confirm `ix view` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)