### PR TITLE
fix(deps): update picomatch to 4.0.4 in core-ingestion

### DIFF
--- a/core-ingestion/package-lock.json
+++ b/core-ingestion/package-lock.json
@@ -1003,9 +1003,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "peer": true,


### PR DESCRIPTION
Resolves Dependabot alert #2 — Method Injection in POSIX Character Classes causes incorrect Glob Matching (moderate).

## Summary
Bumps picomatch from 4.0.3 to 4.0.4 in core-ingestion. The vulnerable version allowed method injection via POSIX character classes, causing incorrect glob matching. This is a transitive dependency, so only package-lock.json changed.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Bumped picomatch from 4.0.3 → 4.0.4 in core-ingestion/package-lock.json

## Validation
Ran npm audit in core-ingestion/ after update. 0 vulnerabilities found.

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format