### PR TITLE
fix: compass upgrade on Windows + stop update nag

### DIFF
--- a/ix-cli/src/cli/commands/upgrade.ts
+++ b/ix-cli/src/cli/commands/upgrade.ts
@@ -120,6 +120,7 @@ export async function checkForUpdate(): Promise<void> {
     const hasCliUpdate = isNewer(cache.latest, current);
     const compassCurrent = getCompassVersion();
     const hasCompassUpdate =
+      compassCurrent !== "0.0.0" &&
       cache.compassLatest && isNewer(cache.compassLatest, compassCurrent);
     if (hasCliUpdate || hasCompassUpdate) {
       printUpdateNotice(current, cache.latest, !!hasCompassUpdate);
@@ -134,6 +135,7 @@ export async function checkForUpdate(): Promise<void> {
       const compassCurrent = getCompassVersion();
       const hasCliUpdate = isNewer(latest, current);
       const hasCompassUpdate =
+        compassCurrent !== "0.0.0" &&
         compassLatest && isNewer(compassLatest, compassCurrent);
       if (hasCliUpdate || hasCompassUpdate) {
         printUpdateNotice(current, latest, hasCompassUpdate ? true : false);
@@ -317,9 +319,18 @@ export function registerUpgradeCommand(program: Command): void {
           // Clear old compass files, then extract new ones
           rmSync(COMPASS_DIR, { recursive: true, force: true });
           mkdirSync(COMPASS_DIR, { recursive: true });
+          // On Windows/MINGW, convert paths for tar
+          let tarFile = compassTar;
+          let tarDest = COMPASS_DIR;
+          if (process.platform === "win32") {
+            try {
+              tarFile = execFileSync("cygpath", ["-u", compassTar], { encoding: "utf-8" }).trim();
+              tarDest = execFileSync("cygpath", ["-u", COMPASS_DIR], { encoding: "utf-8" }).trim();
+            } catch { /* use as-is */ }
+          }
           execFileSync(
             "tar",
-            ["-xzf", compassTar, "-C", COMPASS_DIR, "--strip-components=1"],
+            ["-xzf", tarFile, "-C", tarDest, "--strip-components=1"],
             { stdio: "ignore" }
           );
           writeFileSync(COMPASS_VERSION_FILE, compassLatest);


### PR DESCRIPTION
## Summary
- **Windows fix**: Add `cygpath` path conversion for `tar` during compass extraction on MINGW64, matching the existing CLI upgrade behavior. This was causing `[!!] Could not download compass update` on every `ix upgrade`.
- **Nag fix**: Only show "Compass update available" in background notifications when compass is actually installed (version != `0.0.0`). Previously, if compass was never installed or failed to install, every `ix` command would nag about a compass update that couldn't be applied.

## Test plan
- [x] Windows dev runs `ix upgrade` — compass should download and extract successfully
- [x] After upgrade, `ix status` should not show compass update notification
- [x] macOS/Linux behavior unchanged (cygpath block only runs on win32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)