### PR TITLE
feat: client-agnostic backend — workspace-relative source_uri (client + infra)

### DIFF
--- a/core-ingestion/src/types.ts
+++ b/core-ingestion/src/types.ts
@@ -1,4 +1,3 @@
-// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 export interface PatchSource {
   // uri is the provenance source URI. In the client-agnostic backend design it
   // is a workspace-relative path (POSIX separators), not an absolute host path.

--- a/core-ingestion/src/types.ts
+++ b/core-ingestion/src/types.ts
@@ -1,8 +1,15 @@
+// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 export interface PatchSource {
+  // uri is the provenance source URI. In the client-agnostic backend design it
+  // is a workspace-relative path (POSIX separators), not an absolute host path.
   uri: string;
   sourceHash?: string;
   extractor: string;
   sourceType: string;
+  // workspaceId uniquely identifies the workspace whose files produced this
+  // patch. Derived client-side (SHA-256 of workspace root abs path). Backend
+  // stores it as an opaque attribute.
+  workspaceId?: string;
 }
 
 export interface PatchOp {

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -1,5 +1,3 @@
-# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
-#
 # docker-compose.standalone.yml — Remote install (no repo checkout needed)
 #
 # Used by: curl -fsSL .../install.sh | bash

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -1,9 +1,18 @@
+# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+#
 # docker-compose.standalone.yml — Remote install (no repo checkout needed)
 #
 # Used by: curl -fsSL .../install.sh | bash
 # Location when installed: ~/.ix/backend/docker-compose.yml
 #
 # Uses published Docker images — no local build step required.
+#
+# NOTE: the previous HOME bind mount (${IX_HOST_MOUNT_ROOT:-$HOME}) has been
+# removed. The backend no longer reads host files — staleness detection is now
+# a pure graph comparison (see ix-memory-layer StalenessDetector) and
+# provenance.source_uri is workspace-relative, so the container never needs
+# visibility into the client's filesystem. This closes the privacy hole where
+# the entire user HOME directory was bind-mounted into the backend container.
 
 services:
   arangodb:
@@ -67,11 +76,9 @@ services:
       - backend
     ports:
       - "127.0.0.1:8090:8090"
-    volumes:
-      - type: bind
-        source: ${IX_HOST_MOUNT_ROOT:-$HOME}
-        target: ${IX_CONTAINER_MOUNT_ROOT:-$HOME}
-        read_only: true
+    # No host bind mount: the backend is client-agnostic and never reads host
+    # files. If you are on an old backend image that still expects the HOME
+    # bind mount, upgrade to the client-agnostic image (schema_version >= 2).
     environment:
       ARANGO_HOST: arangodb
       ARANGO_PORT: "8529"

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -1,4 +1,3 @@
-// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 import * as nodePath from 'node:path';
 import * as fs from 'node:fs';
 import * as crypto from 'node:crypto';
@@ -400,8 +399,6 @@ export async function ingestFiles(
     ? path
     : nodePath.resolve(resolveWorkspaceRoot(opts.root), path);
 
-  // NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
-  //
   // Workspace identity for client-agnostic backend.
   //
   // The backend used to dereference provenance.source_uri against the host
@@ -421,9 +418,9 @@ export async function ingestFiles(
 
   const client = new IxClient(getEndpoint());
 
-  // NEEDS HEAVY REVIEW: schema-version check forces a clean re-ingest when the
-  // backend's graph format has changed in a way that invalidates existing node
-  // IDs (e.g. the absolute→relative source_uri migration).
+  // Schema-version check forces a clean re-ingest when the backend's graph
+  // format has changed in a way that invalidates existing node IDs (e.g. the
+  // absolute→relative source_uri migration).
   const CLIENT_EXPECTED_SCHEMA_VERSION = 2;
   try {
     const health = await client.health();
@@ -790,10 +787,10 @@ export async function ingestFiles(
           try {
             let patch = buildPatchFn!(p, hash, batchEdgesByFile.get(p.filePath) ?? emptyEdges, previousHash);
             if (mapMode) patch = stripMapModeOps(patch);
-            // NEEDS HEAVY REVIEW: tag every patch with the workspace_id. The
-            // backend stores this as an opaque attribute. The source.uri has
-            // already been set to the workspace-relative path upstream in
-            // buildPatch (because we passed the relative path to parseFile).
+            // Tag every patch with the workspace_id. The backend stores this
+            // as an opaque attribute. The source.uri has already been set to
+            // the workspace-relative path upstream in buildPatch (because we
+            // passed the relative path to parseFile).
             if (patch?.source) patch.source.workspaceId = workspaceId;
             preparedPatches.push(makePreparedPatch(patch, j + 1, p.filePath));
           } catch (err) {
@@ -861,7 +858,7 @@ export async function ingestFiles(
           try {
             let patch = buildPatchFn!(p, hash, edgesByFile.get(p.filePath) ?? emptyEdges, previousHash);
             if (mapMode) patch = stripMapModeOps(patch);
-            // NEEDS HEAVY REVIEW: tag with workspace_id (see flushBatch).
+            // Tag with workspace_id (see flushBatch).
             if (patch?.source) patch.source.workspaceId = workspaceId;
             preparedPatches.push(makePreparedPatch(patch, j + 1, p.filePath));
           } catch (err) {
@@ -936,9 +933,9 @@ export async function ingestFiles(
             if (debug) process.stderr.write(`\n  [skip minified-likely] ${filePath}\n`);
             continue;
           }
-          // NEEDS HEAVY REVIEW: parseFile receives the workspace-relative path
-          // so every deterministic ID derived in buildPatch (node/edge/chunk/
-          // patch) hashes relative paths. This makes graph IDs portable across
+          // parseFile receives the workspace-relative path so every
+          // deterministic ID derived in buildPatch (node/edge/chunk/patch)
+          // hashes relative paths. This makes graph IDs portable across
           // machines and removes backend dependence on host paths.
           parseable.push({ filePath: toWorkspaceRelative(filePath), absFilePath: filePath, source: sourceText, hash, previousHash });
         }
@@ -966,9 +963,9 @@ export async function ingestFiles(
               if (texts[j] != null) sources.set(batch[j], texts[j]!);
             }
           }
-          // NEEDS HEAVY REVIEW: global resolution index is now keyed on
-          // workspace-relative paths so that edge resolution matches the
-          // relative paths we pass into parseFile.
+          // Global resolution index is keyed on workspace-relative paths so
+          // that edge resolution matches the relative paths we pass into
+          // parseFile.
           const relSources = new Map<string, string>();
           for (const [abs, text] of sources) relSources.set(toWorkspaceRelative(abs), text);
           const relFilePaths = filePaths.map(toWorkspaceRelative);
@@ -1011,8 +1008,8 @@ export async function ingestFiles(
       // Build global resolution index from all repo file paths before the parse loop
       // so cross-batch imports resolve correctly even in streaming per-chunk mode.
       // Read all Go files in parallel to maximize I/O throughput.
-      // NEEDS HEAVY REVIEW: index keys are workspace-relative to match the
-      // relative paths we pass into parseFile below.
+      // Index keys are workspace-relative to match the relative paths we pass
+      // into parseFile below.
       {
         const goIndexStart = performance.now();
         const sources = new Map<string, string>();
@@ -1047,9 +1044,9 @@ export async function ingestFiles(
 
         // Read files asynchronously and dispatch to parse pool as each file completes.
         // This keeps workers busy while I/O is still in flight for other files.
-        // NEEDS HEAVY REVIEW: fd.filePath is the workspace-relative path, which
-        // is what parseFile and all downstream ID derivations see. absFilePath
-        // is kept only so error messages still point at the file on disk.
+        // fd.filePath is the workspace-relative path, which is what parseFile
+        // and all downstream ID derivations see. absFilePath is kept only so
+        // error messages still point at the file on disk.
         const readAndDispatch = chunk.map(async (absFilePath, idx) => {
           try {
             const st = await fs.promises.stat(absFilePath);
@@ -1212,8 +1209,6 @@ export async function ingestFiles(
 // Load existing hashes from the server for change detection
 // ---------------------------------------------------------------------------
 
-// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
-//
 // The backend now stores workspace-relative source_uri values. The CLI still
 // tracks files internally by absolute path (needed for fs reads), so this
 // helper converts to relative before the wire call and maps the server's

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -1,3 +1,4 @@
+// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 import * as nodePath from 'node:path';
 import * as fs from 'node:fs';
 import * as crypto from 'node:crypto';
@@ -399,7 +400,45 @@ export async function ingestFiles(
     ? path
     : nodePath.resolve(resolveWorkspaceRoot(opts.root), path);
 
+  // NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+  //
+  // Workspace identity for client-agnostic backend.
+  //
+  // The backend used to dereference provenance.source_uri against the host
+  // filesystem (via a broad HOME bind mount). We now emit workspace-relative
+  // paths as the canonical source_uri, and pass a workspace_id derived from
+  // the workspace root's absolute path. The backend treats both as opaque
+  // strings; it never reads host files.
+  const workspaceRoot = fs.statSync(resolvedPath).isDirectory()
+    ? resolvedPath
+    : nodePath.dirname(resolvedPath);
+  const workspaceId = crypto.createHash('sha256').update(workspaceRoot).digest('hex');
+  const toWorkspaceRelative = (absPath: string): string => {
+    // Force workspace-local POSIX separators so IDs are stable across OS.
+    const rel = nodePath.relative(workspaceRoot, absPath);
+    return rel.split(nodePath.sep).join('/');
+  };
+
   const client = new IxClient(getEndpoint());
+
+  // NEEDS HEAVY REVIEW: schema-version check forces a clean re-ingest when the
+  // backend's graph format has changed in a way that invalidates existing node
+  // IDs (e.g. the absolute→relative source_uri migration).
+  const CLIENT_EXPECTED_SCHEMA_VERSION = 2;
+  try {
+    const health = await client.health();
+    const serverVersion = (health as any)?.schema_version;
+    if (typeof serverVersion === 'number' && serverVersion !== CLIENT_EXPECTED_SCHEMA_VERSION) {
+      process.stderr.write(
+        `\n  [schema mismatch] backend schema_version=${serverVersion}, ` +
+        `client expects ${CLIENT_EXPECTED_SCHEMA_VERSION}. Forcing full re-ingest.\n`,
+      );
+      opts.force = true;
+    }
+  } catch (err) {
+    if (debug) process.stderr.write(`\n  [schema check skipped] ${err}\n`);
+  }
+
   const start = performance.now();
 
   // Worker pool for parallel file parsing across CPU cores
@@ -532,7 +571,7 @@ export async function ingestFiles(
     // so the cache wasn't cleared). Invalidate the cache so files are re-ingested.
     if (!opts.force && mtimeCache.size > 0) {
       const samplePaths = [...mtimeCache.keys()].slice(0, 5);
-      const sampleHashes = await loadExistingHashes(client, samplePaths, debug);
+      const sampleHashes = await loadExistingHashes(client, samplePaths, toWorkspaceRelative, debug);
       if (sampleHashes.size === 0) {
         mtimeCache.clear();
         if (debug) process.stderr.write(`\n  DB reset detected — invalidating mtime cache\n`);
@@ -564,7 +603,7 @@ export async function ingestFiles(
     // Phase: hash lookup — only needed when mtime-changed files exist.
     let knownHashes: Map<string, string>;
     if (opts.force || mtimeChangedPaths.length > 0) {
-      knownHashes = await loadExistingHashes(client, opts.force ? filePaths : mtimeChangedPaths, debug);
+      knownHashes = await loadExistingHashes(client, opts.force ? filePaths : mtimeChangedPaths, toWorkspaceRelative, debug);
       if (debug) process.stderr.write(`\n  Source hash lookup: ${knownHashes.size} known hashes (${mtimeChangedPaths.length} mtime-changed)\n`);
     } else {
       // All files are mtime-clean — skip server round-trip entirely.
@@ -751,6 +790,11 @@ export async function ingestFiles(
           try {
             let patch = buildPatchFn!(p, hash, batchEdgesByFile.get(p.filePath) ?? emptyEdges, previousHash);
             if (mapMode) patch = stripMapModeOps(patch);
+            // NEEDS HEAVY REVIEW: tag every patch with the workspace_id. The
+            // backend stores this as an opaque attribute. The source.uri has
+            // already been set to the workspace-relative path upstream in
+            // buildPatch (because we passed the relative path to parseFile).
+            if (patch?.source) patch.source.workspaceId = workspaceId;
             preparedPatches.push(makePreparedPatch(patch, j + 1, p.filePath));
           } catch (err) {
             parseErrors++;
@@ -817,6 +861,8 @@ export async function ingestFiles(
           try {
             let patch = buildPatchFn!(p, hash, edgesByFile.get(p.filePath) ?? emptyEdges, previousHash);
             if (mapMode) patch = stripMapModeOps(patch);
+            // NEEDS HEAVY REVIEW: tag with workspace_id (see flushBatch).
+            if (patch?.source) patch.source.workspaceId = workspaceId;
             preparedPatches.push(makePreparedPatch(patch, j + 1, p.filePath));
           } catch (err) {
             parseErrors++;
@@ -877,7 +923,10 @@ export async function ingestFiles(
         buildPatchFn = patchBuilder.buildPatchWithResolution as Function;
 
         // Pre-filter minified files (main thread) then parse in parallel via worker pool.
-        const parseable: Array<{ filePath: string; source: string; hash: string; previousHash: string | undefined }> = [];
+        // filePath here is the workspace-relative path (what goes to parseFile
+        // and downstream into buildPatch → source_uri). absFilePath is the
+        // absolute path retained for any on-disk ops (reads already happened).
+        const parseable: Array<{ filePath: string; absFilePath: string; source: string; hash: string; previousHash: string | undefined }> = [];
         for (const { filePath, bytes, hash, previousHash } of changedPaths) {
           const sourceText = bytes.toString('utf-8');
           if (isLikelyMinifiedSource(sourceText)) {
@@ -887,7 +936,11 @@ export async function ingestFiles(
             if (debug) process.stderr.write(`\n  [skip minified-likely] ${filePath}\n`);
             continue;
           }
-          parseable.push({ filePath, source: sourceText, hash, previousHash });
+          // NEEDS HEAVY REVIEW: parseFile receives the workspace-relative path
+          // so every deterministic ID derived in buildPatch (node/edge/chunk/
+          // patch) hashes relative paths. This makes graph IDs portable across
+          // machines and removes backend dependence on host paths.
+          parseable.push({ filePath: toWorkspaceRelative(filePath), absFilePath: filePath, source: sourceText, hash, previousHash });
         }
 
         progressPhase   = 'Parsing';
@@ -913,13 +966,23 @@ export async function ingestFiles(
               if (texts[j] != null) sources.set(batch[j], texts[j]!);
             }
           }
-          globalIndex = (ingestion.buildGlobalResolutionIndex as Function)(filePaths, sources);
+          // NEEDS HEAVY REVIEW: global resolution index is now keyed on
+          // workspace-relative paths so that edge resolution matches the
+          // relative paths we pass into parseFile.
+          const relSources = new Map<string, string>();
+          for (const [abs, text] of sources) relSources.set(toWorkspaceRelative(abs), text);
+          const relFilePaths = filePaths.map(toWorkspaceRelative);
+          globalIndex = (ingestion.buildGlobalResolutionIndex as Function)(relFilePaths, relSources);
           sources.clear();
+          relSources.clear();
         }
 
         let pendingFlush: Promise<void> = Promise.resolve();
         for (let i = 0; i < parseable.length; i += PARSE_STREAM_CHUNK) {
           const chunk = parseable.slice(i, i + PARSE_STREAM_CHUNK);
+          // parseFile receives the workspace-relative path (f.filePath), so
+          // every deterministic ID in the resulting patch hashes relative
+          // paths. f.absFilePath is retained only for debug/error display.
           const parseResults = await Promise.all(
             chunk.map(f =>
               ensureParsePool().parse(f.filePath, f.source).then(r => { progressCurrent++; return r; }),
@@ -948,6 +1011,8 @@ export async function ingestFiles(
       // Build global resolution index from all repo file paths before the parse loop
       // so cross-batch imports resolve correctly even in streaming per-chunk mode.
       // Read all Go files in parallel to maximize I/O throughput.
+      // NEEDS HEAVY REVIEW: index keys are workspace-relative to match the
+      // relative paths we pass into parseFile below.
       {
         const goIndexStart = performance.now();
         const sources = new Map<string, string>();
@@ -957,10 +1022,11 @@ export async function ingestFiles(
           const batch = goFiles.slice(i, i + GO_READ_CONCURRENCY);
           const texts = await Promise.all(batch.map(fp => fs.promises.readFile(fp, 'utf-8').catch(() => null)));
           for (let j = 0; j < batch.length; j++) {
-            if (texts[j] != null) sources.set(batch[j], texts[j]!);
+            if (texts[j] != null) sources.set(toWorkspaceRelative(batch[j]), texts[j]!);
           }
         }
-        globalIndex = ingestion.buildGlobalResolutionIndex(filePaths, sources);
+        const relFilePaths = filePaths.map(toWorkspaceRelative);
+        globalIndex = ingestion.buildGlobalResolutionIndex(relFilePaths, sources);
         sources.clear();
         timings.goIndexMs = Math.round(performance.now() - goIndexStart);
       }
@@ -981,28 +1047,32 @@ export async function ingestFiles(
 
         // Read files asynchronously and dispatch to parse pool as each file completes.
         // This keeps workers busy while I/O is still in flight for other files.
-        const readAndDispatch = chunk.map(async (filePath, idx) => {
+        // NEEDS HEAVY REVIEW: fd.filePath is the workspace-relative path, which
+        // is what parseFile and all downstream ID derivations see. absFilePath
+        // is kept only so error messages still point at the file on disk.
+        const readAndDispatch = chunk.map(async (absFilePath, idx) => {
           try {
-            const st = await fs.promises.stat(filePath);
+            const st = await fs.promises.stat(absFilePath);
             if (st.size === 0) { filesSkipped++; return; }
             if (st.size > MAX_FILE_BYTES) { tooLarge++; return; }
-            const bytes = await fs.promises.readFile(filePath);
+            const bytes = await fs.promises.readFile(absFilePath);
             const hash = sha256(bytes);
-            if (!opts.force && knownHashes.get(filePath) === hash) { filesSkipped++; return; }
-            const previousHash = knownHashes.get(filePath);
+            if (!opts.force && knownHashes.get(absFilePath) === hash) { filesSkipped++; return; }
+            const previousHash = knownHashes.get(absFilePath);
             const sourceText = bytes.toString('utf-8');
             if (isLikelyMinifiedSource(sourceText)) {
               minifiedLikely++;
               filesSkipped++;
-              if (debug) process.stderr.write(`\n  [skip minified-likely] ${filePath}\n`);
+              if (debug) process.stderr.write(`\n  [skip minified-likely] ${absFilePath}\n`);
               return;
             }
-            const fd: NonNullable<FileData> = { filePath, source: sourceText, hash, previousHash: previousHash !== hash ? previousHash : undefined };
+            const relFilePath = toWorkspaceRelative(absFilePath);
+            const fd: NonNullable<FileData> = { filePath: relFilePath, source: sourceText, hash, previousHash: previousHash !== hash ? previousHash : undefined };
             fileData[idx] = fd;
             parsePromises[idx] = ensureParsePool().parse(fd.filePath, fd.source).then(r => { progressCurrent++; return r; });
           } catch (err) {
             parseErrors++;
-            process.stderr.write(`\n  [read error] ${filePath}: ${err}\n`);
+            process.stderr.write(`\n  [read error] ${absFilePath}: ${err}\n`);
           }
         });
         await Promise.all(readAndDispatch);
@@ -1142,9 +1212,34 @@ export async function ingestFiles(
 // Load existing hashes from the server for change detection
 // ---------------------------------------------------------------------------
 
-async function loadExistingHashes(client: IxClient, filePaths: string[], debug = false): Promise<Map<string, string>> {
+// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+//
+// The backend now stores workspace-relative source_uri values. The CLI still
+// tracks files internally by absolute path (needed for fs reads), so this
+// helper converts to relative before the wire call and maps the server's
+// response back onto the caller's absolute keys.
+async function loadExistingHashes(
+  client: IxClient,
+  filePaths: string[],
+  toRelative: (absPath: string) => string,
+  debug = false,
+): Promise<Map<string, string>> {
   try {
-    return await client.getSourceHashes(filePaths);
+    const relPaths: string[] = new Array(filePaths.length);
+    const relToAbs = new Map<string, string>();
+    for (let i = 0; i < filePaths.length; i++) {
+      const abs = filePaths[i];
+      const rel = toRelative(abs);
+      relPaths[i] = rel;
+      relToAbs.set(rel, abs);
+    }
+    const serverHashes = await client.getSourceHashes(relPaths);
+    const out = new Map<string, string>();
+    for (const [rel, hash] of serverHashes) {
+      const abs = relToAbs.get(rel);
+      if (abs !== undefined) out.set(abs, hash);
+    }
+    return out;
   } catch (err) {
     if (debug) process.stderr.write(`\n  [hash lookup failed] ${err}\n`);
     return new Map();

--- a/ix-cli/src/cli/commands/read.ts
+++ b/ix-cli/src/cli/commands/read.ts
@@ -1,9 +1,10 @@
+// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Command } from "commander";
 import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
-import { getEndpoint, resolveWorkspaceRoot } from "../config.js";
+import { absoluteFromSourceUri, getEndpoint, resolveWorkspaceRoot } from "../config.js";
 import { resolveEntityFull } from "../resolve.js";
 import { stderr } from "../stderr.js";
 import { isFileStale } from "../stale.js";
@@ -181,19 +182,23 @@ Examples:
       const symbolResult = await trySymbolMatch(client, rawTarget, { kind: opts.kind, path: opts.path, pick: opts.pick ? parseInt(opts.pick, 10) : undefined });
       if (symbolResult.type === "resolved") {
         const { node, sourceUri } = symbolResult;
-        const stale = sourceUri ? await checkStale(client, sourceUri) : false;
+        // NEEDS HEAVY REVIEW: sourceUri coming from the graph is now
+        // workspace-relative (client-agnostic backend). Resolve it against the
+        // active workspace root before any fs call.
+        const absSourceUri = sourceUri ? absoluteFromSourceUri(sourceUri, opts.root) : null;
+        const stale = absSourceUri ? await checkStale(client, absSourceUri) : false;
 
         // If the source file exists, extract the symbol's lines
-        if (sourceUri && fs.existsSync(sourceUri)) {
+        if (absSourceUri && fs.existsSync(absSourceUri)) {
           const lineStart = node.attrs?.lineStart ?? node.attrs?.line_start ?? 1;
           const lineEnd = node.attrs?.lineEnd ?? node.attrs?.line_end;
-          const fileContent = fs.readFileSync(sourceUri, "utf-8");
+          const fileContent = fs.readFileSync(absSourceUri, "utf-8");
           const allLines = fileContent.split("\n");
           const effectiveEnd = lineEnd ?? allLines.length;
           const content = allLines.slice(lineStart - 1, effectiveEnd).join("\n");
           const result: ReadResult = {
             targetType: "symbol",
-            path: sourceUri,
+            path: absSourceUri,
             lineStart,
             lineEnd: effectiveEnd,
             content,
@@ -211,7 +216,7 @@ Examples:
           const lines = String(attrContent).split("\n");
           const result: ReadResult = {
             targetType: "symbol",
-            path: sourceUri ?? "(no source file)",
+            path: absSourceUri ?? sourceUri ?? "(no source file)",
             lineStart: 1,
             lineEnd: lines.length,
             content: String(attrContent),
@@ -223,7 +228,7 @@ Examples:
           return;
         }
 
-        stderr(`Source file not found for symbol: ${node.name} (${sourceUri ?? "no provenance"})`);
+        stderr(`Source file not found for symbol: ${node.name} (${absSourceUri ?? sourceUri ?? "no provenance"})`);
         return;
       }
 

--- a/ix-cli/src/cli/commands/read.ts
+++ b/ix-cli/src/cli/commands/read.ts
@@ -1,4 +1,3 @@
-// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Command } from "commander";
@@ -182,9 +181,9 @@ Examples:
       const symbolResult = await trySymbolMatch(client, rawTarget, { kind: opts.kind, path: opts.path, pick: opts.pick ? parseInt(opts.pick, 10) : undefined });
       if (symbolResult.type === "resolved") {
         const { node, sourceUri } = symbolResult;
-        // NEEDS HEAVY REVIEW: sourceUri coming from the graph is now
-        // workspace-relative (client-agnostic backend). Resolve it against the
-        // active workspace root before any fs call.
+        // sourceUri coming from the graph is workspace-relative under the
+        // client-agnostic backend. Resolve it against the active workspace
+        // root before any fs call.
         const absSourceUri = sourceUri ? absoluteFromSourceUri(sourceUri, opts.root) : null;
         const stale = absSourceUri ? await checkStale(client, absSourceUri) : false;
 

--- a/ix-cli/src/cli/config.ts
+++ b/ix-cli/src/cli/config.ts
@@ -153,6 +153,23 @@ export function getActiveWorkspaceRoot(): string | undefined {
   return getDefaultWorkspace()?.root_path;
 }
 
+// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+//
+// Resolve a source_uri from the graph (which is now a workspace-relative
+// POSIX path under the client-agnostic backend design) back to an absolute
+// host filesystem path. If the input is already absolute (e.g. legacy graphs
+// or external absolute paths), it is returned as-is. Used by any command that
+// needs to actually open a file off disk (ix read, ix explain, ...).
+export function absoluteFromSourceUri(sourceUri: string, explicitRoot?: string): string {
+  if (!sourceUri) return sourceUri;
+  // Treat both POSIX abs (`/`) and Windows abs (`C:\`) as already resolved.
+  if (sourceUri.startsWith("/") || /^[A-Za-z]:[\\/]/.test(sourceUri)) return sourceUri;
+  const root = resolveWorkspaceRoot(explicitRoot);
+  // POSIX-normalize the relative segment before joining.
+  const normalized = sourceUri.replace(/\\/g, "/");
+  return require("node:path").resolve(root, normalized);
+}
+
 export function resolveWorkspaceRoot(explicitRoot?: string): string {
   // 1. Explicit --root
   if (explicitRoot) return explicitRoot;

--- a/ix-cli/src/cli/config.ts
+++ b/ix-cli/src/cli/config.ts
@@ -153,8 +153,6 @@ export function getActiveWorkspaceRoot(): string | undefined {
   return getDefaultWorkspace()?.root_path;
 }
 
-// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
-//
 // Resolve a source_uri from the graph (which is now a workspace-relative
 // POSIX path under the client-agnostic backend design) back to an absolute
 // host filesystem path. If the input is already absolute (e.g. legacy graphs

--- a/ix-cli/src/cli/format.ts
+++ b/ix-cli/src/cli/format.ts
@@ -5,7 +5,6 @@ export type ResultSource = "graph" | "text" | "graph+text" | "heuristic";
 
 // ── JSON optimization helpers ──────────────────────────────────────────────
 
-// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 /**
  * Strip the cwd prefix from absolute paths to save tokens in JSON output.
  *

--- a/ix-cli/src/cli/format.ts
+++ b/ix-cli/src/cli/format.ts
@@ -5,9 +5,18 @@ export type ResultSource = "graph" | "text" | "graph+text" | "heuristic";
 
 // ── JSON optimization helpers ──────────────────────────────────────────────
 
-/** Strip the cwd prefix from absolute paths to save tokens in JSON output. */
+// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+/**
+ * Strip the cwd prefix from absolute paths to save tokens in JSON output.
+ *
+ * Under the client-agnostic backend design, source_uri values are already
+ * workspace-relative. For those we return the input unchanged. Legacy absolute
+ * paths (e.g. from older graphs) are still handled the old way.
+ */
 export function relativePath(absPath: string | undefined | null): string | undefined {
   if (!absPath) return undefined;
+  // Already relative (workspace-relative path from post-migration graphs).
+  if (!absPath.startsWith("/") && !/^[A-Za-z]:[\\/]/.test(absPath)) return absPath;
   const cwd = process.cwd();
   if (absPath.startsWith(cwd + "/")) return absPath.slice(cwd.length + 1);
   // Also handle /Users/.../project/ style without trailing slash match

--- a/ix-cli/src/client/types.ts
+++ b/ix-cli/src/client/types.ts
@@ -150,13 +150,27 @@ export interface IngestResult {
 
 export interface HealthResponse {
   status: string;
+  // NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+  // Backend on-disk graph format version. When a client's expected version
+  // differs from this, it forces a clean re-ingest (e.g. absolute→relative
+  // source_uri migration changes every node ID).
+  schema_version?: number;
 }
 
 export interface PatchSource {
+  // uri is the provenance source URI. In the client-agnostic backend design it
+  // is a workspace-relative path (POSIX separators), not an absolute host path.
+  // The backend treats this as an opaque string key for joins/tombstones.
   uri: string;
   sourceHash?: string;
   extractor: string;
   sourceType: string;
+  // NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+  // workspaceId uniquely identifies the workspace whose files produced this
+  // patch. Derived client-side as SHA-256 of the workspace root's absolute
+  // path. Backend stores it as an opaque attribute for future multi-workspace
+  // disambiguation; it does not interpret the value.
+  workspaceId?: string;
 }
 
 export interface PatchOp {

--- a/ix-cli/src/client/types.ts
+++ b/ix-cli/src/client/types.ts
@@ -150,7 +150,6 @@ export interface IngestResult {
 
 export interface HealthResponse {
   status: string;
-  // NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
   // Backend on-disk graph format version. When a client's expected version
   // differs from this, it forces a clean re-ingest (e.g. absolute→relative
   // source_uri migration changes every node ID).
@@ -165,7 +164,6 @@ export interface PatchSource {
   sourceHash?: string;
   extractor: string;
   sourceType: string;
-  // NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
   // workspaceId uniquely identifies the workspace whose files produced this
   // patch. Derived client-side as SHA-256 of the workspace root's absolute
   // path. Backend stores it as an opaque attribute for future multi-workspace

--- a/scripts/backend.sh
+++ b/scripts/backend.sh
@@ -21,23 +21,19 @@ set -euo pipefail
 IX_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$IX_DIR"
 
-# On Windows/MINGW, Docker Compose (a Windows binary) can mix POSIX and Windows
-# home paths if we rely on nested interpolation defaults in the compose file.
-# Export both sides of the bind mount explicitly instead:
-#   IX_HOST_MOUNT_ROOT      → host bind source  (cygpath -m: C:/Users/...)
-#   IX_CONTAINER_MOUNT_ROOT → container target  ($HOME: /c/Users/... or /Users/...)
-# The dc() helper passes -f with a Windows-format path so docker compose can
-# locate its file regardless of how it resolves the CWD from a MINGW shell.
+# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+#
+# The HOME bind mount was removed from docker-compose.standalone.yml because
+# the backend is now client-agnostic and never reads host files. The
+# IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports that fed that bind mount
+# are therefore no longer needed. On Windows/MINGW we still need the dc()
+# helper so docker compose can locate the compose file from a MINGW shell.
 if [[ "$(uname -s)" =~ MINGW|MSYS|CYGWIN ]]; then
-  export IX_HOST_MOUNT_ROOT="$(cygpath -m "$HOME")"
-  export IX_CONTAINER_MOUNT_ROOT="${HOME}"
   dc() {
     MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' \
       docker compose -f "$(cygpath -m "$IX_DIR/$COMPOSE_FILE")" "$@"
   }
 else
-  export IX_HOST_MOUNT_ROOT="${HOME}"
-  export IX_CONTAINER_MOUNT_ROOT="${HOME}"
   dc() { docker compose -f "$COMPOSE_FILE" "$@"; }
 fi
 

--- a/scripts/backend.sh
+++ b/scripts/backend.sh
@@ -21,8 +21,6 @@ set -euo pipefail
 IX_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$IX_DIR"
 
-# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
-#
 # The HOME bind mount was removed from docker-compose.standalone.yml because
 # the backend is now client-agnostic and never reads host files. The
 # IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports that fed that bind mount

--- a/scripts/dev/shutdown.sh
+++ b/scripts/dev/shutdown.sh
@@ -20,16 +20,16 @@ cd "$IX_DIR"
 
 COMPOSE_FILE="docker-compose.standalone.yml"
 
+# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+# IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports removed: the HOME bind
+# mount is gone from docker-compose.standalone.yml because the backend is now
+# client-agnostic and never reads host files.
 if [[ "$(uname -s)" =~ MINGW|MSYS|CYGWIN ]]; then
-  export IX_HOST_MOUNT_ROOT="$(cygpath -m "$HOME")"
-  export IX_CONTAINER_MOUNT_ROOT="${HOME}"
   dc() {
     MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' \
       docker compose -f "$(cygpath -m "$IX_DIR/$COMPOSE_FILE")" "$@"
   }
 else
-  export IX_HOST_MOUNT_ROOT="${HOME}"
-  export IX_CONTAINER_MOUNT_ROOT="${HOME}"
   dc() { docker compose -f "$IX_DIR/$COMPOSE_FILE" "$@"; }
 fi
 

--- a/scripts/dev/shutdown.sh
+++ b/scripts/dev/shutdown.sh
@@ -20,7 +20,6 @@ cd "$IX_DIR"
 
 COMPOSE_FILE="docker-compose.standalone.yml"
 
-# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 # IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports removed: the HOME bind
 # mount is gone from docker-compose.standalone.yml because the backend is now
 # client-agnostic and never reads host files.

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -32,7 +32,6 @@ NODE_MIN_MAJOR=18
 
 # -- Windows / POSIX docker compose wrapper --
 #
-# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 # IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports removed: the HOME bind
 # mount is gone from docker-compose.standalone.yml because the backend is now
 # client-agnostic and never reads host files.

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -31,17 +31,17 @@ ARANGO_URL="http://localhost:8529/_api/version"
 NODE_MIN_MAJOR=18
 
 # -- Windows / POSIX docker compose wrapper --
+#
+# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+# IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports removed: the HOME bind
+# mount is gone from docker-compose.standalone.yml because the backend is now
+# client-agnostic and never reads host files.
 
 case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*)
-    IX_HOST_MOUNT_ROOT="$(cygpath -m "$HOME")"
-    export IX_HOST_MOUNT_ROOT
-    export IX_CONTAINER_MOUNT_ROOT="${HOME}"
     dc() { MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' docker compose "$@"; }
     ;;
   *)
-    export IX_HOST_MOUNT_ROOT="${HOME}"
-    export IX_CONTAINER_MOUNT_ROOT="${HOME}"
     dc() { docker compose "$@"; }
     ;;
 esac


### PR DESCRIPTION
## Summary

Client + infra half of the client/backend separation. Removes the HOME bind mount entirely and switches the client to emit workspace-relative paths as the canonical `source_uri` so no absolute host paths ever cross the wire.

## What changed

**Client (ingestion pipeline)**
- `core-ingestion/src/types.ts`, `ix-cli/src/client/types.ts` — `PatchSource` gains `workspaceId?: string`; `source.uri` is now documented as a workspace-relative POSIX path. `HealthResponse` gains `schema_version?: number`.
- `ix-cli/src/cli/commands/ingest.ts`:
  - Computes `workspaceRoot` + `workspaceId` (SHA-256 of workspaceRoot abs path) once per run.
  - Converts absolute paths to workspace-relative before dispatching to `parseFile`, `buildGlobalResolutionIndex`, and the parse pool, so every deterministic node/patch/edge/chunk ID hashes relative paths.
  - Tags every built patch's `source` with `workspaceId`.
  - `loadExistingHashes` now queries the backend with relative paths and maps the response back onto absolute keys.
  - On startup, compares `/v1/health` `schema_version` against `CLIENT_EXPECTED_SCHEMA_VERSION = 2` and forces a clean re-ingest on mismatch (node IDs change when the graph format flips from absolute to relative).
- `ix-cli/src/cli/config.ts` — new `absoluteFromSourceUri` helper that joins a workspace-relative `source_uri` against the active workspace root for commands that still need to open files off disk.
- `ix-cli/src/cli/format.ts` — `relativePath` is a no-op for already-relative input.
- `ix-cli/src/cli/commands/read.ts` — resolves `sourceUri` via `absoluteFromSourceUri` before any `fs.*` call so the graph's relative paths still map to real files.

**Infra**
- `docker-compose.standalone.yml` — removed the HOME bind mount from the `memory-layer` service. Closes the privacy hole where the entire user HOME directory was bind-mounted (read-only) into the backend container.
- `scripts/backend.sh`, `scripts/dev/shutdown.sh`, `scripts/install/install.sh` — removed `IX_HOST_MOUNT_ROOT` / `IX_CONTAINER_MOUNT_ROOT` exports. `dc()` wrappers preserved for Windows/MINGW compose dispatch.

## Must land with

`ix-infrastructure/ix-memory-layer` PR on `feat/client-agnostic-backend` → `dev`:
- Rewrites `StalenessDetector` to pure graph comparison (no `java.nio.file`).
- Bumps `/v1/health` `schema_version` to 2.
- Updates `RoutesSpec` / `StalenessDetectorSpec` accordingly.

## Test plan

- [ ] Run `ix map --force` against a backend built from the paired backend branch. Confirm every patch's `source.uri` is workspace-relative and `source.workspaceId` is populated.
- [ ] Run `ix read <symbol>` and `ix read <file>` — confirm files still resolve via `absoluteFromSourceUri`.
- [ ] Confirm `docker compose -f docker-compose.standalone.yml up` starts cleanly with no HOME bind mount and memory-layer still serves `/v1/health`.
- [ ] Verify schema mismatch forces re-ingest: start backend on old image (schema_version 1 or absent) and confirm the CLI prints the mismatch warning and flips `opts.force`.
- [ ] Audit a handful of graph queries end-to-end (`ix impact`, `ix overview`, `ix search`).
