### PR TITLE
fix(core-ingestion): preserve effective container in chunks

### DIFF
--- a/core-ingestion/src/__tests__/queries.go.test.ts
+++ b/core-ingestion/src/__tests__/queries.go.test.ts
@@ -38,6 +38,13 @@ func (s *Service) Run() {
       dstName: 'fmt',
       predicate: 'IMPORTS',
     });
+
+    expect(result!.entities).toContainEqual(
+      expect.objectContaining({ name: 'Run', kind: 'method', container: 'Service' }),
+    );
+    expect(result!.chunks).toContainEqual(
+      expect.objectContaining({ name: 'Run', chunkKind: 'method', container: 'Service' }),
+    );
   });
 
   it('captures REFERENCES edges for pointer-typed struct fields (Bug 2)', () => {

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -480,7 +480,7 @@ export function parseFile(filePath: string, source: string): FileParseResult | n
           startByte,
           endByte,
           language,
-          container: enclosing ?? undefined,
+          container: effectiveContainer,
         });
 
         if (kind === 'class' || kind === 'interface' || kind === 'trait') {


### PR DESCRIPTION
## Summary
- keep method chunks aligned with `effectiveContainer` instead of the weaker enclosing fallback
- add a Go parser regression test that asserts both the entity and chunk retain the receiver-owned container
- preserve the previously fixed method ownership behavior in the parser output

## Test plan
- [x] `npm --prefix core-ingestion test -- --run src/__tests__/queries.go.test.ts`
- [ ] broader parser test suite if desired