### PR TITLE
feat: recalculate map after watch ingestion

### DIFF
--- a/ix-cli/src/cli/commands/watch.ts
+++ b/ix-cli/src/cli/commands/watch.ts
@@ -104,6 +104,17 @@ export function registerWatchCommand(program: Command): void {
           const result = await client.commitPatch(patch);
           lastHash.set(filePath, hash);
           console.log(`${chalk.cyan("[watch]")} ingested: ${chalk.bold(rel)} → rev ${result.rev}`);
+
+          // Recalculate the map after successful ingestion
+          try {
+            const mapResult = await client.map();
+            const systems = mapResult.regions?.filter((r: any) => r.label_kind === "system").length ?? 0;
+            const subsystems = mapResult.regions?.filter((r: any) => r.label_kind === "subsystem").length ?? 0;
+            const modules = mapResult.regions?.filter((r: any) => r.label_kind === "module").length ?? 0;
+            console.log(`${chalk.cyan("[watch]")} map updated: ${systems}s/${subsystems}ss/${modules}m regions`);
+          } catch (mapErr: any) {
+            console.error(`${chalk.red("[watch]")} map error: ${mapErr.message}`);
+          }
         } catch (err: any) {
           console.error(`${chalk.red("[watch]")} error ingesting ${rel}: ${err.message}`);
         }
@@ -209,6 +220,7 @@ async function pollMode(
       } catch {}
     }
 
+    let anyIngested = false;
     for (const f of changed) {
       const rel = path.relative(root, f);
       console.log(`${chalk.dim("[watch]")} changed: ${rel}`);
@@ -221,8 +233,22 @@ async function pollMode(
         const patch = buildPatch(parsed, hash);
         const result = await client.commitPatch(patch);
         console.log(`${chalk.cyan("[watch]")} ingested: ${chalk.bold(rel)} → rev ${result.rev}`);
+        anyIngested = true;
       } catch (err: any) {
         console.error(`${chalk.red("[watch]")} error: ${err.message}`);
+      }
+    }
+
+    // Recalculate the map once after processing all changed files
+    if (anyIngested) {
+      try {
+        const mapResult = await client.map();
+        const systems = mapResult.regions?.filter((r: any) => r.label_kind === "system").length ?? 0;
+        const subsystems = mapResult.regions?.filter((r: any) => r.label_kind === "subsystem").length ?? 0;
+        const modules = mapResult.regions?.filter((r: any) => r.label_kind === "module").length ?? 0;
+        console.log(`${chalk.cyan("[watch]")} map updated: ${systems}s/${subsystems}ss/${modules}m regions`);
+      } catch (mapErr: any) {
+        console.error(`${chalk.red("[watch]")} map error: ${mapErr.message}`);
       }
     }
   };
@@ -234,3 +260,4 @@ async function pollMode(
     process.exit(0);
   });
 }
+


### PR DESCRIPTION
## Summary
- Watch command now triggers `client.map()` after each successful file ingestion, keeping the architectural hierarchy current as code changes
- In the fs.watch path, map recalculates per file change
- In the polling fallback path, map recalculates once per batch (after all changed files are ingested), avoiding redundant calls
- Map errors are caught and logged without interrupting the watch loop

## Test plan
- [x] Verified locally: started `ix watch`, edited a file, confirmed `[watch] map updated: 27s/0ss/29m regions` output
- [x] Verify polling fallback path triggers map after batch ingestion
- [x] Verify map errors don't crash the watch process

🤖 Generated with [Claude Code](https://claude.com/claude-code)