### PR TITLE
feat: add cloud authentication to IxClient

### DIFF
--- a/ix-cli/src/cli/config.ts
+++ b/ix-cli/src/cli/config.ts
@@ -11,11 +11,26 @@ export interface WorkspaceConfig {
   default: boolean;
 }
 
+export interface InstanceAuth {
+  api_key: string;
+  token: string;
+  expires_at: string;
+  org_id: string;
+  plan: string;
+}
+
+export interface InstanceConfig {
+  endpoint: string;
+  auth?: InstanceAuth;
+}
+
 export interface IxConfig {
   endpoint: string;
   format: string;
   workspace?: string;
   workspaces?: WorkspaceConfig[];
+  instances?: Record<string, InstanceConfig>;
+  active?: string;
 }
 
 const defaultConfig: IxConfig = {
@@ -40,8 +55,72 @@ export function saveConfig(config: IxConfig): void {
   writeFileSync(configPath, stringify(config));
 }
 
+export function getActiveInstance(): InstanceConfig | undefined {
+  const config = loadConfig();
+  if (!config.active || !config.instances?.[config.active]) return undefined;
+  return config.instances[config.active];
+}
+
 export function getEndpoint(): string {
-  return process.env.IX_ENDPOINT || loadConfig().endpoint;
+  if (process.env.IX_ENDPOINT) return process.env.IX_ENDPOINT;
+  const instance = getActiveInstance();
+  if (instance) return instance.endpoint;
+  return loadConfig().endpoint;
+}
+
+export function getAuthToken(): string | undefined {
+  const instance = getActiveInstance();
+  if (!instance?.auth) return undefined;
+  const expiresAt = new Date(instance.auth.expires_at);
+  if (expiresAt <= new Date()) return undefined;
+  return instance.auth.token;
+}
+
+export function storeAuth(instanceName: string, auth: InstanceAuth): void {
+  const config = loadConfig() as any;
+  if (!config.instances?.[instanceName]) return;
+  config.instances[instanceName].auth = auth;
+  saveConfig(config);
+}
+
+export function clearAuth(instanceName: string): void {
+  const config = loadConfig() as any;
+  if (!config.instances?.[instanceName]) return;
+  delete config.instances[instanceName].auth;
+  saveConfig(config);
+}
+
+export async function refreshAuthIfNeeded(): Promise<string | undefined> {
+  const config = loadConfig() as any;
+  const instanceName = config.active;
+  if (!instanceName || !config.instances?.[instanceName]) return undefined;
+
+  const instance = config.instances[instanceName] as InstanceConfig;
+  if (!instance.auth) return undefined;
+
+  const expiresAt = new Date(instance.auth.expires_at);
+  const now = new Date();
+  const bufferMs = 2 * 60 * 1000;
+  if (expiresAt.getTime() - now.getTime() > bufferMs) {
+    return instance.auth.token;
+  }
+
+  try {
+    const resp = await fetch(`${instance.endpoint}/auth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ api_key: instance.auth.api_key }),
+      signal: AbortSignal.timeout(10000),
+    });
+    if (!resp.ok) return undefined;
+    const data = await resp.json() as { token: string; expires_at: string; org_id: string; plan: string };
+    instance.auth.token = data.token;
+    instance.auth.expires_at = data.expires_at;
+    saveConfig(config);
+    return data.token;
+  } catch {
+    return undefined;
+  }
 }
 
 export function loadWorkspaces(): WorkspaceConfig[] {

--- a/ix-cli/src/client/api.ts
+++ b/ix-cli/src/client/api.ts
@@ -8,9 +8,20 @@ import type {
   GraphPatchPayload,
   PatchCommitResult,
 } from "./types.js";
+import { getAuthToken } from "../cli/config.js";
 
 export class IxClient {
-  constructor(private endpoint: string = "http://localhost:8090") {}
+  private authToken?: string;
+
+  constructor(private endpoint: string = "http://localhost:8090", authToken?: string) {
+    this.authToken = authToken ?? getAuthToken();
+  }
+
+  private authHeaders(): Record<string, string> {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.authToken) headers["Authorization"] = `Bearer ${this.authToken}`;
+    return headers;
+  }
 
   async query(
     question: string,
@@ -22,7 +33,7 @@ export class IxClient {
   async ingest(path: string, recursive?: boolean, force?: boolean): Promise<IngestResult> {
     const resp = await fetch(`${this.endpoint}/v1/ingest`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: this.authHeaders(),
       body: JSON.stringify({ path, recursive, force: force || undefined }),
       signal: AbortSignal.timeout(30 * 60 * 1000), // 30 minute timeout for large repos
     });
@@ -173,7 +184,7 @@ export class IxClient {
   async commitPatch(patch: GraphPatchPayload): Promise<PatchCommitResult> {
     const resp = await fetch(`${this.endpoint}/v1/patch`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: this.authHeaders(),
       body: JSON.stringify(patch),
       signal: AbortSignal.timeout(5 * 60 * 1000), // 5 min — matches commitPatchBulk
     });
@@ -201,7 +212,7 @@ export class IxClient {
   async map(opts?: { full?: boolean }): Promise<any> {
     const resp = await fetch(`${this.endpoint}/v1/map`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: this.authHeaders(),
       body: JSON.stringify(opts ?? {}),
       signal: AbortSignal.timeout(30 * 60 * 1000), // 30 minute timeout
     });
@@ -215,7 +226,7 @@ export class IxClient {
   async commitPatchBulk(patches: GraphPatchPayload[]): Promise<PatchCommitResult> {
     const resp = await fetch(`${this.endpoint}/v1/patches/bulk`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: this.authHeaders(),
       body: JSON.stringify({ patches }),
       signal: AbortSignal.timeout(5 * 60 * 1000), // 5 min — prevents hang when k8s ingress closes idle connections
     });
@@ -264,7 +275,7 @@ export class IxClient {
   async reset(): Promise<{ ok: boolean; message: string }> {
     const resp = await fetch(`${this.endpoint}/v1/reset`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: this.authHeaders(),
       body: JSON.stringify({}),
       signal: AbortSignal.timeout(10 * 60 * 1000), // 10 minutes
     });
@@ -278,7 +289,7 @@ export class IxClient {
   async resetCode(): Promise<{ ok: boolean; message: string }> {
     const resp = await fetch(`${this.endpoint}/v1/reset/code`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: this.authHeaders(),
       body: JSON.stringify({}),
       signal: AbortSignal.timeout(10 * 60 * 1000), // 10 minutes
     });
@@ -295,7 +306,10 @@ export class IxClient {
   }
 
   async savingsReset(): Promise<any> {
-    const resp = await fetch(`${this.endpoint}/v1/savings`, { method: "DELETE" });
+    const resp = await fetch(`${this.endpoint}/v1/savings`, {
+      method: "DELETE",
+      headers: this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {},
+    });
     if (!resp.ok) {
       const text = await resp.text();
       throw new Error(`${resp.status}: ${text}`);
@@ -314,7 +328,7 @@ export class IxClient {
   private async post<T>(path: string, body: unknown): Promise<T> {
     const resp = await fetch(`${this.endpoint}${path}`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: this.authHeaders(),
       body: JSON.stringify(body),
     });
     if (!resp.ok) {
@@ -325,7 +339,9 @@ export class IxClient {
   }
 
   private async get<T>(path: string): Promise<T> {
-    const resp = await fetch(`${this.endpoint}${path}`);
+    const resp = await fetch(`${this.endpoint}${path}`, {
+      headers: this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {},
+    });
     if (!resp.ok) {
       const text = await resp.text();
       throw new Error(`${resp.status}: ${text}`);


### PR DESCRIPTION
## Summary
- Adds JWT-based cloud authentication to `IxClient` — auto-resolves auth token from config on construction, attaches `Authorization: Bearer` header to all requests
- Adds `InstanceAuth`/`InstanceConfig` types, `getAuthToken()`, `storeAuth()`, `clearAuth()`, `refreshAuthIfNeeded()` to config
- `getEndpoint()` now resolves active cloud instance endpoint instead of always returning localhost

**Companion PR:** ix-infrastructure/Ix-pro#5 (adds `ix instance login/logout` commands)

## Test plan
- [x] `ix instance add dev <endpoint>` + `ix instance login dev --api-key <key>` → verify token stored
- [x] `ix truth list` against cloud instance → verify Bearer header attached (no 401)
- [x] `ix instance use local` → verify commands hit localhost, not cloud
- [x] `ix instance use dev` → verify commands switch back to cloud endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)