### PR TITLE
chore: bump version to 0.5.1

### DIFF
--- a/ix-cli/package.json
+++ b/ix-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ix/cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "description": "Ix Memory — Persistent Memory for LLM Systems",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps `ix-cli/package.json` version from `0.5.0` to `0.5.1`
- After merge, tag `v0.5.1` on main to trigger the release workflow