### PR TITLE
v0.6.0: install fixes, client-agnostic backend, view port option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,8 +89,8 @@ jobs:
         run: |
           STAGING="ix-${{ steps.version.outputs.version }}-linux-amd64"
           mkdir -p "$STAGING/cli" "$STAGING/core-ingestion" "$STAGING/compass"
-          cp -r ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
-          cp -r core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
+          cp -rL ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
+          cp -rL core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
           [ -d system-compass/dist ] && cp -r system-compass/dist/* "$STAGING/compass/" || true
           cat > "$STAGING/ix" <<'WRAPPER'
           #!/bin/sh
@@ -105,8 +105,8 @@ jobs:
         run: |
           STAGING="ix-${{ steps.version.outputs.version }}-linux-arm64"
           mkdir -p "$STAGING/cli" "$STAGING/core-ingestion" "$STAGING/compass"
-          cp -r ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
-          cp -r core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
+          cp -rL ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
+          cp -rL core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
           [ -d system-compass/dist ] && cp -r system-compass/dist/* "$STAGING/compass/" || true
           cat > "$STAGING/ix" <<'WRAPPER'
           #!/bin/sh
@@ -121,8 +121,8 @@ jobs:
         run: |
           STAGING="ix-${{ steps.version.outputs.version }}-darwin-amd64"
           mkdir -p "$STAGING/cli" "$STAGING/core-ingestion" "$STAGING/compass"
-          cp -r ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
-          cp -r core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
+          cp -rL ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
+          cp -rL core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
           [ -d system-compass/dist ] && cp -r system-compass/dist/* "$STAGING/compass/" || true
           cat > "$STAGING/ix" <<'WRAPPER'
           #!/bin/sh
@@ -137,8 +137,8 @@ jobs:
         run: |
           STAGING="ix-${{ steps.version.outputs.version }}-darwin-arm64"
           mkdir -p "$STAGING/cli" "$STAGING/core-ingestion" "$STAGING/compass"
-          cp -r ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
-          cp -r core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
+          cp -rL ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
+          cp -rL core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
           [ -d system-compass/dist ] && cp -r system-compass/dist/* "$STAGING/compass/" || true
           cat > "$STAGING/ix" <<'WRAPPER'
           #!/bin/sh
@@ -153,8 +153,8 @@ jobs:
         run: |
           STAGING="ix-${{ steps.version.outputs.version }}-windows-amd64"
           mkdir -p "$STAGING/cli" "$STAGING/core-ingestion" "$STAGING/compass"
-          cp -r ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
-          cp -r core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
+          cp -rL ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
+          cp -rL core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
           [ -d system-compass/dist ] && cp -r system-compass/dist/* "$STAGING/compass/" || true
           cat > "$STAGING/ix.cmd" <<'WRAPPER'
           @echo off

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ core-ingestion/dist/
 ix-cli/dist/
 .vscode/
 .mcp.json
+# Ix agent worktrees
+.ix-worktrees/

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ gemini extensions install https://github.com/ix-infrastructure/ix-gemini-plugin
 ## Requirements
 
 - macOS, Linux, or Windows
+- Node.js 20 or newer
 - Git installed
 - Docker (for full functionality)
 

--- a/core-ingestion/src/types.ts
+++ b/core-ingestion/src/types.ts
@@ -1,4 +1,3 @@
-// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 export interface PatchSource {
   // uri is the provenance source URI. In the client-agnostic backend design it
   // is a workspace-relative path (POSIX separators), not an absolute host path.

--- a/core-ingestion/src/types.ts
+++ b/core-ingestion/src/types.ts
@@ -1,8 +1,15 @@
+// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 export interface PatchSource {
+  // uri is the provenance source URI. In the client-agnostic backend design it
+  // is a workspace-relative path (POSIX separators), not an absolute host path.
   uri: string;
   sourceHash?: string;
   extractor: string;
   sourceType: string;
+  // workspaceId uniquely identifies the workspace whose files produced this
+  // patch. Derived client-side (SHA-256 of workspace root abs path). Backend
+  // stores it as an opaque attribute.
+  workspaceId?: string;
 }
 
 export interface PatchOp {

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -1,5 +1,3 @@
-# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
-#
 # docker-compose.standalone.yml — Remote install (no repo checkout needed)
 #
 # Used by: curl -fsSL .../install.sh | bash

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -14,6 +14,7 @@ services:
       - "127.0.0.1:8529:8529"
     environment:
       ARANGO_NO_AUTH: "1"
+    command: ["arangod", "--server.endpoint", "tcp://0.0.0.0:8529", "--experimental-vector-index"]
     volumes:
       - arangodb-data:/var/lib/arangodb3
     healthcheck:
@@ -23,6 +24,42 @@ services:
       start_period: 60s
       retries: 15
     restart: unless-stopped
+
+  ollama:
+    image: ollama/ollama:latest
+    networks:
+      - backend
+    ports:
+      - "127.0.0.1:11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+    restart: unless-stopped
+    profiles:
+      - semantic
+
+  semantic-extraction:
+    image: ghcr.io/ix-infrastructure/ix-semantic-extraction:latest
+    networks:
+      - backend
+    ports:
+      - "127.0.0.1:11400:11400"
+    environment:
+      OLLAMA_BASE_URL: http://ollama:11434
+      IX_EXTRACTION_MODEL: qwen2.5vl:7b
+      IX_EMBEDDING_MODEL: "nomic-embed-text:v2-moe"
+      IX_AUTO_PULL: "true"
+      PORT: "11400"
+    depends_on:
+      - ollama
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:11400/v1/health"]
+      interval: 10s
+      timeout: 5s
+      start_period: 120s
+      retries: 10
+    restart: unless-stopped
+    profiles:
+      - semantic
 
   memory-layer:
     image: ghcr.io/ix-infrastructure/ix-memory-layer:latest
@@ -41,6 +78,7 @@ services:
       ARANGO_DATABASE: ix_memory
       ARANGO_USER: root
       ARANGO_PASSWORD: ""
+      IX_EXTRACTION_URL: http://semantic-extraction:11400
       PORT: "8090"
     depends_on:
       arangodb:
@@ -55,6 +93,7 @@ services:
 
 volumes:
   arangodb-data:
+  ollama-data:
 
 networks:
   backend:

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -1,9 +1,18 @@
+# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+#
 # docker-compose.standalone.yml — Remote install (no repo checkout needed)
 #
 # Used by: curl -fsSL .../install.sh | bash
 # Location when installed: ~/.ix/backend/docker-compose.yml
 #
 # Uses published Docker images — no local build step required.
+#
+# NOTE: the previous HOME bind mount (${IX_HOST_MOUNT_ROOT:-$HOME}) has been
+# removed. The backend no longer reads host files — staleness detection is now
+# a pure graph comparison (see ix-memory-layer StalenessDetector) and
+# provenance.source_uri is workspace-relative, so the container never needs
+# visibility into the client's filesystem. This closes the privacy hole where
+# the entire user HOME directory was bind-mounted into the backend container.
 
 services:
   arangodb:
@@ -67,11 +76,9 @@ services:
       - backend
     ports:
       - "127.0.0.1:8090:8090"
-    volumes:
-      - type: bind
-        source: ${IX_HOST_MOUNT_ROOT:-$HOME}
-        target: ${IX_CONTAINER_MOUNT_ROOT:-$HOME}
-        read_only: true
+    # No host bind mount: the backend is client-agnostic and never reads host
+    # files. If you are on an old backend image that still expects the HOME
+    # bind mount, upgrade to the client-agnostic image (schema_version >= 2).
     environment:
       ARANGO_HOST: arangodb
       ARANGO_PORT: "8529"

--- a/ix-cli/package.json
+++ b/ix-cli/package.json
@@ -12,6 +12,9 @@
   "bin": {
     "ix": "dist/cli/main.js"
   },
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "scripts": {
     "build": "node scripts/build-core-ingestion.mjs && node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
     "test": "node scripts/build-core-ingestion.mjs && vitest run --exclude test/parser.test.ts && node test/parser.smoke.mjs",

--- a/ix-cli/src/cli/__tests__/github-transform.test.ts
+++ b/ix-cli/src/cli/__tests__/github-transform.test.ts
@@ -11,7 +11,7 @@ describe("GitHub transform", () => {
     expect(id1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
   });
 
-  it("transforms an issue into UpsertNode ops", async () => {
+  it("transforms an issue into UpsertNode with intent kind and github attrs", async () => {
     const { transformIssue } = await import("../github/transform.js");
     const ops = transformIssue(
       { owner: "acme", repo: "app" },
@@ -27,9 +27,27 @@ describe("GitHub transform", () => {
     expect(upsert).toBeDefined();
     expect(upsert!.kind).toBe("intent");
     expect(upsert!.name).toBe("Fix login bug");
+    expect((upsert as any).attrs.source).toBe("github");
+    expect((upsert as any).attrs.github_type).toBe("issue");
+    expect((upsert as any).attrs.is_bug).toBe(true);
   });
 
-  it("transforms a PR into UpsertNode ops with decision kind", async () => {
+  it("marks non-bug issues with is_bug false", async () => {
+    const { transformIssue } = await import("../github/transform.js");
+    const ops = transformIssue(
+      { owner: "acme", repo: "app" },
+      {
+        number: 43, title: "Add feature", body: "New feature request",
+        state: "open", user: { login: "bob" }, labels: [{ name: "enhancement" }],
+        created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-02T00:00:00Z",
+        html_url: "https://github.com/acme/app/issues/43", comments: 0,
+      }
+    );
+    const upsert = ops.find((op: any) => op.type === "UpsertNode") as any;
+    expect(upsert.attrs.is_bug).toBe(false);
+  });
+
+  it("transforms a PR into UpsertNode with decision kind and github attrs", async () => {
     const { transformPR } = await import("../github/transform.js");
     const ops = transformPR(
       { owner: "acme", repo: "app" },
@@ -45,9 +63,33 @@ describe("GitHub transform", () => {
     expect(upsert).toBeDefined();
     expect(upsert!.kind).toBe("decision");
     expect(upsert!.name).toBe("Add auth flow");
+    expect((upsert as any).attrs.source).toBe("github");
+    expect((upsert as any).attrs.github_type).toBe("pull_request");
   });
 
-  it("transforms a commit into UpsertNode ops with doc kind", async () => {
+  it("creates RESOLVES edges when PR body references issues", async () => {
+    const { transformPR, deterministicId } = await import("../github/transform.js");
+    const ops = transformPR(
+      { owner: "acme", repo: "app" },
+      {
+        number: 11, title: "Fix auth", body: "Fixes #42 and closes #43",
+        state: "closed", merged_at: "2026-01-05T00:00:00Z",
+        user: { login: "bob" }, base: { ref: "main" }, head: { ref: "fix/auth" },
+        created_at: "2026-01-03T00:00:00Z", updated_at: "2026-01-05T00:00:00Z",
+        html_url: "https://github.com/acme/app/pull/11", changed_files: 2,
+      }
+    );
+    const edges = ops.filter((op: any) => op.type === "UpsertEdge" && op.predicate === "RESOLVES");
+    expect(edges.length).toBe(2);
+    // Verify edge destinations match the expected issue node IDs
+    const issue42Id = deterministicId("github://acme/app/issues/42");
+    const issue43Id = deterministicId("github://acme/app/issues/43");
+    const dstIds = edges.map((e: any) => e.dst);
+    expect(dstIds).toContain(issue42Id);
+    expect(dstIds).toContain(issue43Id);
+  });
+
+  it("transforms a commit into UpsertNode with doc kind and github attrs", async () => {
     const { transformCommit } = await import("../github/transform.js");
     const ops = transformCommit(
       { owner: "acme", repo: "app" },
@@ -62,5 +104,20 @@ describe("GitHub transform", () => {
     expect(upsert).toBeDefined();
     expect(upsert!.kind).toBe("doc");
     expect(upsert!.name).toContain("fix: resolve null pointer");
+    expect((upsert as any).attrs.source).toBe("github");
+    expect((upsert as any).attrs.github_type).toBe("commit");
+  });
+
+  it("parseFixesRefs extracts issue numbers from various patterns", async () => {
+    const { parseFixesRefs } = await import("../github/transform.js");
+    expect(parseFixesRefs("Fixes #42")).toEqual([42]);
+    expect(parseFixesRefs("closes #10 and fixes #20")).toEqual([10, 20]);
+    expect(parseFixesRefs("Resolved #5")).toEqual([5]);
+    expect(parseFixesRefs("Fixed #1, closes #2, resolves #3")).toEqual([1, 2, 3]);
+    expect(parseFixesRefs("No references here")).toEqual([]);
+    expect(parseFixesRefs(null)).toEqual([]);
+    expect(parseFixesRefs(undefined)).toEqual([]);
+    // Deduplicates
+    expect(parseFixesRefs("Fixes #42 and also fixes #42")).toEqual([42]);
   });
 });

--- a/ix-cli/src/cli/__tests__/jira-transform.test.ts
+++ b/ix-cli/src/cli/__tests__/jira-transform.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+
+describe("Jira transform", () => {
+  it("creates deterministic node IDs from Jira URIs", async () => {
+    const { deterministicId } = await import("../jira/transform.js");
+    const id1 = deterministicId("jira://PROJ-123");
+    const id2 = deterministicId("jira://PROJ-123");
+    const id3 = deterministicId("jira://PROJ-456");
+    expect(id1).toBe(id2);
+    expect(id1).not.toBe(id3);
+    expect(id1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  it("parseJiraKey extracts project and number", async () => {
+    const { parseJiraKey } = await import("../jira/transform.js");
+    expect(parseJiraKey("PROJ-123")).toEqual({ project: "PROJ", number: 123 });
+    expect(parseJiraKey("MY_TEAM-42")).toEqual({ project: "MY_TEAM", number: 42 });
+    expect(parseJiraKey("invalid")).toBeNull();
+    expect(parseJiraKey("123-ABC")).toBeNull();
+  });
+
+  it("transforms a story into intent node with jira attrs", async () => {
+    const { transformIssue } = await import("../jira/transform.js");
+    const ops = transformIssue("https://myorg.atlassian.net", {
+      id: "10001",
+      key: "PROJ-42",
+      self: "https://myorg.atlassian.net/rest/api/3/issue/10001",
+      fields: {
+        summary: "Add user onboarding flow",
+        description: null,
+        status: { name: "In Progress", statusCategory: { key: "indeterminate", name: "In Progress" } },
+        priority: { name: "High" },
+        issuetype: { name: "Story", subtask: false },
+        assignee: { accountId: "123", displayName: "Alice" },
+        reporter: { accountId: "456", displayName: "Bob" },
+        labels: ["frontend"],
+        created: "2026-01-01T00:00:00.000+0000",
+        updated: "2026-01-05T00:00:00.000+0000",
+        resolutiondate: null,
+      },
+    });
+    const upsert = ops.find((op: any) => op.type === "UpsertNode") as any;
+    expect(upsert).toBeDefined();
+    expect(upsert.kind).toBe("intent");
+    expect(upsert.name).toBe("Add user onboarding flow");
+    expect(upsert.attrs.source).toBe("jira");
+    expect(upsert.attrs.jira_type).toBe("story");
+    expect(upsert.attrs.jira_key).toBe("PROJ-42");
+    expect(upsert.attrs.assignee).toBe("Alice");
+    expect(upsert.attrs.state).toBe("in_progress");
+    expect(upsert.attrs.is_bug).toBe(false);
+  });
+
+  it("transforms a bug into intent node with is_bug=true", async () => {
+    const { transformIssue } = await import("../jira/transform.js");
+    const ops = transformIssue("https://myorg.atlassian.net", {
+      id: "10002",
+      key: "PROJ-43",
+      self: "https://myorg.atlassian.net/rest/api/3/issue/10002",
+      fields: {
+        summary: "Login page crashes on Safari",
+        description: null,
+        status: { name: "Open", statusCategory: { key: "new", name: "To Do" } },
+        priority: { name: "Critical" },
+        issuetype: { name: "Bug", subtask: false },
+        assignee: null,
+        reporter: { accountId: "456", displayName: "Bob" },
+        labels: [],
+        created: "2026-01-01T00:00:00.000+0000",
+        updated: "2026-01-02T00:00:00.000+0000",
+        resolutiondate: null,
+      },
+    });
+    const upsert = ops.find((op: any) => op.type === "UpsertNode") as any;
+    expect(upsert.kind).toBe("intent");
+    expect(upsert.attrs.jira_type).toBe("bug");
+    expect(upsert.attrs.is_bug).toBe(true);
+    expect(upsert.attrs.state).toBe("pending");
+  });
+
+  it("transforms an epic into goal node", async () => {
+    const { transformIssue } = await import("../jira/transform.js");
+    const ops = transformIssue("https://myorg.atlassian.net", {
+      id: "10003",
+      key: "PROJ-10",
+      self: "https://myorg.atlassian.net/rest/api/3/issue/10003",
+      fields: {
+        summary: "User Authentication Overhaul",
+        description: null,
+        status: { name: "In Progress", statusCategory: { key: "indeterminate", name: "In Progress" } },
+        priority: { name: "High" },
+        issuetype: { name: "Epic", subtask: false },
+        assignee: { accountId: "123", displayName: "Alice" },
+        reporter: { accountId: "456", displayName: "Bob" },
+        labels: ["auth"],
+        created: "2026-01-01T00:00:00.000+0000",
+        updated: "2026-01-10T00:00:00.000+0000",
+        resolutiondate: null,
+      },
+    });
+    const upsert = ops.find((op: any) => op.type === "UpsertNode") as any;
+    expect(upsert.kind).toBe("goal");
+    expect(upsert.attrs.jira_type).toBe("epic");
+    expect(upsert.attrs.source).toBe("jira");
+  });
+
+  it("creates PART_OF edge when issue has parent epic", async () => {
+    const { transformIssue, deterministicId } = await import("../jira/transform.js");
+    const ops = transformIssue("https://myorg.atlassian.net", {
+      id: "10004",
+      key: "PROJ-50",
+      self: "https://myorg.atlassian.net/rest/api/3/issue/10004",
+      fields: {
+        summary: "Implement OAuth login",
+        description: null,
+        status: { name: "To Do", statusCategory: { key: "new", name: "To Do" } },
+        priority: { name: "Medium" },
+        issuetype: { name: "Story", subtask: false },
+        assignee: null,
+        reporter: { accountId: "456", displayName: "Bob" },
+        labels: [],
+        created: "2026-01-01T00:00:00.000+0000",
+        updated: "2026-01-02T00:00:00.000+0000",
+        resolutiondate: null,
+        parent: { key: "PROJ-10", fields: { summary: "Auth Overhaul", issuetype: { name: "Epic", subtask: false } } },
+      },
+    });
+    const edges = ops.filter((op: any) => op.type === "UpsertEdge" && op.predicate === "PART_OF");
+    expect(edges.length).toBe(1);
+    const edge = edges[0] as any;
+    expect(edge.dst).toBe(deterministicId("jira://PROJ-10"));
+    expect(edge.attrs.source).toBe("jira");
+  });
+
+  it("transforms a sprint into plan node", async () => {
+    const { transformSprint } = await import("../jira/transform.js");
+    const ops = transformSprint("https://myorg.atlassian.net", {
+      id: 101,
+      name: "Sprint 14",
+      state: "active",
+      startDate: "2026-01-06T00:00:00.000Z",
+      endDate: "2026-01-20T00:00:00.000Z",
+      goal: "Ship auth overhaul",
+    });
+    const upsert = ops.find((op: any) => op.type === "UpsertNode") as any;
+    expect(upsert).toBeDefined();
+    expect(upsert.kind).toBe("plan");
+    expect(upsert.name).toBe("Sprint 14");
+    expect(upsert.attrs.source).toBe("jira");
+    expect(upsert.attrs.jira_type).toBe("sprint");
+    expect(upsert.attrs.goal).toBe("Ship auth overhaul");
+  });
+
+  it("transforms a comment with CONTAINS edge", async () => {
+    const { transformComment } = await import("../jira/transform.js");
+    const issue = {
+      id: "10001",
+      key: "PROJ-42",
+      self: "https://myorg.atlassian.net/rest/api/3/issue/10001",
+      fields: {
+        summary: "Test issue",
+        description: null,
+        status: { name: "Open", statusCategory: { key: "new", name: "To Do" } },
+        priority: null,
+        issuetype: { name: "Task", subtask: false },
+        assignee: null,
+        reporter: null,
+        labels: [],
+        created: "2026-01-01T00:00:00.000+0000",
+        updated: "2026-01-02T00:00:00.000+0000",
+        resolutiondate: null,
+      },
+    };
+    const ops = transformComment(issue, {
+      id: "20001",
+      body: "This needs more investigation",
+      author: { accountId: "123", displayName: "Alice" },
+      created: "2026-01-03T00:00:00.000+0000",
+      updated: "2026-01-03T00:00:00.000+0000",
+    });
+    expect(ops.length).toBe(2);
+    const node = ops.find((op: any) => op.type === "UpsertNode") as any;
+    expect(node.kind).toBe("doc");
+    expect(node.attrs.source).toBe("jira");
+    expect(node.attrs.jira_type).toBe("comment");
+    const edge = ops.find((op: any) => op.type === "UpsertEdge") as any;
+    expect(edge.predicate).toBe("CONTAINS");
+  });
+});

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -1,4 +1,3 @@
-// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 import * as nodePath from 'node:path';
 import * as fs from 'node:fs';
 import * as crypto from 'node:crypto';
@@ -400,8 +399,6 @@ export async function ingestFiles(
     ? path
     : nodePath.resolve(resolveWorkspaceRoot(opts.root), path);
 
-  // NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
-  //
   // Workspace identity for client-agnostic backend.
   //
   // The backend used to dereference provenance.source_uri against the host
@@ -421,9 +418,9 @@ export async function ingestFiles(
 
   const client = new IxClient(getEndpoint());
 
-  // NEEDS HEAVY REVIEW: schema-version check forces a clean re-ingest when the
-  // backend's graph format has changed in a way that invalidates existing node
-  // IDs (e.g. the absolute→relative source_uri migration).
+  // Schema-version check forces a clean re-ingest when the backend's graph
+  // format has changed in a way that invalidates existing node IDs (e.g. the
+  // absolute→relative source_uri migration).
   const CLIENT_EXPECTED_SCHEMA_VERSION = 2;
   try {
     const health = await client.health();
@@ -790,10 +787,10 @@ export async function ingestFiles(
           try {
             let patch = buildPatchFn!(p, hash, batchEdgesByFile.get(p.filePath) ?? emptyEdges, previousHash);
             if (mapMode) patch = stripMapModeOps(patch);
-            // NEEDS HEAVY REVIEW: tag every patch with the workspace_id. The
-            // backend stores this as an opaque attribute. The source.uri has
-            // already been set to the workspace-relative path upstream in
-            // buildPatch (because we passed the relative path to parseFile).
+            // Tag every patch with the workspace_id. The backend stores this
+            // as an opaque attribute. The source.uri has already been set to
+            // the workspace-relative path upstream in buildPatch (because we
+            // passed the relative path to parseFile).
             if (patch?.source) patch.source.workspaceId = workspaceId;
             preparedPatches.push(makePreparedPatch(patch, j + 1, p.filePath));
           } catch (err) {
@@ -861,7 +858,7 @@ export async function ingestFiles(
           try {
             let patch = buildPatchFn!(p, hash, edgesByFile.get(p.filePath) ?? emptyEdges, previousHash);
             if (mapMode) patch = stripMapModeOps(patch);
-            // NEEDS HEAVY REVIEW: tag with workspace_id (see flushBatch).
+            // Tag with workspace_id (see flushBatch).
             if (patch?.source) patch.source.workspaceId = workspaceId;
             preparedPatches.push(makePreparedPatch(patch, j + 1, p.filePath));
           } catch (err) {
@@ -936,9 +933,9 @@ export async function ingestFiles(
             if (debug) process.stderr.write(`\n  [skip minified-likely] ${filePath}\n`);
             continue;
           }
-          // NEEDS HEAVY REVIEW: parseFile receives the workspace-relative path
-          // so every deterministic ID derived in buildPatch (node/edge/chunk/
-          // patch) hashes relative paths. This makes graph IDs portable across
+          // parseFile receives the workspace-relative path so every
+          // deterministic ID derived in buildPatch (node/edge/chunk/patch)
+          // hashes relative paths. This makes graph IDs portable across
           // machines and removes backend dependence on host paths.
           parseable.push({ filePath: toWorkspaceRelative(filePath), absFilePath: filePath, source: sourceText, hash, previousHash });
         }
@@ -966,9 +963,9 @@ export async function ingestFiles(
               if (texts[j] != null) sources.set(batch[j], texts[j]!);
             }
           }
-          // NEEDS HEAVY REVIEW: global resolution index is now keyed on
-          // workspace-relative paths so that edge resolution matches the
-          // relative paths we pass into parseFile.
+          // Global resolution index is keyed on workspace-relative paths so
+          // that edge resolution matches the relative paths we pass into
+          // parseFile.
           const relSources = new Map<string, string>();
           for (const [abs, text] of sources) relSources.set(toWorkspaceRelative(abs), text);
           const relFilePaths = filePaths.map(toWorkspaceRelative);
@@ -1011,8 +1008,8 @@ export async function ingestFiles(
       // Build global resolution index from all repo file paths before the parse loop
       // so cross-batch imports resolve correctly even in streaming per-chunk mode.
       // Read all Go files in parallel to maximize I/O throughput.
-      // NEEDS HEAVY REVIEW: index keys are workspace-relative to match the
-      // relative paths we pass into parseFile below.
+      // Index keys are workspace-relative to match the relative paths we pass
+      // into parseFile below.
       {
         const goIndexStart = performance.now();
         const sources = new Map<string, string>();
@@ -1047,9 +1044,9 @@ export async function ingestFiles(
 
         // Read files asynchronously and dispatch to parse pool as each file completes.
         // This keeps workers busy while I/O is still in flight for other files.
-        // NEEDS HEAVY REVIEW: fd.filePath is the workspace-relative path, which
-        // is what parseFile and all downstream ID derivations see. absFilePath
-        // is kept only so error messages still point at the file on disk.
+        // fd.filePath is the workspace-relative path, which is what parseFile
+        // and all downstream ID derivations see. absFilePath is kept only so
+        // error messages still point at the file on disk.
         const readAndDispatch = chunk.map(async (absFilePath, idx) => {
           try {
             const st = await fs.promises.stat(absFilePath);
@@ -1212,8 +1209,6 @@ export async function ingestFiles(
 // Load existing hashes from the server for change detection
 // ---------------------------------------------------------------------------
 
-// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
-//
 // The backend now stores workspace-relative source_uri values. The CLI still
 // tracks files internally by absolute path (needed for fs reads), so this
 // helper converts to relative before the wire call and maps the server's

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -1,3 +1,4 @@
+// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 import * as nodePath from 'node:path';
 import * as fs from 'node:fs';
 import * as crypto from 'node:crypto';
@@ -399,7 +400,45 @@ export async function ingestFiles(
     ? path
     : nodePath.resolve(resolveWorkspaceRoot(opts.root), path);
 
+  // NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+  //
+  // Workspace identity for client-agnostic backend.
+  //
+  // The backend used to dereference provenance.source_uri against the host
+  // filesystem (via a broad HOME bind mount). We now emit workspace-relative
+  // paths as the canonical source_uri, and pass a workspace_id derived from
+  // the workspace root's absolute path. The backend treats both as opaque
+  // strings; it never reads host files.
+  const workspaceRoot = fs.statSync(resolvedPath).isDirectory()
+    ? resolvedPath
+    : nodePath.dirname(resolvedPath);
+  const workspaceId = crypto.createHash('sha256').update(workspaceRoot).digest('hex');
+  const toWorkspaceRelative = (absPath: string): string => {
+    // Force workspace-local POSIX separators so IDs are stable across OS.
+    const rel = nodePath.relative(workspaceRoot, absPath);
+    return rel.split(nodePath.sep).join('/');
+  };
+
   const client = new IxClient(getEndpoint());
+
+  // NEEDS HEAVY REVIEW: schema-version check forces a clean re-ingest when the
+  // backend's graph format has changed in a way that invalidates existing node
+  // IDs (e.g. the absolute→relative source_uri migration).
+  const CLIENT_EXPECTED_SCHEMA_VERSION = 2;
+  try {
+    const health = await client.health();
+    const serverVersion = (health as any)?.schema_version;
+    if (typeof serverVersion === 'number' && serverVersion !== CLIENT_EXPECTED_SCHEMA_VERSION) {
+      process.stderr.write(
+        `\n  [schema mismatch] backend schema_version=${serverVersion}, ` +
+        `client expects ${CLIENT_EXPECTED_SCHEMA_VERSION}. Forcing full re-ingest.\n`,
+      );
+      opts.force = true;
+    }
+  } catch (err) {
+    if (debug) process.stderr.write(`\n  [schema check skipped] ${err}\n`);
+  }
+
   const start = performance.now();
 
   // Worker pool for parallel file parsing across CPU cores
@@ -532,7 +571,7 @@ export async function ingestFiles(
     // so the cache wasn't cleared). Invalidate the cache so files are re-ingested.
     if (!opts.force && mtimeCache.size > 0) {
       const samplePaths = [...mtimeCache.keys()].slice(0, 5);
-      const sampleHashes = await loadExistingHashes(client, samplePaths, debug);
+      const sampleHashes = await loadExistingHashes(client, samplePaths, toWorkspaceRelative, debug);
       if (sampleHashes.size === 0) {
         mtimeCache.clear();
         if (debug) process.stderr.write(`\n  DB reset detected — invalidating mtime cache\n`);
@@ -564,7 +603,7 @@ export async function ingestFiles(
     // Phase: hash lookup — only needed when mtime-changed files exist.
     let knownHashes: Map<string, string>;
     if (opts.force || mtimeChangedPaths.length > 0) {
-      knownHashes = await loadExistingHashes(client, opts.force ? filePaths : mtimeChangedPaths, debug);
+      knownHashes = await loadExistingHashes(client, opts.force ? filePaths : mtimeChangedPaths, toWorkspaceRelative, debug);
       if (debug) process.stderr.write(`\n  Source hash lookup: ${knownHashes.size} known hashes (${mtimeChangedPaths.length} mtime-changed)\n`);
     } else {
       // All files are mtime-clean — skip server round-trip entirely.
@@ -751,6 +790,11 @@ export async function ingestFiles(
           try {
             let patch = buildPatchFn!(p, hash, batchEdgesByFile.get(p.filePath) ?? emptyEdges, previousHash);
             if (mapMode) patch = stripMapModeOps(patch);
+            // NEEDS HEAVY REVIEW: tag every patch with the workspace_id. The
+            // backend stores this as an opaque attribute. The source.uri has
+            // already been set to the workspace-relative path upstream in
+            // buildPatch (because we passed the relative path to parseFile).
+            if (patch?.source) patch.source.workspaceId = workspaceId;
             preparedPatches.push(makePreparedPatch(patch, j + 1, p.filePath));
           } catch (err) {
             parseErrors++;
@@ -817,6 +861,8 @@ export async function ingestFiles(
           try {
             let patch = buildPatchFn!(p, hash, edgesByFile.get(p.filePath) ?? emptyEdges, previousHash);
             if (mapMode) patch = stripMapModeOps(patch);
+            // NEEDS HEAVY REVIEW: tag with workspace_id (see flushBatch).
+            if (patch?.source) patch.source.workspaceId = workspaceId;
             preparedPatches.push(makePreparedPatch(patch, j + 1, p.filePath));
           } catch (err) {
             parseErrors++;
@@ -877,7 +923,10 @@ export async function ingestFiles(
         buildPatchFn = patchBuilder.buildPatchWithResolution as Function;
 
         // Pre-filter minified files (main thread) then parse in parallel via worker pool.
-        const parseable: Array<{ filePath: string; source: string; hash: string; previousHash: string | undefined }> = [];
+        // filePath here is the workspace-relative path (what goes to parseFile
+        // and downstream into buildPatch → source_uri). absFilePath is the
+        // absolute path retained for any on-disk ops (reads already happened).
+        const parseable: Array<{ filePath: string; absFilePath: string; source: string; hash: string; previousHash: string | undefined }> = [];
         for (const { filePath, bytes, hash, previousHash } of changedPaths) {
           const sourceText = bytes.toString('utf-8');
           if (isLikelyMinifiedSource(sourceText)) {
@@ -887,7 +936,11 @@ export async function ingestFiles(
             if (debug) process.stderr.write(`\n  [skip minified-likely] ${filePath}\n`);
             continue;
           }
-          parseable.push({ filePath, source: sourceText, hash, previousHash });
+          // NEEDS HEAVY REVIEW: parseFile receives the workspace-relative path
+          // so every deterministic ID derived in buildPatch (node/edge/chunk/
+          // patch) hashes relative paths. This makes graph IDs portable across
+          // machines and removes backend dependence on host paths.
+          parseable.push({ filePath: toWorkspaceRelative(filePath), absFilePath: filePath, source: sourceText, hash, previousHash });
         }
 
         progressPhase   = 'Parsing';
@@ -913,13 +966,23 @@ export async function ingestFiles(
               if (texts[j] != null) sources.set(batch[j], texts[j]!);
             }
           }
-          globalIndex = (ingestion.buildGlobalResolutionIndex as Function)(filePaths, sources);
+          // NEEDS HEAVY REVIEW: global resolution index is now keyed on
+          // workspace-relative paths so that edge resolution matches the
+          // relative paths we pass into parseFile.
+          const relSources = new Map<string, string>();
+          for (const [abs, text] of sources) relSources.set(toWorkspaceRelative(abs), text);
+          const relFilePaths = filePaths.map(toWorkspaceRelative);
+          globalIndex = (ingestion.buildGlobalResolutionIndex as Function)(relFilePaths, relSources);
           sources.clear();
+          relSources.clear();
         }
 
         let pendingFlush: Promise<void> = Promise.resolve();
         for (let i = 0; i < parseable.length; i += PARSE_STREAM_CHUNK) {
           const chunk = parseable.slice(i, i + PARSE_STREAM_CHUNK);
+          // parseFile receives the workspace-relative path (f.filePath), so
+          // every deterministic ID in the resulting patch hashes relative
+          // paths. f.absFilePath is retained only for debug/error display.
           const parseResults = await Promise.all(
             chunk.map(f =>
               ensureParsePool().parse(f.filePath, f.source).then(r => { progressCurrent++; return r; }),
@@ -948,6 +1011,8 @@ export async function ingestFiles(
       // Build global resolution index from all repo file paths before the parse loop
       // so cross-batch imports resolve correctly even in streaming per-chunk mode.
       // Read all Go files in parallel to maximize I/O throughput.
+      // NEEDS HEAVY REVIEW: index keys are workspace-relative to match the
+      // relative paths we pass into parseFile below.
       {
         const goIndexStart = performance.now();
         const sources = new Map<string, string>();
@@ -957,10 +1022,11 @@ export async function ingestFiles(
           const batch = goFiles.slice(i, i + GO_READ_CONCURRENCY);
           const texts = await Promise.all(batch.map(fp => fs.promises.readFile(fp, 'utf-8').catch(() => null)));
           for (let j = 0; j < batch.length; j++) {
-            if (texts[j] != null) sources.set(batch[j], texts[j]!);
+            if (texts[j] != null) sources.set(toWorkspaceRelative(batch[j]), texts[j]!);
           }
         }
-        globalIndex = ingestion.buildGlobalResolutionIndex(filePaths, sources);
+        const relFilePaths = filePaths.map(toWorkspaceRelative);
+        globalIndex = ingestion.buildGlobalResolutionIndex(relFilePaths, sources);
         sources.clear();
         timings.goIndexMs = Math.round(performance.now() - goIndexStart);
       }
@@ -981,28 +1047,32 @@ export async function ingestFiles(
 
         // Read files asynchronously and dispatch to parse pool as each file completes.
         // This keeps workers busy while I/O is still in flight for other files.
-        const readAndDispatch = chunk.map(async (filePath, idx) => {
+        // NEEDS HEAVY REVIEW: fd.filePath is the workspace-relative path, which
+        // is what parseFile and all downstream ID derivations see. absFilePath
+        // is kept only so error messages still point at the file on disk.
+        const readAndDispatch = chunk.map(async (absFilePath, idx) => {
           try {
-            const st = await fs.promises.stat(filePath);
+            const st = await fs.promises.stat(absFilePath);
             if (st.size === 0) { filesSkipped++; return; }
             if (st.size > MAX_FILE_BYTES) { tooLarge++; return; }
-            const bytes = await fs.promises.readFile(filePath);
+            const bytes = await fs.promises.readFile(absFilePath);
             const hash = sha256(bytes);
-            if (!opts.force && knownHashes.get(filePath) === hash) { filesSkipped++; return; }
-            const previousHash = knownHashes.get(filePath);
+            if (!opts.force && knownHashes.get(absFilePath) === hash) { filesSkipped++; return; }
+            const previousHash = knownHashes.get(absFilePath);
             const sourceText = bytes.toString('utf-8');
             if (isLikelyMinifiedSource(sourceText)) {
               minifiedLikely++;
               filesSkipped++;
-              if (debug) process.stderr.write(`\n  [skip minified-likely] ${filePath}\n`);
+              if (debug) process.stderr.write(`\n  [skip minified-likely] ${absFilePath}\n`);
               return;
             }
-            const fd: NonNullable<FileData> = { filePath, source: sourceText, hash, previousHash: previousHash !== hash ? previousHash : undefined };
+            const relFilePath = toWorkspaceRelative(absFilePath);
+            const fd: NonNullable<FileData> = { filePath: relFilePath, source: sourceText, hash, previousHash: previousHash !== hash ? previousHash : undefined };
             fileData[idx] = fd;
             parsePromises[idx] = ensureParsePool().parse(fd.filePath, fd.source).then(r => { progressCurrent++; return r; });
           } catch (err) {
             parseErrors++;
-            process.stderr.write(`\n  [read error] ${filePath}: ${err}\n`);
+            process.stderr.write(`\n  [read error] ${absFilePath}: ${err}\n`);
           }
         });
         await Promise.all(readAndDispatch);
@@ -1142,9 +1212,34 @@ export async function ingestFiles(
 // Load existing hashes from the server for change detection
 // ---------------------------------------------------------------------------
 
-async function loadExistingHashes(client: IxClient, filePaths: string[], debug = false): Promise<Map<string, string>> {
+// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+//
+// The backend now stores workspace-relative source_uri values. The CLI still
+// tracks files internally by absolute path (needed for fs reads), so this
+// helper converts to relative before the wire call and maps the server's
+// response back onto the caller's absolute keys.
+async function loadExistingHashes(
+  client: IxClient,
+  filePaths: string[],
+  toRelative: (absPath: string) => string,
+  debug = false,
+): Promise<Map<string, string>> {
   try {
-    return await client.getSourceHashes(filePaths);
+    const relPaths: string[] = new Array(filePaths.length);
+    const relToAbs = new Map<string, string>();
+    for (let i = 0; i < filePaths.length; i++) {
+      const abs = filePaths[i];
+      const rel = toRelative(abs);
+      relPaths[i] = rel;
+      relToAbs.set(rel, abs);
+    }
+    const serverHashes = await client.getSourceHashes(relPaths);
+    const out = new Map<string, string>();
+    for (const [rel, hash] of serverHashes) {
+      const abs = relToAbs.get(rel);
+      if (abs !== undefined) out.set(abs, hash);
+    }
+    return out;
   } catch (err) {
     if (debug) process.stderr.write(`\n  [hash lookup failed] ${err}\n`);
     return new Map();

--- a/ix-cli/src/cli/commands/load.ts
+++ b/ix-cli/src/cli/commands/load.ts
@@ -1,0 +1,144 @@
+/**
+ * `ix load <url|path>` — Multi-source semantic ingestion command.
+ *
+ * Thin client: detects source type, fetches content, and POSTs to the
+ * backend's /v1/load endpoint which handles LLM extraction, embedding,
+ * and patch commit server-side.
+ *
+ * Supports: tweets, arXiv papers, PDFs, images/screenshots, webpages,
+ * chat exports, and generic local files.
+ */
+
+import type { Command } from "commander";
+import chalk from "chalk";
+import { IxClient } from "../../client/api.js";
+import { getEndpoint } from "../config.js";
+import { detectSource } from "../sources/detect.js";
+import { fetchContent } from "../sources/fetch.js";
+
+interface LoadOptions {
+  format: string;
+  verbose: boolean;
+}
+
+export function registerLoadCommand(program: Command): void {
+  program
+    .command("load")
+    .description("Ingest a URL or file into the knowledge graph (papers, tweets, screenshots, etc.)")
+    .argument("<source>", "URL or local file path to ingest")
+    .option("--format <format>", "Output format (text or json)", "text")
+    .option("--verbose", "Show detailed output", false)
+    .action(async (source: string, opts: LoadOptions) => {
+      try {
+        await runLoad(source, opts);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (opts.format === "json") {
+          console.log(JSON.stringify({ error: msg }));
+        } else {
+          console.error(chalk.red(`Error: ${msg}`));
+        }
+        process.exitCode = 1;
+      }
+    });
+}
+
+async function runLoad(source: string, opts: LoadOptions): Promise<void> {
+  const isJson = opts.format === "json";
+
+  // 1. Detect source type
+  const detected = detectSource(source);
+
+  if (detected.kind === "github") {
+    if (!isJson) {
+      console.error(
+        chalk.yellow("GitHub repos should be ingested with: ix ingest --github <owner/repo>")
+      );
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!isJson) {
+    console.log(
+      chalk.dim(`Detected source type: `) + chalk.cyan(detected.kind) +
+      chalk.dim(` (${detected.uri})`)
+    );
+  }
+
+  // 2. Fetch content
+  if (!isJson) process.stdout.write(chalk.dim("Fetching content... "));
+  const content = await fetchContent(detected);
+  if (!isJson) {
+    const size = content.text
+      ? `${content.text.length} chars`
+      : content.binary
+        ? `${(content.binary.length / 1024).toFixed(1)} KB`
+        : "empty";
+    console.log(chalk.green(`done`) + chalk.dim(` (${size})`));
+  }
+
+  // 3. Build request payload for backend
+  const payload: Record<string, unknown> = {
+    uri: detected.uri,
+    kind: detected.kind,
+    meta: { ...detected.meta, ...content.meta },
+  };
+
+  if (content.text) {
+    payload.text = content.text;
+  }
+
+  if (content.binary) {
+    payload.binaryBase64 = content.binary.toString("base64");
+    payload.contentType = (content.meta.content_type as string) ?? undefined;
+  }
+
+  // 4. POST to backend — extraction, embedding, and commit happen server-side
+  if (!isJson) process.stdout.write(chalk.dim("Extracting and committing... "));
+
+  const endpoint = getEndpoint();
+  const resp = await fetch(`${endpoint}/v1/load`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(5 * 60 * 1000), // 5 min for LLM extraction
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Backend error (${resp.status}): ${text}`);
+  }
+
+  const result = (await resp.json()) as {
+    status: string;
+    rev: number;
+    patchId: string;
+    nodes: number;
+    edges: number;
+    claims: number;
+  };
+
+  if (!isJson) {
+    console.log(chalk.green("done") + chalk.dim(` (rev ${result.rev})`));
+    console.log();
+    console.log(
+      chalk.bold("Ingested: ") +
+      chalk.cyan(detected.kind) +
+      chalk.dim(" → ") +
+      `${result.nodes} nodes, ${result.edges} edges, ${result.claims} claims` +
+      chalk.dim(` (rev ${result.rev})`)
+    );
+  } else {
+    console.log(JSON.stringify({
+      status: result.status,
+      kind: detected.kind,
+      uri: detected.uri,
+      nodes: result.nodes,
+      edges: result.edges,
+      claims: result.claims,
+      rev: result.rev,
+      patchId: result.patchId,
+    }));
+  }
+}

--- a/ix-cli/src/cli/commands/load.ts
+++ b/ix-cli/src/cli/commands/load.ts
@@ -11,7 +11,6 @@
 
 import type { Command } from "commander";
 import chalk from "chalk";
-import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { detectSource } from "../sources/detect.js";
 import { fetchContent } from "../sources/fetch.js";

--- a/ix-cli/src/cli/commands/map.ts
+++ b/ix-cli/src/cli/commands/map.ts
@@ -5,6 +5,7 @@ import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { roundFloat } from "../format.js";
 import { bootstrap } from "../bootstrap.js";
+import { formatFetchError } from "../errors.js";
 import { ingestFiles } from "./ingest.js";
 
 export interface MapRegion {
@@ -159,7 +160,7 @@ Examples:
           mapMode: true,
         });
       } catch (err: any) {
-        console.error(chalk.red("Error:"), err.message ?? err);
+        console.error(chalk.red("Error:"), formatFetchError(err));
         process.exitCode = 1;
         return;
       }
@@ -183,7 +184,7 @@ Examples:
         result = await client.map({ full: opts.full }) as MapResult;
       } catch (err: any) {
         if (mapInterval) { clearInterval(mapInterval); process.stderr.write('\r' + ' '.repeat(60) + '\r'); }
-        console.error(chalk.red("Error:"), err.message ?? err);
+        console.error(chalk.red("Error:"), formatFetchError(err));
         process.exitCode = 1;
         return;
       }

--- a/ix-cli/src/cli/commands/read.ts
+++ b/ix-cli/src/cli/commands/read.ts
@@ -1,9 +1,10 @@
+// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Command } from "commander";
 import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
-import { getEndpoint, resolveWorkspaceRoot } from "../config.js";
+import { absoluteFromSourceUri, getEndpoint, resolveWorkspaceRoot } from "../config.js";
 import { resolveEntityFull } from "../resolve.js";
 import { stderr } from "../stderr.js";
 import { isFileStale } from "../stale.js";
@@ -181,19 +182,23 @@ Examples:
       const symbolResult = await trySymbolMatch(client, rawTarget, { kind: opts.kind, path: opts.path, pick: opts.pick ? parseInt(opts.pick, 10) : undefined });
       if (symbolResult.type === "resolved") {
         const { node, sourceUri } = symbolResult;
-        const stale = sourceUri ? await checkStale(client, sourceUri) : false;
+        // NEEDS HEAVY REVIEW: sourceUri coming from the graph is now
+        // workspace-relative (client-agnostic backend). Resolve it against the
+        // active workspace root before any fs call.
+        const absSourceUri = sourceUri ? absoluteFromSourceUri(sourceUri, opts.root) : null;
+        const stale = absSourceUri ? await checkStale(client, absSourceUri) : false;
 
         // If the source file exists, extract the symbol's lines
-        if (sourceUri && fs.existsSync(sourceUri)) {
+        if (absSourceUri && fs.existsSync(absSourceUri)) {
           const lineStart = node.attrs?.lineStart ?? node.attrs?.line_start ?? 1;
           const lineEnd = node.attrs?.lineEnd ?? node.attrs?.line_end;
-          const fileContent = fs.readFileSync(sourceUri, "utf-8");
+          const fileContent = fs.readFileSync(absSourceUri, "utf-8");
           const allLines = fileContent.split("\n");
           const effectiveEnd = lineEnd ?? allLines.length;
           const content = allLines.slice(lineStart - 1, effectiveEnd).join("\n");
           const result: ReadResult = {
             targetType: "symbol",
-            path: sourceUri,
+            path: absSourceUri,
             lineStart,
             lineEnd: effectiveEnd,
             content,
@@ -211,7 +216,7 @@ Examples:
           const lines = String(attrContent).split("\n");
           const result: ReadResult = {
             targetType: "symbol",
-            path: sourceUri ?? "(no source file)",
+            path: absSourceUri ?? sourceUri ?? "(no source file)",
             lineStart: 1,
             lineEnd: lines.length,
             content: String(attrContent),
@@ -223,7 +228,7 @@ Examples:
           return;
         }
 
-        stderr(`Source file not found for symbol: ${node.name} (${sourceUri ?? "no provenance"})`);
+        stderr(`Source file not found for symbol: ${node.name} (${absSourceUri ?? sourceUri ?? "no provenance"})`);
         return;
       }
 

--- a/ix-cli/src/cli/commands/read.ts
+++ b/ix-cli/src/cli/commands/read.ts
@@ -1,4 +1,3 @@
-// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Command } from "commander";
@@ -182,9 +181,9 @@ Examples:
       const symbolResult = await trySymbolMatch(client, rawTarget, { kind: opts.kind, path: opts.path, pick: opts.pick ? parseInt(opts.pick, 10) : undefined });
       if (symbolResult.type === "resolved") {
         const { node, sourceUri } = symbolResult;
-        // NEEDS HEAVY REVIEW: sourceUri coming from the graph is now
-        // workspace-relative (client-agnostic backend). Resolve it against the
-        // active workspace root before any fs call.
+        // sourceUri coming from the graph is workspace-relative under the
+        // client-agnostic backend. Resolve it against the active workspace
+        // root before any fs call.
         const absSourceUri = sourceUri ? absoluteFromSourceUri(sourceUri, opts.root) : null;
         const stale = absSourceUri ? await checkStale(client, absSourceUri) : false;
 

--- a/ix-cli/src/cli/commands/view.ts
+++ b/ix-cli/src/cli/commands/view.ts
@@ -13,13 +13,8 @@ import { fileURLToPath } from "url";
 import { createConnection } from "net";
 
 const IX_HOME = process.env.IX_HOME || join(homedir(), ".ix");
-const STATE_FILE = join(IX_HOME, "compass.json");
+const PID_FILE = join(IX_HOME, "compass.pid");
 const BACKEND_URL = "http://localhost:8090";
-
-interface CompassState {
-  pid: number;
-  port: number;
-}
 
 /** Resolve the compass dist directory — installed path first, then dev fallback. */
 function findCompassDist(): string | null {
@@ -35,23 +30,17 @@ function findCompassDist(): string | null {
   return null;
 }
 
-/** Read state from file and check if the process is alive. */
-function readAliveState(): CompassState | null {
-  if (!existsSync(STATE_FILE)) return null;
+/** Read PID from file and check if the process is alive. */
+function readAlivePid(): number | null {
+  if (!existsSync(PID_FILE)) return null;
+  const pid = parseInt(readFileSync(PID_FILE, "utf-8").trim(), 10);
+  if (isNaN(pid)) return null;
   try {
-    const state: CompassState = JSON.parse(
-      readFileSync(STATE_FILE, "utf-8").trim(),
-    );
-    if (!state.pid || !state.port) return null;
-    process.kill(state.pid, 0); // signal 0 = existence check
-    return state;
+    process.kill(pid, 0); // signal 0 = existence check
+    return pid;
   } catch {
-    // Stale or corrupt state file
-    try {
-      unlinkSync(STATE_FILE);
-    } catch {
-      /* ignore */
-    }
+    // Stale PID file
+    try { unlinkSync(PID_FILE); } catch { /* ignore */ }
     return null;
   }
 }
@@ -64,9 +53,7 @@ function isPortInUse(port: number): Promise<boolean> {
       conn.end();
       resolve(true);
     });
-    conn.on("error", () => {
-      resolve(false);
-    });
+    conn.on("error", () => resolve(false));
   });
 }
 
@@ -149,13 +136,8 @@ const server = http.createServer((req, res) => {
   });
 });
 
-server.on("error", (err) => {
-  process.exit(1);
-});
-
 server.listen(PORT, () => {
-  // Signal readiness to parent via stdout
-  process.stdout.write("READY");
+  // Server ready — parent already detached
 });
 `;
 }
@@ -178,26 +160,24 @@ function openBrowser(url: string): void {
 export function registerViewCommand(program: Command): void {
   const view = program
     .command("view")
-    .description("Open the Ix System Compass visualizer");
+    .description("Open the Ix System Compass visualizer")
+    .option("-p, --port <port>", "Port to serve on", "8080");
 
   view
     .command("start", { isDefault: true })
     .description("Start the visualizer (default)")
-    .option("-p, --port <port>", "Port to serve on", "8080")
     .option("--no-open", "Don't auto-open browser")
     .action(async (opts) => {
-      const port = parseInt(opts.port, 10);
+      const port = parseInt(view.opts().port, 10);
       if (isNaN(port) || port < 1 || port > 65535) {
         console.error("[error] Invalid port number.");
         process.exit(1);
       }
 
-      const existing = readAliveState();
+      const existing = readAlivePid();
       if (existing) {
-        console.log(
-          `[ok] Visualizer is already running (PID ${existing.pid})`,
-        );
-        console.log(`  http://localhost:${existing.port}`);
+        console.log(`[ok] Visualizer is already running (PID ${existing})`);
+        console.log(`  http://localhost:${port}`);
         return;
       }
 
@@ -225,62 +205,21 @@ export function registerViewCommand(program: Command): void {
       const scriptPath = join(scriptDir, "compass-server.js");
       writeFileSync(scriptPath, serverScript(distDir, port));
 
-      // Spawn detached process — capture stdout for readiness signal
+      // Spawn detached process
       const child = spawn("node", [scriptPath], {
         detached: true,
-        stdio: ["ignore", "pipe", "pipe"],
+        stdio: "ignore",
       });
+      child.unref();
 
       if (!child.pid) {
         console.error("[error] Failed to start visualizer server.");
         process.exit(1);
       }
 
-      // Wait for the server to signal readiness or fail
-      const ready = await new Promise<boolean>((resolve) => {
-        const timeout = setTimeout(() => {
-          resolve(false);
-        }, 5000);
-
-        child.stdout!.on("data", (data: Buffer) => {
-          if (data.toString().includes("READY")) {
-            clearTimeout(timeout);
-            resolve(true);
-          }
-        });
-
-        child.stderr!.on("data", () => {
-          // Server wrote to stderr — likely an error
-        });
-
-        child.on("exit", () => {
-          clearTimeout(timeout);
-          resolve(false);
-        });
-      });
-
-      if (!ready) {
-        console.error(`[error] Visualizer failed to start on port ${port}.`);
-        console.error(`  The port may be in use. Use -p <port> to specify a different port.`);
-        try {
-          child.kill();
-        } catch {
-          /* ignore */
-        }
-        process.exit(1);
-      }
-
-      // Detach stdio so the parent can exit
-      child.stdout!.destroy();
-      child.stderr!.destroy();
-      child.unref();
-
-      // Save state (PID + port)
-      mkdirSync(dirname(STATE_FILE), { recursive: true });
-      writeFileSync(
-        STATE_FILE,
-        JSON.stringify({ pid: child.pid, port } as CompassState),
-      );
+      // Save PID
+      mkdirSync(dirname(PID_FILE), { recursive: true });
+      writeFileSync(PID_FILE, String(child.pid));
 
       const url = `http://localhost:${port}`;
       console.log(`[ok] Visualizer started (PID ${child.pid})`);
@@ -295,34 +234,29 @@ export function registerViewCommand(program: Command): void {
     .command("stop")
     .description("Stop the visualizer")
     .action(() => {
-      const state = readAliveState();
-      if (!state) {
+      const pid = readAlivePid();
+      if (!pid) {
         console.log("[ok] Visualizer is not running.");
         return;
       }
 
       try {
-        process.kill(state.pid, "SIGTERM");
+        process.kill(pid, "SIGTERM");
       } catch {
         // Already dead
       }
 
-      try {
-        unlinkSync(STATE_FILE);
-      } catch {
-        /* ignore */
-      }
-      console.log(`[ok] Visualizer stopped (PID ${state.pid})`);
+      try { unlinkSync(PID_FILE); } catch { /* ignore */ }
+      console.log(`[ok] Visualizer stopped (PID ${pid})`);
     });
 
   view
     .command("status")
     .description("Show visualizer status")
     .action(() => {
-      const state = readAliveState();
-      if (state) {
-        console.log(`[ok] Visualizer is running (PID ${state.pid})`);
-        console.log(`  http://localhost:${state.port}`);
+      const pid = readAlivePid();
+      if (pid) {
+        console.log(`[ok] Visualizer is running (PID ${pid})`);
       } else {
         console.log("[--] Visualizer is not running.");
         console.log("  Run 'ix view' to start it.");

--- a/ix-cli/src/cli/commands/view.ts
+++ b/ix-cli/src/cli/commands/view.ts
@@ -10,10 +10,16 @@ import {
 import { join, dirname } from "path";
 import { homedir, platform } from "os";
 import { fileURLToPath } from "url";
+import { createConnection } from "net";
 
 const IX_HOME = process.env.IX_HOME || join(homedir(), ".ix");
-const PID_FILE = join(IX_HOME, "compass.pid");
+const STATE_FILE = join(IX_HOME, "compass.json");
 const BACKEND_URL = "http://localhost:8090";
+
+interface CompassState {
+  pid: number;
+  port: number;
+}
 
 /** Resolve the compass dist directory — installed path first, then dev fallback. */
 function findCompassDist(): string | null {
@@ -29,19 +35,39 @@ function findCompassDist(): string | null {
   return null;
 }
 
-/** Read PID from file and check if the process is alive. */
-function readAlivePid(): number | null {
-  if (!existsSync(PID_FILE)) return null;
-  const pid = parseInt(readFileSync(PID_FILE, "utf-8").trim(), 10);
-  if (isNaN(pid)) return null;
+/** Read state from file and check if the process is alive. */
+function readAliveState(): CompassState | null {
+  if (!existsSync(STATE_FILE)) return null;
   try {
-    process.kill(pid, 0); // signal 0 = existence check
-    return pid;
+    const state: CompassState = JSON.parse(
+      readFileSync(STATE_FILE, "utf-8").trim(),
+    );
+    if (!state.pid || !state.port) return null;
+    process.kill(state.pid, 0); // signal 0 = existence check
+    return state;
   } catch {
-    // Stale PID file
-    try { unlinkSync(PID_FILE); } catch { /* ignore */ }
+    // Stale or corrupt state file
+    try {
+      unlinkSync(STATE_FILE);
+    } catch {
+      /* ignore */
+    }
     return null;
   }
+}
+
+/** Check whether a port is already in use. */
+function isPortInUse(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const conn = createConnection({ port, host: "127.0.0.1" });
+    conn.on("connect", () => {
+      conn.end();
+      resolve(true);
+    });
+    conn.on("error", () => {
+      resolve(false);
+    });
+  });
 }
 
 /** Generate the inline server script that serves static files + proxies /v1. */
@@ -123,8 +149,13 @@ const server = http.createServer((req, res) => {
   });
 });
 
+server.on("error", (err) => {
+  process.exit(1);
+});
+
 server.listen(PORT, () => {
-  // Server ready — parent already detached
+  // Signal readiness to parent via stdout
+  process.stdout.write("READY");
 });
 `;
 }
@@ -152,20 +183,29 @@ export function registerViewCommand(program: Command): void {
   view
     .command("start", { isDefault: true })
     .description("Start the visualizer (default)")
-    .option("--port <port>", "Port to serve on", "8080")
+    .option("-p, --port <port>", "Port to serve on", "8080")
     .option("--no-open", "Don't auto-open browser")
-    .action((opts) => {
+    .action(async (opts) => {
       const port = parseInt(opts.port, 10);
       if (isNaN(port) || port < 1 || port > 65535) {
         console.error("[error] Invalid port number.");
         process.exit(1);
       }
 
-      const existing = readAlivePid();
+      const existing = readAliveState();
       if (existing) {
-        console.log(`[ok] Visualizer is already running (PID ${existing})`);
-        console.log(`  http://localhost:${port}`);
+        console.log(
+          `[ok] Visualizer is already running (PID ${existing.pid})`,
+        );
+        console.log(`  http://localhost:${existing.port}`);
         return;
+      }
+
+      // Check if the port is already in use before attempting to start
+      if (await isPortInUse(port)) {
+        console.error(`[error] Port ${port} is already in use.`);
+        console.error(`  Use -p <port> to specify a different port.`);
+        process.exit(1);
       }
 
       const distDir = findCompassDist();
@@ -185,21 +225,62 @@ export function registerViewCommand(program: Command): void {
       const scriptPath = join(scriptDir, "compass-server.js");
       writeFileSync(scriptPath, serverScript(distDir, port));
 
-      // Spawn detached process
+      // Spawn detached process — capture stdout for readiness signal
       const child = spawn("node", [scriptPath], {
         detached: true,
-        stdio: "ignore",
+        stdio: ["ignore", "pipe", "pipe"],
       });
-      child.unref();
 
       if (!child.pid) {
         console.error("[error] Failed to start visualizer server.");
         process.exit(1);
       }
 
-      // Save PID
-      mkdirSync(dirname(PID_FILE), { recursive: true });
-      writeFileSync(PID_FILE, String(child.pid));
+      // Wait for the server to signal readiness or fail
+      const ready = await new Promise<boolean>((resolve) => {
+        const timeout = setTimeout(() => {
+          resolve(false);
+        }, 5000);
+
+        child.stdout!.on("data", (data: Buffer) => {
+          if (data.toString().includes("READY")) {
+            clearTimeout(timeout);
+            resolve(true);
+          }
+        });
+
+        child.stderr!.on("data", () => {
+          // Server wrote to stderr — likely an error
+        });
+
+        child.on("exit", () => {
+          clearTimeout(timeout);
+          resolve(false);
+        });
+      });
+
+      if (!ready) {
+        console.error(`[error] Visualizer failed to start on port ${port}.`);
+        console.error(`  The port may be in use. Use -p <port> to specify a different port.`);
+        try {
+          child.kill();
+        } catch {
+          /* ignore */
+        }
+        process.exit(1);
+      }
+
+      // Detach stdio so the parent can exit
+      child.stdout!.destroy();
+      child.stderr!.destroy();
+      child.unref();
+
+      // Save state (PID + port)
+      mkdirSync(dirname(STATE_FILE), { recursive: true });
+      writeFileSync(
+        STATE_FILE,
+        JSON.stringify({ pid: child.pid, port } as CompassState),
+      );
 
       const url = `http://localhost:${port}`;
       console.log(`[ok] Visualizer started (PID ${child.pid})`);
@@ -214,29 +295,34 @@ export function registerViewCommand(program: Command): void {
     .command("stop")
     .description("Stop the visualizer")
     .action(() => {
-      const pid = readAlivePid();
-      if (!pid) {
+      const state = readAliveState();
+      if (!state) {
         console.log("[ok] Visualizer is not running.");
         return;
       }
 
       try {
-        process.kill(pid, "SIGTERM");
+        process.kill(state.pid, "SIGTERM");
       } catch {
         // Already dead
       }
 
-      try { unlinkSync(PID_FILE); } catch { /* ignore */ }
-      console.log(`[ok] Visualizer stopped (PID ${pid})`);
+      try {
+        unlinkSync(STATE_FILE);
+      } catch {
+        /* ignore */
+      }
+      console.log(`[ok] Visualizer stopped (PID ${state.pid})`);
     });
 
   view
     .command("status")
     .description("Show visualizer status")
     .action(() => {
-      const pid = readAlivePid();
-      if (pid) {
-        console.log(`[ok] Visualizer is running (PID ${pid})`);
+      const state = readAliveState();
+      if (state) {
+        console.log(`[ok] Visualizer is running (PID ${state.pid})`);
+        console.log(`  http://localhost:${state.port}`);
       } else {
         console.log("[--] Visualizer is not running.");
         console.log("  Run 'ix view' to start it.");

--- a/ix-cli/src/cli/commands/watch.ts
+++ b/ix-cli/src/cli/commands/watch.ts
@@ -104,6 +104,17 @@ export function registerWatchCommand(program: Command): void {
           const result = await client.commitPatch(patch);
           lastHash.set(filePath, hash);
           console.log(`${chalk.cyan("[watch]")} ingested: ${chalk.bold(rel)} → rev ${result.rev}`);
+
+          // Recalculate the map after successful ingestion
+          try {
+            const mapResult = await client.map();
+            const systems = mapResult.regions?.filter((r: any) => r.label_kind === "system").length ?? 0;
+            const subsystems = mapResult.regions?.filter((r: any) => r.label_kind === "subsystem").length ?? 0;
+            const modules = mapResult.regions?.filter((r: any) => r.label_kind === "module").length ?? 0;
+            console.log(`${chalk.cyan("[watch]")} map updated: ${systems}s/${subsystems}ss/${modules}m regions`);
+          } catch (mapErr: any) {
+            console.error(`${chalk.red("[watch]")} map error: ${mapErr.message}`);
+          }
         } catch (err: any) {
           console.error(`${chalk.red("[watch]")} error ingesting ${rel}: ${err.message}`);
         }
@@ -209,6 +220,7 @@ async function pollMode(
       } catch {}
     }
 
+    let anyIngested = false;
     for (const f of changed) {
       const rel = path.relative(root, f);
       console.log(`${chalk.dim("[watch]")} changed: ${rel}`);
@@ -221,8 +233,22 @@ async function pollMode(
         const patch = buildPatch(parsed, hash);
         const result = await client.commitPatch(patch);
         console.log(`${chalk.cyan("[watch]")} ingested: ${chalk.bold(rel)} → rev ${result.rev}`);
+        anyIngested = true;
       } catch (err: any) {
         console.error(`${chalk.red("[watch]")} error: ${err.message}`);
+      }
+    }
+
+    // Recalculate the map once after processing all changed files
+    if (anyIngested) {
+      try {
+        const mapResult = await client.map();
+        const systems = mapResult.regions?.filter((r: any) => r.label_kind === "system").length ?? 0;
+        const subsystems = mapResult.regions?.filter((r: any) => r.label_kind === "subsystem").length ?? 0;
+        const modules = mapResult.regions?.filter((r: any) => r.label_kind === "module").length ?? 0;
+        console.log(`${chalk.cyan("[watch]")} map updated: ${systems}s/${subsystems}ss/${modules}m regions`);
+      } catch (mapErr: any) {
+        console.error(`${chalk.red("[watch]")} map error: ${mapErr.message}`);
       }
     }
   };
@@ -234,3 +260,4 @@ async function pollMode(
     process.exit(0);
   });
 }
+

--- a/ix-cli/src/cli/commands/watch.ts
+++ b/ix-cli/src/cli/commands/watch.ts
@@ -41,7 +41,8 @@ export function registerWatchCommand(program: Command): void {
     .description("Watch files and auto-ingest on changes")
     .option("--path <path>", "Restrict watching to a subdirectory")
     .option("--root <dir>", "Workspace root directory")
-    .action(async (opts: { path?: string; root?: string }) => {
+    .option("--branch <branchId>", "Commit changes to a graph branch")
+    .action(async (opts: { path?: string; root?: string; branch?: string }) => {
       try {
         await bootstrap();
       } catch (err: any) {
@@ -63,6 +64,7 @@ export function registerWatchCommand(program: Command): void {
 
       const relative = path.relative(root, watchPath) || ".";
       console.log(chalk.cyan(`[watch] Watching ${relative}`));
+      if (opts.branch) console.log(chalk.cyan(`[watch] Branch: ${opts.branch}`));
       console.log(chalk.dim(`[watch] Debounce: ${DEBOUNCE_MS}ms`));
       console.log(chalk.dim("[watch] Press Ctrl+C to stop.\n"));
 
@@ -101,6 +103,7 @@ export function registerWatchCommand(program: Command): void {
             return;
           }
           const patch = buildPatch(parsed, hash);
+          if (opts.branch) patch.branchId = opts.branch;
           const result = await client.commitPatch(patch);
           lastHash.set(filePath, hash);
           console.log(`${chalk.cyan("[watch]")} ingested: ${chalk.bold(rel)} → rev ${result.rev}`);
@@ -156,7 +159,7 @@ export function registerWatchCommand(program: Command): void {
         // Fallback to polling if fs.watch with recursive isn't supported
         if (err.code === "ERR_FEATURE_UNAVAILABLE_ON_PLATFORM") {
           console.log(chalk.dim("[watch] Falling back to polling mode (2s interval)..."));
-          await pollMode(watchPath, root, client);
+          await pollMode(watchPath, root, client, opts.branch);
         } else {
           throw err;
         }
@@ -170,7 +173,8 @@ export function registerWatchCommand(program: Command): void {
 async function pollMode(
   watchPath: string,
   root: string,
-  client: IxClient
+  client: IxClient,
+  branchId?: string
 ): Promise<void> {
   const [{ parseFile }, { buildPatch }] = await loadWatchIngestionModules();
   const mtimes = new Map<string, number>();
@@ -231,6 +235,7 @@ async function pollMode(
         if (!parsed) continue;
         const hash = hashContent(content);
         const patch = buildPatch(parsed, hash);
+        if (branchId) patch.branchId = branchId;
         const result = await client.commitPatch(patch);
         console.log(`${chalk.cyan("[watch]")} ingested: ${chalk.bold(rel)} → rev ${result.rev}`);
         anyIngested = true;

--- a/ix-cli/src/cli/config.ts
+++ b/ix-cli/src/cli/config.ts
@@ -153,6 +153,23 @@ export function getActiveWorkspaceRoot(): string | undefined {
   return getDefaultWorkspace()?.root_path;
 }
 
+// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+//
+// Resolve a source_uri from the graph (which is now a workspace-relative
+// POSIX path under the client-agnostic backend design) back to an absolute
+// host filesystem path. If the input is already absolute (e.g. legacy graphs
+// or external absolute paths), it is returned as-is. Used by any command that
+// needs to actually open a file off disk (ix read, ix explain, ...).
+export function absoluteFromSourceUri(sourceUri: string, explicitRoot?: string): string {
+  if (!sourceUri) return sourceUri;
+  // Treat both POSIX abs (`/`) and Windows abs (`C:\`) as already resolved.
+  if (sourceUri.startsWith("/") || /^[A-Za-z]:[\\/]/.test(sourceUri)) return sourceUri;
+  const root = resolveWorkspaceRoot(explicitRoot);
+  // POSIX-normalize the relative segment before joining.
+  const normalized = sourceUri.replace(/\\/g, "/");
+  return require("node:path").resolve(root, normalized);
+}
+
 export function resolveWorkspaceRoot(explicitRoot?: string): string {
   // 1. Explicit --root
   if (explicitRoot) return explicitRoot;

--- a/ix-cli/src/cli/config.ts
+++ b/ix-cli/src/cli/config.ts
@@ -11,11 +11,26 @@ export interface WorkspaceConfig {
   default: boolean;
 }
 
+export interface InstanceAuth {
+  api_key: string;
+  token: string;
+  expires_at: string;
+  org_id: string;
+  plan: string;
+}
+
+export interface InstanceConfig {
+  endpoint: string;
+  auth?: InstanceAuth;
+}
+
 export interface IxConfig {
   endpoint: string;
   format: string;
   workspace?: string;
   workspaces?: WorkspaceConfig[];
+  instances?: Record<string, InstanceConfig>;
+  active?: string;
 }
 
 const defaultConfig: IxConfig = {
@@ -40,8 +55,72 @@ export function saveConfig(config: IxConfig): void {
   writeFileSync(configPath, stringify(config));
 }
 
+export function getActiveInstance(): InstanceConfig | undefined {
+  const config = loadConfig();
+  if (!config.active || !config.instances?.[config.active]) return undefined;
+  return config.instances[config.active];
+}
+
 export function getEndpoint(): string {
-  return process.env.IX_ENDPOINT || loadConfig().endpoint;
+  if (process.env.IX_ENDPOINT) return process.env.IX_ENDPOINT;
+  const instance = getActiveInstance();
+  if (instance) return instance.endpoint;
+  return loadConfig().endpoint;
+}
+
+export function getAuthToken(): string | undefined {
+  const instance = getActiveInstance();
+  if (!instance?.auth) return undefined;
+  const expiresAt = new Date(instance.auth.expires_at);
+  if (expiresAt <= new Date()) return undefined;
+  return instance.auth.token;
+}
+
+export function storeAuth(instanceName: string, auth: InstanceAuth): void {
+  const config = loadConfig() as any;
+  if (!config.instances?.[instanceName]) return;
+  config.instances[instanceName].auth = auth;
+  saveConfig(config);
+}
+
+export function clearAuth(instanceName: string): void {
+  const config = loadConfig() as any;
+  if (!config.instances?.[instanceName]) return;
+  delete config.instances[instanceName].auth;
+  saveConfig(config);
+}
+
+export async function refreshAuthIfNeeded(): Promise<string | undefined> {
+  const config = loadConfig() as any;
+  const instanceName = config.active;
+  if (!instanceName || !config.instances?.[instanceName]) return undefined;
+
+  const instance = config.instances[instanceName] as InstanceConfig;
+  if (!instance.auth) return undefined;
+
+  const expiresAt = new Date(instance.auth.expires_at);
+  const now = new Date();
+  const bufferMs = 2 * 60 * 1000;
+  if (expiresAt.getTime() - now.getTime() > bufferMs) {
+    return instance.auth.token;
+  }
+
+  try {
+    const resp = await fetch(`${instance.endpoint}/auth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ api_key: instance.auth.api_key }),
+      signal: AbortSignal.timeout(10000),
+    });
+    if (!resp.ok) return undefined;
+    const data = await resp.json() as { token: string; expires_at: string; org_id: string; plan: string };
+    instance.auth.token = data.token;
+    instance.auth.expires_at = data.expires_at;
+    saveConfig(config);
+    return data.token;
+  } catch {
+    return undefined;
+  }
 }
 
 export function loadWorkspaces(): WorkspaceConfig[] {

--- a/ix-cli/src/cli/config.ts
+++ b/ix-cli/src/cli/config.ts
@@ -153,8 +153,6 @@ export function getActiveWorkspaceRoot(): string | undefined {
   return getDefaultWorkspace()?.root_path;
 }
 
-// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
-//
 // Resolve a source_uri from the graph (which is now a workspace-relative
 // POSIX path under the client-agnostic backend design) back to an absolute
 // host filesystem path. If the input is already absolute (e.g. legacy graphs

--- a/ix-cli/src/cli/errors.ts
+++ b/ix-cli/src/cli/errors.ts
@@ -70,6 +70,39 @@ export class CliResolutionError extends Error {
   }
 }
 
+/**
+ * Format an error for display, unwrapping fetch `TypeError: fetch failed`
+ * to expose the underlying transport cause (e.g. ECONNRESET, UND_ERR_SOCKET).
+ *
+ * Node's built-in fetch (undici) throws `TypeError('fetch failed')` on any
+ * transport-level failure and stashes the real error in `err.cause`. Without
+ * this unwrap, users see a bare "fetch failed" with no actionable detail —
+ * see the Node 18 EOL / undici 5.x transport-drop bug report.
+ */
+export function formatFetchError(err: unknown): string {
+  if (err === null || err === undefined) return String(err);
+  const e = err as { message?: unknown; cause?: unknown };
+  const base = typeof e.message === "string" && e.message.length > 0
+    ? e.message
+    : String(err);
+
+  if (base.toLowerCase().includes("fetch failed") && e.cause) {
+    const cause = e.cause as { code?: unknown; message?: unknown };
+    const parts: string[] = [];
+    if (typeof cause.code === "string" && cause.code.length > 0) {
+      parts.push(cause.code);
+    }
+    if (typeof cause.message === "string" && cause.message.length > 0) {
+      parts.push(cause.message);
+    } else if (parts.length === 0) {
+      parts.push(String(e.cause));
+    }
+    return `${base} (${parts.join(": ")})`;
+  }
+
+  return base;
+}
+
 export function renderCliError(err: unknown, debug = false): void {
   if (err instanceof CliUsageError || err instanceof CliResolutionError) {
     process.stderr.write(chalk.red(`Error: ${err.message}\n`));

--- a/ix-cli/src/cli/format.ts
+++ b/ix-cli/src/cli/format.ts
@@ -5,7 +5,6 @@ export type ResultSource = "graph" | "text" | "graph+text" | "heuristic";
 
 // ── JSON optimization helpers ──────────────────────────────────────────────
 
-// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 /**
  * Strip the cwd prefix from absolute paths to save tokens in JSON output.
  *

--- a/ix-cli/src/cli/format.ts
+++ b/ix-cli/src/cli/format.ts
@@ -5,9 +5,18 @@ export type ResultSource = "graph" | "text" | "graph+text" | "heuristic";
 
 // ── JSON optimization helpers ──────────────────────────────────────────────
 
-/** Strip the cwd prefix from absolute paths to save tokens in JSON output. */
+// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+/**
+ * Strip the cwd prefix from absolute paths to save tokens in JSON output.
+ *
+ * Under the client-agnostic backend design, source_uri values are already
+ * workspace-relative. For those we return the input unchanged. Legacy absolute
+ * paths (e.g. from older graphs) are still handled the old way.
+ */
 export function relativePath(absPath: string | undefined | null): string | undefined {
   if (!absPath) return undefined;
+  // Already relative (workspace-relative path from post-migration graphs).
+  if (!absPath.startsWith("/") && !/^[A-Za-z]:[\\/]/.test(absPath)) return absPath;
   const cwd = process.cwd();
   if (absPath.startsWith(cwd + "/")) return absPath.slice(cwd.length + 1);
   // Also handle /Users/.../project/ style without trailing slash match

--- a/ix-cli/src/cli/github/transform.ts
+++ b/ix-cli/src/cli/github/transform.ts
@@ -19,9 +19,25 @@ function truncate(s: string | null | undefined, max: number): string {
   return s.length > max ? s.slice(0, max) + "..." : s;
 }
 
+/**
+ * Parse "fixes #N", "closes #N", "resolves #N" references from text.
+ * Returns unique issue numbers referenced.
+ */
+export function parseFixesRefs(text: string | null | undefined): number[] {
+  if (!text) return [];
+  const pattern = /(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s+#(\d+)/gi;
+  const nums = new Set<number>();
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(text)) !== null) {
+    nums.add(parseInt(match[1], 10));
+  }
+  return [...nums];
+}
+
 export function transformIssue(repo: GitHubRepo, issue: GitHubIssue): PatchOp[] {
   const uri = `github://${repo.owner}/${repo.repo}/issues/${issue.number}`;
   const nodeId = deterministicId(uri);
+  const isBug = issue.labels.some(l => /bug|defect/i.test(l.name));
   return [
     {
       type: "UpsertNode",
@@ -37,6 +53,9 @@ export function transformIssue(repo: GitHubRepo, issue: GitHubIssue): PatchOp[] 
         created_at: issue.created_at,
         body: truncate(issue.body, 2000),
         source_uri: uri,
+        source: "github",
+        github_type: "issue",
+        is_bug: isBug,
       },
     },
   ];
@@ -62,6 +81,8 @@ export function transformIssueComment(
         created_at: comment.created_at,
         body: truncate(comment.body, 2000),
         source_uri: commentUri,
+        source: "github",
+        github_type: "issue_comment",
       },
     },
     {
@@ -78,7 +99,7 @@ export function transformIssueComment(
 export function transformPR(repo: GitHubRepo, pr: GitHubPR): PatchOp[] {
   const uri = `github://${repo.owner}/${repo.repo}/pull/${pr.number}`;
   const nodeId = deterministicId(uri);
-  return [
+  const ops: PatchOp[] = [
     {
       type: "UpsertNode",
       id: nodeId,
@@ -97,9 +118,29 @@ export function transformPR(repo: GitHubRepo, pr: GitHubPR): PatchOp[] {
         body: truncate(pr.body, 2000),
         rationale: truncate(pr.body, 500),
         source_uri: uri,
+        source: "github",
+        github_type: "pull_request",
       },
     },
   ];
+
+  // Create RESOLVES edges for "fixes #N" / "closes #N" references in PR body + title
+  const fixedIssues = parseFixesRefs(`${pr.title}\n${pr.body ?? ""}`);
+  for (const issueNum of fixedIssues) {
+    const issueUri = `github://${repo.owner}/${repo.repo}/issues/${issueNum}`;
+    const issueNodeId = deterministicId(issueUri);
+    const edgeId = deterministicId(`${uri}:RESOLVES:${issueUri}`);
+    ops.push({
+      type: "UpsertEdge",
+      id: edgeId,
+      src: nodeId,
+      dst: issueNodeId,
+      predicate: "RESOLVES",
+      attrs: { source: "github" },
+    });
+  }
+
+  return ops;
 }
 
 export function transformPRComment(
@@ -122,6 +163,8 @@ export function transformPRComment(
         created_at: comment.created_at,
         body: truncate(comment.body, 2000),
         source_uri: commentUri,
+        source: "github",
+        github_type: "pr_comment",
       },
     },
     {
@@ -153,6 +196,8 @@ export function transformCommit(repo: GitHubRepo, commit: GitHubCommit): PatchOp
         message: truncate(commit.commit.message, 2000),
         changed_files: commit.files?.map(f => f.filename) ?? [],
         source_uri: uri,
+        source: "github",
+        github_type: "commit",
       },
     },
   ];

--- a/ix-cli/src/cli/jira/auth.ts
+++ b/ix-cli/src/cli/jira/auth.ts
@@ -1,0 +1,50 @@
+/**
+ * Resolve Jira credentials using this priority:
+ * 1. Explicit --token / --email / --url flags
+ * 2. Environment variables: JIRA_TOKEN, JIRA_EMAIL, JIRA_URL
+ */
+
+export interface JiraCredentials {
+  baseUrl: string;
+  email: string;
+  token: string;
+}
+
+export function resolveJiraCredentials(opts?: {
+  url?: string;
+  email?: string;
+  token?: string;
+}): JiraCredentials {
+  const baseUrl = opts?.url ?? process.env.JIRA_URL;
+  const email = opts?.email ?? process.env.JIRA_EMAIL;
+  const token = opts?.token ?? process.env.JIRA_TOKEN;
+
+  if (!baseUrl) {
+    throw new Error(
+      "Jira URL required. Provide one of:\n" +
+      "  --url <url>         Jira instance URL (e.g. https://myorg.atlassian.net)\n" +
+      "  JIRA_URL=<url>      Environment variable"
+    );
+  }
+
+  if (!email) {
+    throw new Error(
+      "Jira email required. Provide one of:\n" +
+      "  --email <email>     Atlassian account email\n" +
+      "  JIRA_EMAIL=<email>  Environment variable"
+    );
+  }
+
+  if (!token) {
+    throw new Error(
+      "Jira API token required. Provide one of:\n" +
+      "  --token <token>         API token (from id.atlassian.com)\n" +
+      "  JIRA_TOKEN=<token>      Environment variable"
+    );
+  }
+
+  // Normalize: strip trailing slash
+  const normalizedUrl = baseUrl.replace(/\/+$/, "");
+
+  return { baseUrl: normalizedUrl, email, token };
+}

--- a/ix-cli/src/cli/jira/fetch.ts
+++ b/ix-cli/src/cli/jira/fetch.ts
@@ -1,0 +1,222 @@
+import type { JiraCredentials } from "./auth.js";
+
+// ── Jira API Types ──────────────────────────────────────────────────
+
+export interface JiraUser {
+  accountId: string;
+  displayName: string;
+  emailAddress?: string;
+}
+
+export interface JiraStatus {
+  name: string;
+  statusCategory: { key: string; name: string };
+}
+
+export interface JiraPriority {
+  name: string;
+}
+
+export interface JiraIssueType {
+  name: string;
+  subtask: boolean;
+}
+
+export interface JiraIssueFields {
+  summary: string;
+  description: string | null;
+  status: JiraStatus;
+  priority: JiraPriority | null;
+  issuetype: JiraIssueType;
+  assignee: JiraUser | null;
+  reporter: JiraUser | null;
+  labels: string[];
+  created: string;
+  updated: string;
+  resolutiondate: string | null;
+  parent?: { key: string; fields?: { summary?: string; issuetype?: JiraIssueType } };
+  comment?: { comments: JiraComment[]; total: number };
+}
+
+export interface JiraIssue {
+  id: string;
+  key: string;
+  self: string;
+  fields: JiraIssueFields;
+}
+
+export interface JiraComment {
+  id: string;
+  body: string;
+  author: JiraUser;
+  created: string;
+  updated: string;
+}
+
+export interface JiraSprint {
+  id: number;
+  name: string;
+  state: string; // "active" | "closed" | "future"
+  startDate?: string;
+  endDate?: string;
+  completeDate?: string;
+  goal?: string;
+}
+
+export interface JiraFetchResult {
+  issues: JiraIssue[];
+  sprints: JiraSprint[];
+}
+
+// ── Status mapping ──────────────────────────────────────────────────
+
+const DEFAULT_STATUS_MAP: Record<string, string> = {
+  "to do": "pending",
+  "open": "pending",
+  "backlog": "pending",
+  "in progress": "in_progress",
+  "in review": "in_progress",
+  "done": "done",
+  "closed": "done",
+  "resolved": "done",
+};
+
+export function mapJiraStatus(jiraStatus: string): string {
+  return DEFAULT_STATUS_MAP[jiraStatus.toLowerCase()] ?? "pending";
+}
+
+// ── API client ──────────────────────────────────────────────────────
+
+async function jiraFetch<T>(
+  creds: JiraCredentials,
+  path: string,
+): Promise<T> {
+  const url = `${creds.baseUrl}/rest/api/3/${path}`;
+  const auth = Buffer.from(`${creds.email}:${creds.token}`).toString("base64");
+
+  const resp = await fetch(url, {
+    headers: {
+      Authorization: `Basic ${auth}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Jira API ${resp.status}: ${text}`);
+  }
+
+  return resp.json() as Promise<T>;
+}
+
+async function jiraAgileGet<T>(
+  creds: JiraCredentials,
+  path: string,
+): Promise<T> {
+  const url = `${creds.baseUrl}/rest/agile/1.0/${path}`;
+  const auth = Buffer.from(`${creds.email}:${creds.token}`).toString("base64");
+
+  const resp = await fetch(url, {
+    headers: {
+      Authorization: `Basic ${auth}`,
+      Accept: "application/json",
+    },
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Jira Agile API ${resp.status}: ${text}`);
+  }
+
+  return resp.json() as Promise<T>;
+}
+
+// ── Transition helper ───────────────────────────────────────────────
+
+export async function transitionIssue(
+  creds: JiraCredentials,
+  issueKey: string,
+  targetStatus: string,
+): Promise<{ transitioned: boolean; transitionName?: string }> {
+  const url = `${creds.baseUrl}/rest/api/3/issue/${issueKey}/transitions`;
+  const auth = Buffer.from(`${creds.email}:${creds.token}`).toString("base64");
+
+  // Get available transitions
+  const resp = await fetch(url, {
+    headers: { Authorization: `Basic ${auth}`, Accept: "application/json" },
+  });
+  if (!resp.ok) throw new Error(`Jira transitions ${resp.status}`);
+  const { transitions } = (await resp.json()) as {
+    transitions: { id: string; name: string; to: { name: string } }[];
+  };
+
+  // Find matching transition
+  const match = transitions.find(
+    (t) => t.to.name.toLowerCase() === targetStatus.toLowerCase(),
+  );
+  if (!match) return { transitioned: false };
+
+  // Execute transition
+  const execResp = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${auth}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ transition: { id: match.id } }),
+  });
+
+  if (!execResp.ok) {
+    const text = await execResp.text();
+    throw new Error(`Jira transition failed ${execResp.status}: ${text}`);
+  }
+
+  return { transitioned: true, transitionName: match.name };
+}
+
+// ── Fetch orchestrator ──────────────────────────────────────────────
+
+export async function fetchJiraData(
+  creds: JiraCredentials,
+  projectKey: string,
+  opts: { since?: string; limit?: number; jql?: string },
+): Promise<JiraFetchResult> {
+  const limit = opts.limit ?? 50;
+
+  // Build JQL
+  let jql = opts.jql ?? `project = ${projectKey}`;
+  if (opts.since) {
+    jql += ` AND updated >= "${opts.since}"`;
+  }
+  jql += " ORDER BY updated DESC";
+
+  const encodedJql = encodeURIComponent(jql);
+  const fields = "summary,description,status,priority,issuetype,assignee,reporter,labels,created,updated,resolutiondate,parent,comment";
+
+  const searchResult = await jiraFetch<{
+    issues: JiraIssue[];
+    total: number;
+  }>(creds, `search?jql=${encodedJql}&maxResults=${limit}&fields=${fields}`);
+
+  // Fetch sprints via Agile API (board-based)
+  let sprints: JiraSprint[] = [];
+  try {
+    const boards = await jiraAgileGet<{
+      values: { id: number; name: string }[];
+    }>(creds, `board?projectKeyOrId=${projectKey}&maxResults=1`);
+
+    if (boards.values.length > 0) {
+      const boardId = boards.values[0].id;
+      const sprintResult = await jiraAgileGet<{
+        values: JiraSprint[];
+      }>(creds, `board/${boardId}/sprint?maxResults=10&state=active,closed,future`);
+      sprints = sprintResult.values;
+    }
+  } catch {
+    // Agile API may not be available or board may not exist
+  }
+
+  return { issues: searchResult.issues, sprints };
+}

--- a/ix-cli/src/cli/jira/transform.ts
+++ b/ix-cli/src/cli/jira/transform.ts
@@ -1,0 +1,188 @@
+import { createHash } from "node:crypto";
+import type { PatchOp } from "../../client/types.js";
+import type { JiraIssue, JiraComment, JiraSprint } from "./fetch.js";
+import { mapJiraStatus } from "./fetch.js";
+
+/** Generate a deterministic UUID-like ID from a string. */
+export function deterministicId(input: string): string {
+  const hash = createHash("sha256").update(input).digest("hex");
+  return [
+    hash.slice(0, 8),
+    hash.slice(8, 12),
+    hash.slice(12, 16),
+    hash.slice(16, 20),
+    hash.slice(20, 32),
+  ].join("-");
+}
+
+function truncate(s: string | null | undefined, max: number): string {
+  if (!s) return "";
+  return s.length > max ? s.slice(0, max) + "..." : s;
+}
+
+/** Parse a Jira issue key like "PROJ-123" */
+export function parseJiraKey(key: string): { project: string; number: number } | null {
+  const match = key.match(/^([A-Z][A-Z0-9_]+)-(\d+)$/);
+  if (!match) return null;
+  return { project: match[1], number: parseInt(match[2], 10) };
+}
+
+// ── Issue type detection ────────────────────────────────────────────
+
+const BUG_TYPES = new Set(["bug", "defect", "incident"]);
+const EPIC_TYPES = new Set(["epic"]);
+
+function isBugType(issue: JiraIssue): boolean {
+  const typeName = issue.fields.issuetype.name.toLowerCase();
+  if (BUG_TYPES.has(typeName)) return true;
+  return issue.fields.labels.some((l) => /bug|defect/i.test(l));
+}
+
+function isEpicType(issue: JiraIssue): boolean {
+  return EPIC_TYPES.has(issue.fields.issuetype.name.toLowerCase());
+}
+
+// ── Jira description → plain text ──────────────────────────────────
+
+function adfToPlainText(node: any): string {
+  if (!node) return "";
+  if (typeof node === "string") return node;
+  if (node.type === "text") return node.text ?? "";
+  if (node.content && Array.isArray(node.content)) {
+    return node.content.map(adfToPlainText).join("");
+  }
+  return "";
+}
+
+function descriptionText(desc: any): string {
+  if (!desc) return "";
+  if (typeof desc === "string") return desc;
+  // ADF (Atlassian Document Format)
+  return adfToPlainText(desc);
+}
+
+// ── Transforms ──────────────────────────────────────────────────────
+
+export function transformIssue(baseUrl: string, issue: JiraIssue): PatchOp[] {
+  const uri = `jira://${issue.key}`;
+  const nodeId = deterministicId(uri);
+  const isBug = isBugType(issue);
+  const isEpic = isEpicType(issue);
+  const description = descriptionText(issue.fields.description);
+
+  // Map Jira issue types to graph node kinds:
+  //   Epic → goal, Bug → intent (is_bug=true), Story/Task/Sub-task → intent
+  const kind = isEpic ? "goal" : "intent";
+  const jiraType = isEpic
+    ? "epic"
+    : isBug
+      ? "bug"
+      : issue.fields.issuetype.name.toLowerCase();
+
+  const ops: PatchOp[] = [
+    {
+      type: "UpsertNode",
+      id: nodeId,
+      kind,
+      name: issue.fields.summary,
+      attrs: {
+        jira_key: issue.key,
+        jira_id: issue.id,
+        url: `${baseUrl}/browse/${issue.key}`,
+        author: issue.fields.reporter?.displayName ?? "unknown",
+        assignee: issue.fields.assignee?.displayName ?? null,
+        labels: issue.fields.labels,
+        state: mapJiraStatus(issue.fields.status.name),
+        jira_status: issue.fields.status.name,
+        priority: issue.fields.priority?.name ?? null,
+        created_at: issue.fields.created,
+        updated_at: issue.fields.updated,
+        resolved_at: issue.fields.resolutiondate ?? null,
+        body: truncate(description, 2000),
+        source_uri: uri,
+        source: "jira",
+        jira_type: jiraType,
+        is_bug: isBug,
+      },
+    },
+  ];
+
+  // Create PART_OF edge to parent epic if present
+  if (issue.fields.parent) {
+    const parentUri = `jira://${issue.fields.parent.key}`;
+    const parentId = deterministicId(parentUri);
+    const edgeId = deterministicId(`${uri}:PART_OF:${parentUri}`);
+    ops.push({
+      type: "UpsertEdge",
+      id: edgeId,
+      src: nodeId,
+      dst: parentId,
+      predicate: "PART_OF",
+      attrs: { source: "jira" },
+    });
+  }
+
+  return ops;
+}
+
+export function transformComment(
+  issue: JiraIssue,
+  comment: JiraComment,
+): PatchOp[] {
+  const parentUri = `jira://${issue.key}`;
+  const commentUri = `${parentUri}/comments/${comment.id}`;
+  const parentId = deterministicId(parentUri);
+  const commentId = deterministicId(commentUri);
+  const edgeId = deterministicId(`${parentUri}:CONTAINS:${commentUri}`);
+
+  return [
+    {
+      type: "UpsertNode",
+      id: commentId,
+      kind: "doc",
+      name: `${issue.key} comment by ${comment.author?.displayName ?? "unknown"}`,
+      attrs: {
+        jira_key: issue.key,
+        author: comment.author?.displayName ?? "unknown",
+        created_at: comment.created,
+        body: truncate(comment.body, 2000),
+        source_uri: commentUri,
+        source: "jira",
+        jira_type: "comment",
+      },
+    },
+    {
+      type: "UpsertEdge",
+      id: edgeId,
+      src: parentId,
+      dst: commentId,
+      predicate: "CONTAINS",
+      attrs: {},
+    },
+  ];
+}
+
+export function transformSprint(baseUrl: string, sprint: JiraSprint): PatchOp[] {
+  const uri = `jira://sprint/${sprint.id}`;
+  const nodeId = deterministicId(uri);
+
+  return [
+    {
+      type: "UpsertNode",
+      id: nodeId,
+      kind: "plan",
+      name: sprint.name,
+      attrs: {
+        jira_sprint_id: sprint.id,
+        state: sprint.state,
+        start_date: sprint.startDate ?? null,
+        end_date: sprint.endDate ?? null,
+        complete_date: sprint.completeDate ?? null,
+        goal: sprint.goal ?? null,
+        source_uri: uri,
+        source: "jira",
+        jira_type: "sprint",
+      },
+    },
+  ];
+}

--- a/ix-cli/src/cli/main.ts
+++ b/ix-cli/src/cli/main.ts
@@ -9,6 +9,22 @@ import { readFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
+// Runtime Node version guard. Runs before any command work so users on an
+// unsupported Node get an actionable message instead of a cryptic "fetch
+// failed" deep inside undici.
+const MIN_NODE_MAJOR = 20;
+{
+  const current = process.versions.node;
+  const major = parseInt(current.split(".")[0] ?? "0", 10);
+  if (!Number.isFinite(major) || major < MIN_NODE_MAJOR) {
+    process.stderr.write(
+      `Ix requires Node.js ${MIN_NODE_MAJOR} or newer. You are running v${current}.\n` +
+      `Install a supported version from https://nodejs.org/ and re-run.\n`
+    );
+    process.exit(1);
+  }
+}
+
 let cliVersion = "0.0.0";
 try {
   const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/ix-cli/src/cli/register/oss.ts
+++ b/ix-cli/src/cli/register/oss.ts
@@ -34,6 +34,7 @@ import { registerSubsystemsCommand } from "../commands/subsystems.js";
 import { registerUpgradeCommand } from "../commands/upgrade.js";
 import { registerViewCommand } from "../commands/view.js";
 import { registerSavingsCommand } from "../commands/savings.js";
+import { registerLoadCommand } from "../commands/load.js";
 
 const PRO_COMMANDS: { name: string; desc: string }[] = [
   { name: "briefing", desc: "Session-resume briefing" },
@@ -96,6 +97,7 @@ export function registerOssCommands(program: Command): void {
   registerUpgradeCommand(program);
   registerViewCommand(program);
   registerSavingsCommand(program);
+  registerLoadCommand(program);
 
   // Hide advanced commands from default help
   const advancedSet = new Set(ADVANCED_COMMANDS);

--- a/ix-cli/src/cli/sources/detect.ts
+++ b/ix-cli/src/cli/sources/detect.ts
@@ -1,0 +1,151 @@
+/**
+ * URL / path type detection for multi-source ingestion.
+ *
+ * Auto-classifies a user-provided string (URL or local path) into a
+ * SourceKind that drives the fetch → extract → transform pipeline.
+ */
+
+export type SourceKind =
+  | "tweet"
+  | "arxiv"
+  | "pdf"
+  | "image"
+  | "webpage"
+  | "chat_export"
+  | "github"
+  | "local_file";
+
+export interface DetectedSource {
+  kind: SourceKind;
+  /** Original input string (URL or file path). */
+  raw: string;
+  /** Normalized URL if applicable, otherwise the absolute file path. */
+  uri: string;
+  /** Extra metadata extracted during detection (e.g. arxiv paper ID). */
+  meta: Record<string, string>;
+}
+
+const IMAGE_EXTENSIONS = new Set([
+  ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp", ".tiff",
+]);
+
+const CHAT_EXTENSIONS = new Set([".json", ".csv", ".jsonl"]);
+
+/**
+ * Detect the source type from a URL or file path.
+ *
+ * Detection order matters — more specific patterns are checked first.
+ */
+export function detectSource(input: string): DetectedSource {
+  const trimmed = input.trim();
+
+  // --- URL-based detection ---
+  if (/^https?:\/\//i.test(trimmed)) {
+    return detectUrl(trimmed);
+  }
+
+  // --- Local file path ---
+  return detectLocalFile(trimmed);
+}
+
+function detectUrl(url: string): DetectedSource {
+  const lower = url.toLowerCase();
+  const parsed = new URL(url);
+  const host = parsed.hostname.replace(/^www\./, "");
+  const path = parsed.pathname.toLowerCase();
+
+  // Twitter / X
+  if (host === "twitter.com" || host === "x.com") {
+    const tweetMatch = parsed.pathname.match(/\/([^/]+)\/status\/(\d+)/);
+    return {
+      kind: "tweet",
+      raw: url,
+      uri: url,
+      meta: tweetMatch
+        ? { author: tweetMatch[1], tweetId: tweetMatch[2] }
+        : {},
+    };
+  }
+
+  // arXiv
+  if (host === "arxiv.org" || host.endsWith(".arxiv.org")) {
+    const paperMatch = parsed.pathname.match(
+      /\/(?:abs|pdf|html)\/(\d{4}\.\d{4,5})/
+    );
+    return {
+      kind: "arxiv",
+      raw: url,
+      uri: url,
+      meta: paperMatch ? { paperId: paperMatch[1] } : {},
+    };
+  }
+
+  // GitHub — delegate to existing GitHub ingestion
+  if (host === "github.com") {
+    return {
+      kind: "github",
+      raw: url,
+      uri: url,
+      meta: {},
+    };
+  }
+
+  // Direct PDF link
+  if (path.endsWith(".pdf") || lower.includes("content-type=application/pdf")) {
+    return {
+      kind: "pdf",
+      raw: url,
+      uri: url,
+      meta: {},
+    };
+  }
+
+  // Direct image link
+  const ext = extFrom(path);
+  if (ext && IMAGE_EXTENSIONS.has(ext)) {
+    return {
+      kind: "image",
+      raw: url,
+      uri: url,
+      meta: {},
+    };
+  }
+
+  // Default: webpage
+  return {
+    kind: "webpage",
+    raw: url,
+    uri: url,
+    meta: {},
+  };
+}
+
+function detectLocalFile(filePath: string): DetectedSource {
+  const lower = filePath.toLowerCase();
+  const ext = extFrom(lower);
+
+  if (ext === ".pdf") {
+    return { kind: "pdf", raw: filePath, uri: filePath, meta: {} };
+  }
+
+  if (ext && IMAGE_EXTENSIONS.has(ext)) {
+    return { kind: "image", raw: filePath, uri: filePath, meta: {} };
+  }
+
+  // Chat export heuristic: JSON/CSV/JSONL files with "chat", "slack",
+  // "discord", or "messages" in the filename
+  if (ext && CHAT_EXTENSIONS.has(ext)) {
+    const name = filePath.split("/").pop() ?? "";
+    if (/chat|slack|discord|messages|conversation/i.test(name)) {
+      return { kind: "chat_export", raw: filePath, uri: filePath, meta: {} };
+    }
+  }
+
+  return { kind: "local_file", raw: filePath, uri: filePath, meta: {} };
+}
+
+function extFrom(path: string): string | null {
+  const dot = path.lastIndexOf(".");
+  if (dot === -1) return null;
+  return path.slice(dot).toLowerCase();
+}

--- a/ix-cli/src/cli/sources/fetch.ts
+++ b/ix-cli/src/cli/sources/fetch.ts
@@ -62,12 +62,9 @@ async function fetchTweet(source: DetectedSource): Promise<FetchedContent> {
   };
 
   // Strip HTML tags to get plain text
-  const plainText = data.html
-    .replace(/<[^>]+>/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
+  const plainText = decodeEntities(
+    data.html.replace(/<[^>]+>/g, " ")
+  )
     .replace(/\s+/g, " ")
     .trim();
 
@@ -331,26 +328,52 @@ function extractByClass(html: string, className: string): string | null {
   return match[1].replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
 }
 
-/** Simple HTML to text conversion — strips tags, decodes entities. */
-function htmlToText(html: string): string {
-  return html
-    // Remove script and style blocks
-    .replace(/<script[\s\S]*?<\/script>/gi, "")
-    .replace(/<style[\s\S]*?<\/style>/gi, "")
-    .replace(/<nav[\s\S]*?<\/nav>/gi, "")
-    .replace(/<header[\s\S]*?<\/header>/gi, "")
-    .replace(/<footer[\s\S]*?<\/footer>/gi, "")
-    // Convert block elements to newlines
-    .replace(/<\/?(?:div|p|br|h[1-6]|li|tr|blockquote)[^>]*>/gi, "\n")
-    // Strip remaining tags
-    .replace(/<[^>]+>/g, " ")
-    // Decode common entities
-    .replace(/&amp;/g, "&")
+/** Decode common HTML entities. Run after all tags are stripped. */
+function decodeEntities(text: string): string {
+  return text
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
     .replace(/&nbsp;/g, " ")
+    // &amp; must be last to avoid double-decoding
+    .replace(/&amp;/g, "&");
+}
+
+/** Strip dangerous HTML blocks (script, style) using iterative replacement. */
+function stripBlocks(html: string, tag: string): string {
+  const open = new RegExp(`<${tag}[\\s>]`, "i");
+  const close = new RegExp(`</${tag}\\s*>`, "i");
+  let result = html;
+  // Iterate to handle nested/malformed occurrences
+  while (open.test(result)) {
+    const start = result.search(open);
+    const endMatch = close.exec(result.slice(start));
+    if (endMatch) {
+      result = result.slice(0, start) + result.slice(start + endMatch.index + endMatch[0].length);
+    } else {
+      // No closing tag — remove everything from the opening tag onward
+      result = result.slice(0, start);
+      break;
+    }
+  }
+  return result;
+}
+
+/** Simple HTML to text conversion — strips tags, decodes entities. */
+function htmlToText(html: string): string {
+  let text = html;
+  // Remove dangerous and non-content blocks iteratively
+  for (const tag of ["script", "style", "nav", "header", "footer"]) {
+    text = stripBlocks(text, tag);
+  }
+  return decodeEntities(
+    text
+      // Convert block elements to newlines
+      .replace(/<\/?(?:div|p|br|h[1-6]|li|tr|blockquote)[^>]*>/gi, "\n")
+      // Strip remaining tags
+      .replace(/<[^>]+>/g, " ")
+  )
     // Collapse whitespace
     .replace(/[ \t]+/g, " ")
     .replace(/\n{3,}/g, "\n\n")

--- a/ix-cli/src/cli/sources/fetch.ts
+++ b/ix-cli/src/cli/sources/fetch.ts
@@ -1,0 +1,358 @@
+/**
+ * Per-source-type content fetchers.
+ *
+ * Each fetcher takes a DetectedSource and returns a FetchedContent object
+ * containing the raw content (text or binary) plus extracted metadata.
+ */
+
+import { readFileSync } from "node:fs";
+import type { DetectedSource, SourceKind } from "./detect.js";
+
+export interface FetchedContent {
+  kind: SourceKind;
+  /** Source URI for provenance tracking. */
+  uri: string;
+  /** Text content (for text-based sources). */
+  text?: string;
+  /** Binary content (for images, PDFs). */
+  binary?: Buffer;
+  /** Structured metadata extracted during fetch. */
+  meta: Record<string, unknown>;
+}
+
+type Fetcher = (source: DetectedSource) => Promise<FetchedContent>;
+
+const fetchers: Record<string, Fetcher> = {
+  tweet: fetchTweet,
+  arxiv: fetchArxiv,
+  pdf: fetchPdf,
+  image: fetchImage,
+  webpage: fetchWebpage,
+  chat_export: fetchChatExport,
+  local_file: fetchLocalFile,
+};
+
+export async function fetchContent(source: DetectedSource): Promise<FetchedContent> {
+  const fetcher = fetchers[source.kind];
+  if (!fetcher) {
+    throw new Error(`No fetcher for source kind: ${source.kind}`);
+  }
+  return fetcher(source);
+}
+
+// ─── Tweet ──────────────────────────────────────────────────────────
+
+async function fetchTweet(source: DetectedSource): Promise<FetchedContent> {
+  // Use Twitter oEmbed API — no auth required, returns HTML + metadata
+  const oembedUrl = `https://publish.twitter.com/oembed?url=${encodeURIComponent(source.uri)}&omit_script=true`;
+
+  const resp = await fetch(oembedUrl, {
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!resp.ok) {
+    throw new Error(`Twitter oEmbed failed (${resp.status}): ${await resp.text()}`);
+  }
+
+  const data = (await resp.json()) as {
+    html: string;
+    author_name: string;
+    author_url: string;
+    url: string;
+  };
+
+  // Strip HTML tags to get plain text
+  const plainText = data.html
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return {
+    kind: "tweet",
+    uri: source.uri,
+    text: plainText,
+    meta: {
+      author: data.author_name,
+      author_url: data.author_url,
+      tweet_url: data.url,
+      tweet_id: source.meta.tweetId,
+    },
+  };
+}
+
+// ─── arXiv ──────────────────────────────────────────────────────────
+
+async function fetchArxiv(source: DetectedSource): Promise<FetchedContent> {
+  const paperId = source.meta.paperId;
+  // Use arXiv abstract page for metadata extraction
+  const absUrl = paperId
+    ? `https://arxiv.org/abs/${paperId}`
+    : source.uri.replace("/pdf/", "/abs/").replace("/html/", "/abs/");
+
+  const resp = await fetch(absUrl, {
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (!resp.ok) {
+    throw new Error(`arXiv fetch failed (${resp.status})`);
+  }
+
+  const html = await resp.text();
+
+  // Extract metadata from the HTML
+  const title = extractMeta(html, "citation_title") ?? extractTag(html, "title") ?? "Unknown";
+  const abstract = extractMetaContent(html, "citation_abstract")
+    ?? extractByClass(html, "abstract")
+    ?? "";
+  const authors = extractAllMeta(html, "citation_author");
+  const date = extractMeta(html, "citation_date") ?? "";
+  const doi = extractMeta(html, "citation_doi") ?? "";
+
+  const text = `# ${title}\n\n**Authors:** ${authors.join(", ")}\n**Date:** ${date}\n\n## Abstract\n\n${abstract.trim()}`;
+
+  return {
+    kind: "arxiv",
+    uri: source.uri,
+    text,
+    meta: {
+      paper_id: paperId ?? "",
+      title,
+      authors,
+      date,
+      doi,
+      abstract_url: absUrl,
+    },
+  };
+}
+
+// ─── PDF ────────────────────────────────────────────────────────────
+
+async function fetchPdf(source: DetectedSource): Promise<FetchedContent> {
+  if (isUrl(source.uri)) {
+    const resp = await fetch(source.uri, {
+      signal: AbortSignal.timeout(60_000),
+    });
+    if (!resp.ok) {
+      throw new Error(`PDF download failed (${resp.status})`);
+    }
+    const buffer = Buffer.from(await resp.arrayBuffer());
+    return {
+      kind: "pdf",
+      uri: source.uri,
+      binary: buffer,
+      meta: { size: buffer.length },
+    };
+  }
+
+  // Local file
+  const buffer = readFileSync(source.uri);
+  return {
+    kind: "pdf",
+    uri: source.uri,
+    binary: buffer,
+    meta: { size: buffer.length },
+  };
+}
+
+// ─── Image ──────────────────────────────────────────────────────────
+
+async function fetchImage(source: DetectedSource): Promise<FetchedContent> {
+  if (isUrl(source.uri)) {
+    const resp = await fetch(source.uri, {
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!resp.ok) {
+      throw new Error(`Image download failed (${resp.status})`);
+    }
+    const buffer = Buffer.from(await resp.arrayBuffer());
+    return {
+      kind: "image",
+      uri: source.uri,
+      binary: buffer,
+      meta: { size: buffer.length, content_type: resp.headers.get("content-type") ?? "unknown" },
+    };
+  }
+
+  const buffer = readFileSync(source.uri);
+  return {
+    kind: "image",
+    uri: source.uri,
+    binary: buffer,
+    meta: { size: buffer.length },
+  };
+}
+
+// ─── Webpage ────────────────────────────────────────────────────────
+
+async function fetchWebpage(source: DetectedSource): Promise<FetchedContent> {
+  const resp = await fetch(source.uri, {
+    signal: AbortSignal.timeout(30_000),
+    headers: {
+      "User-Agent": "Mozilla/5.0 (compatible; Ix/1.0; +https://github.com/ix-infrastructure)",
+    },
+  });
+
+  if (!resp.ok) {
+    throw new Error(`Webpage fetch failed (${resp.status})`);
+  }
+
+  const html = await resp.text();
+  const title = extractTag(html, "title") ?? source.uri;
+  const text = htmlToText(html);
+  const description = extractMeta(html, "description") ?? "";
+
+  return {
+    kind: "webpage",
+    uri: source.uri,
+    text,
+    meta: {
+      title,
+      description,
+      url: source.uri,
+    },
+  };
+}
+
+// ─── Chat export ────────────────────────────────────────────────────
+
+async function fetchChatExport(source: DetectedSource): Promise<FetchedContent> {
+  const raw = readFileSync(source.uri, "utf-8");
+  const ext = source.uri.split(".").pop()?.toLowerCase();
+
+  if (ext === "json" || ext === "jsonl") {
+    // Try parsing as JSON array or JSONL
+    let messages: unknown[];
+    if (ext === "jsonl") {
+      messages = raw.split("\n").filter(Boolean).map((line) => JSON.parse(line));
+    } else {
+      const parsed = JSON.parse(raw);
+      messages = Array.isArray(parsed) ? parsed : parsed.messages ?? [parsed];
+    }
+
+    return {
+      kind: "chat_export",
+      uri: source.uri,
+      text: raw,
+      meta: {
+        format: ext,
+        message_count: messages.length,
+        messages,
+      },
+    };
+  }
+
+  // CSV — return as raw text, let extraction handle it
+  return {
+    kind: "chat_export",
+    uri: source.uri,
+    text: raw,
+    meta: { format: "csv" },
+  };
+}
+
+// ─── Local file (generic) ───────────────────────────────────────────
+
+async function fetchLocalFile(source: DetectedSource): Promise<FetchedContent> {
+  const raw = readFileSync(source.uri, "utf-8");
+  return {
+    kind: "local_file",
+    uri: source.uri,
+    text: raw,
+    meta: {},
+  };
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+function isUrl(s: string): boolean {
+  return /^https?:\/\//i.test(s);
+}
+
+/** Extract content from a meta tag by name. */
+function extractMeta(html: string, name: string): string | null {
+  const re = new RegExp(
+    `<meta[^>]+name=["']${name}["'][^>]+content=["']([^"']+)["']`,
+    "i"
+  );
+  const match = html.match(re);
+  if (match) return match[1];
+
+  // Try reversed attribute order
+  const re2 = new RegExp(
+    `<meta[^>]+content=["']([^"']+)["'][^>]+name=["']${name}["']`,
+    "i"
+  );
+  const match2 = html.match(re2);
+  return match2 ? match2[1] : null;
+}
+
+/** Same as extractMeta but for property-based meta tags (og:, etc). */
+function extractMetaContent(html: string, name: string): string | null {
+  // Also try matching the content within a <blockquote> or <span> with the class
+  const re = new RegExp(
+    `<meta[^>]+(?:name|property)=["']${name}["'][^>]+content=["']([^"']+)["']`,
+    "i"
+  );
+  return html.match(re)?.[1] ?? null;
+}
+
+/** Extract all values for a repeated meta tag. */
+function extractAllMeta(html: string, name: string): string[] {
+  const re = new RegExp(
+    `<meta[^>]+name=["']${name}["'][^>]+content=["']([^"']+)["']`,
+    "gi"
+  );
+  const results: string[] = [];
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    results.push(m[1]);
+  }
+  return results;
+}
+
+/** Extract text content of a tag. */
+function extractTag(html: string, tag: string): string | null {
+  const re = new RegExp(`<${tag}[^>]*>([^<]+)</${tag}>`, "i");
+  return html.match(re)?.[1]?.trim() ?? null;
+}
+
+/** Extract text content by class name. */
+function extractByClass(html: string, className: string): string | null {
+  const re = new RegExp(
+    `<[^>]+class=["'][^"']*\\b${className}\\b[^"']*["'][^>]*>([\\s\\S]*?)</`,
+    "i"
+  );
+  const match = html.match(re);
+  if (!match) return null;
+  return match[1].replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+}
+
+/** Simple HTML to text conversion — strips tags, decodes entities. */
+function htmlToText(html: string): string {
+  return html
+    // Remove script and style blocks
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<style[\s\S]*?<\/style>/gi, "")
+    .replace(/<nav[\s\S]*?<\/nav>/gi, "")
+    .replace(/<header[\s\S]*?<\/header>/gi, "")
+    .replace(/<footer[\s\S]*?<\/footer>/gi, "")
+    // Convert block elements to newlines
+    .replace(/<\/?(?:div|p|br|h[1-6]|li|tr|blockquote)[^>]*>/gi, "\n")
+    // Strip remaining tags
+    .replace(/<[^>]+>/g, " ")
+    // Decode common entities
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    // Collapse whitespace
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}

--- a/ix-cli/src/client/api.ts
+++ b/ix-cli/src/client/api.ts
@@ -8,9 +8,20 @@ import type {
   GraphPatchPayload,
   PatchCommitResult,
 } from "./types.js";
+import { getAuthToken } from "../cli/config.js";
 
 export class IxClient {
-  constructor(private endpoint: string = "http://localhost:8090") {}
+  private authToken?: string;
+
+  constructor(private endpoint: string = "http://localhost:8090", authToken?: string) {
+    this.authToken = authToken ?? getAuthToken();
+  }
+
+  private authHeaders(): Record<string, string> {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.authToken) headers["Authorization"] = `Bearer ${this.authToken}`;
+    return headers;
+  }
 
   async query(
     question: string,
@@ -22,7 +33,7 @@ export class IxClient {
   async ingest(path: string, recursive?: boolean, force?: boolean): Promise<IngestResult> {
     const resp = await fetch(`${this.endpoint}/v1/ingest`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: this.authHeaders(),
       body: JSON.stringify({ path, recursive, force: force || undefined }),
       signal: AbortSignal.timeout(30 * 60 * 1000), // 30 minute timeout for large repos
     });
@@ -173,7 +184,7 @@ export class IxClient {
   async commitPatch(patch: GraphPatchPayload): Promise<PatchCommitResult> {
     const resp = await fetch(`${this.endpoint}/v1/patch`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: this.authHeaders(),
       body: JSON.stringify(patch),
       signal: AbortSignal.timeout(5 * 60 * 1000), // 5 min — matches commitPatchBulk
     });
@@ -201,7 +212,7 @@ export class IxClient {
   async map(opts?: { full?: boolean }): Promise<any> {
     const resp = await fetch(`${this.endpoint}/v1/map`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: this.authHeaders(),
       body: JSON.stringify(opts ?? {}),
       signal: AbortSignal.timeout(30 * 60 * 1000), // 30 minute timeout
     });
@@ -215,7 +226,7 @@ export class IxClient {
   async commitPatchBulk(patches: GraphPatchPayload[]): Promise<PatchCommitResult> {
     const resp = await fetch(`${this.endpoint}/v1/patches/bulk`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: this.authHeaders(),
       body: JSON.stringify({ patches }),
       signal: AbortSignal.timeout(5 * 60 * 1000), // 5 min — prevents hang when k8s ingress closes idle connections
     });
@@ -264,7 +275,7 @@ export class IxClient {
   async reset(): Promise<{ ok: boolean; message: string }> {
     const resp = await fetch(`${this.endpoint}/v1/reset`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: this.authHeaders(),
       body: JSON.stringify({}),
       signal: AbortSignal.timeout(10 * 60 * 1000), // 10 minutes
     });
@@ -278,7 +289,7 @@ export class IxClient {
   async resetCode(): Promise<{ ok: boolean; message: string }> {
     const resp = await fetch(`${this.endpoint}/v1/reset/code`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: this.authHeaders(),
       body: JSON.stringify({}),
       signal: AbortSignal.timeout(10 * 60 * 1000), // 10 minutes
     });
@@ -295,7 +306,10 @@ export class IxClient {
   }
 
   async savingsReset(): Promise<any> {
-    const resp = await fetch(`${this.endpoint}/v1/savings`, { method: "DELETE" });
+    const resp = await fetch(`${this.endpoint}/v1/savings`, {
+      method: "DELETE",
+      headers: this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {},
+    });
     if (!resp.ok) {
       const text = await resp.text();
       throw new Error(`${resp.status}: ${text}`);
@@ -314,7 +328,7 @@ export class IxClient {
   private async post<T>(path: string, body: unknown): Promise<T> {
     const resp = await fetch(`${this.endpoint}${path}`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: this.authHeaders(),
       body: JSON.stringify(body),
     });
     if (!resp.ok) {
@@ -325,7 +339,9 @@ export class IxClient {
   }
 
   private async get<T>(path: string): Promise<T> {
-    const resp = await fetch(`${this.endpoint}${path}`);
+    const resp = await fetch(`${this.endpoint}${path}`, {
+      headers: this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {},
+    });
     if (!resp.ok) {
       const text = await resp.text();
       throw new Error(`${resp.status}: ${text}`);

--- a/ix-cli/src/client/api.ts
+++ b/ix-cli/src/client/api.ts
@@ -325,6 +325,53 @@ export class IxClient {
     return this.get("/v1/health");
   }
 
+  // ── Branch API ──────────────────────────────────────────────────
+
+  async createBranch(name: string, createdBy: string): Promise<{
+    id: string; name: string; baseRev: number; headRev: number;
+    status: string; createdBy: string;
+  }> {
+    return this.post("/v1/branches", { name, createdBy });
+  }
+
+  async listBranches(opts?: { status?: string }): Promise<unknown[]> {
+    const params = new URLSearchParams();
+    if (opts?.status) params.set("status", opts.status);
+    const qs = params.toString();
+    return this.get(`/v1/branches${qs ? `?${qs}` : ""}`);
+  }
+
+  async getBranch(id: string): Promise<unknown> {
+    return this.get(`/v1/branches/${id}`);
+  }
+
+  async mergeBranch(id: string, opts?: { force?: boolean }): Promise<{
+    branchId: string; conflicts: unknown[]; safeToMerge: boolean;
+    merged?: boolean; mergedRev?: number;
+  }> {
+    return this.post(`/v1/branches/${id}/merge`, { force: opts?.force ?? false });
+  }
+
+  async compareBranches(branchIds: string[]): Promise<{
+    conflicts: Array<{ logicalId: string; touchedBy: string[] }>;
+    safeToMerge: boolean;
+  }> {
+    return this.post("/v1/branches/compare", { branches: branchIds });
+  }
+
+  async abandonBranch(id: string): Promise<{ status: string }> {
+    const resp = await fetch(`${this.endpoint}/v1/branches/${id}`, {
+      method: "DELETE",
+      headers: this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {},
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(`${resp.status}: ${text}`);
+    }
+    return resp.json() as Promise<{ status: string }>;
+  }
+
   private async post<T>(path: string, body: unknown): Promise<T> {
     const resp = await fetch(`${this.endpoint}${path}`, {
       method: "POST",

--- a/ix-cli/src/client/types.ts
+++ b/ix-cli/src/client/types.ts
@@ -173,6 +173,7 @@ export interface GraphPatchPayload {
   ops: PatchOp[];
   replaces: string[];
   intent?: string;
+  branchId?: string;
 }
 
 export interface PatchCommitResult {

--- a/ix-cli/src/client/types.ts
+++ b/ix-cli/src/client/types.ts
@@ -150,13 +150,27 @@ export interface IngestResult {
 
 export interface HealthResponse {
   status: string;
+  // NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+  // Backend on-disk graph format version. When a client's expected version
+  // differs from this, it forces a clean re-ingest (e.g. absolute→relative
+  // source_uri migration changes every node ID).
+  schema_version?: number;
 }
 
 export interface PatchSource {
+  // uri is the provenance source URI. In the client-agnostic backend design it
+  // is a workspace-relative path (POSIX separators), not an absolute host path.
+  // The backend treats this as an opaque string key for joins/tombstones.
   uri: string;
   sourceHash?: string;
   extractor: string;
   sourceType: string;
+  // NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+  // workspaceId uniquely identifies the workspace whose files produced this
+  // patch. Derived client-side as SHA-256 of the workspace root's absolute
+  // path. Backend stores it as an opaque attribute for future multi-workspace
+  // disambiguation; it does not interpret the value.
+  workspaceId?: string;
 }
 
 export interface PatchOp {

--- a/ix-cli/src/client/types.ts
+++ b/ix-cli/src/client/types.ts
@@ -150,7 +150,6 @@ export interface IngestResult {
 
 export interface HealthResponse {
   status: string;
-  // NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
   // Backend on-disk graph format version. When a client's expected version
   // differs from this, it forces a clean re-ingest (e.g. absolute→relative
   // source_uri migration changes every node ID).
@@ -165,7 +164,6 @@ export interface PatchSource {
   sourceHash?: string;
   extractor: string;
   sourceType: string;
-  // NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
   // workspaceId uniquely identifies the workspace whose files produced this
   // patch. Derived client-side as SHA-256 of the workspace root's absolute
   // path. Backend stores it as an opaque attribute for future multi-workspace

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,11 +29,11 @@ git>=2
 #  STEP 1: Node.js (auto-installed/upgraded if missing or too old)
 # ============================================================================
 
-# Node.js >= 18 (installer targets Node 22 LTS)
+# Node.js >= 20 (installer targets Node 22 LTS)
 #   macOS:   brew install node OR official .pkg installer
 #   Linux:   NodeSource apt/dnf/yum repo (setup_22.x) OR apk
 #   Windows: manual from https://nodejs.org/
-node>=18
+node>=20
 npm>=8  # bundled with Node.js
 
 # ============================================================================

--- a/scripts/backend.sh
+++ b/scripts/backend.sh
@@ -21,23 +21,19 @@ set -euo pipefail
 IX_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$IX_DIR"
 
-# On Windows/MINGW, Docker Compose (a Windows binary) can mix POSIX and Windows
-# home paths if we rely on nested interpolation defaults in the compose file.
-# Export both sides of the bind mount explicitly instead:
-#   IX_HOST_MOUNT_ROOT      → host bind source  (cygpath -m: C:/Users/...)
-#   IX_CONTAINER_MOUNT_ROOT → container target  ($HOME: /c/Users/... or /Users/...)
-# The dc() helper passes -f with a Windows-format path so docker compose can
-# locate its file regardless of how it resolves the CWD from a MINGW shell.
+# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+#
+# The HOME bind mount was removed from docker-compose.standalone.yml because
+# the backend is now client-agnostic and never reads host files. The
+# IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports that fed that bind mount
+# are therefore no longer needed. On Windows/MINGW we still need the dc()
+# helper so docker compose can locate the compose file from a MINGW shell.
 if [[ "$(uname -s)" =~ MINGW|MSYS|CYGWIN ]]; then
-  export IX_HOST_MOUNT_ROOT="$(cygpath -m "$HOME")"
-  export IX_CONTAINER_MOUNT_ROOT="${HOME}"
   dc() {
     MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' \
       docker compose -f "$(cygpath -m "$IX_DIR/$COMPOSE_FILE")" "$@"
   }
 else
-  export IX_HOST_MOUNT_ROOT="${HOME}"
-  export IX_CONTAINER_MOUNT_ROOT="${HOME}"
   dc() { docker compose -f "$COMPOSE_FILE" "$@"; }
 fi
 

--- a/scripts/backend.sh
+++ b/scripts/backend.sh
@@ -21,8 +21,6 @@ set -euo pipefail
 IX_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$IX_DIR"
 
-# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
-#
 # The HOME bind mount was removed from docker-compose.standalone.yml because
 # the backend is now client-agnostic and never reads host files. The
 # IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports that fed that bind mount

--- a/scripts/build-cli.sh
+++ b/scripts/build-cli.sh
@@ -20,13 +20,13 @@ CLI_DIR="$IX_DIR/ix-cli"
 check_prerequisites() {
   if ! command -v node &> /dev/null; then
     echo "Error: Node.js is not installed."
-    echo "  Install: https://nodejs.org/ (v18+ required)"
+    echo "  Install: https://nodejs.org/ (v20+ required)"
     exit 1
   fi
 
   NODE_VERSION=$(node -v | sed 's/v//' | cut -d. -f1)
-  if [ "$NODE_VERSION" -lt 18 ]; then
-    echo "Error: Node.js 18+ required (found $(node -v))"
+  if [ "$NODE_VERSION" -lt 20 ]; then
+    echo "Error: Node.js 20+ required (found $(node -v))"
     exit 1
   fi
 

--- a/scripts/dev/setup.sh
+++ b/scripts/dev/setup.sh
@@ -129,7 +129,7 @@ if [ "${#MISSING_DEPS[@]}" -gt 0 ]; then
   for dep in "${MISSING_DEPS[@]}"; do
     case "$dep" in
       docker) echo "    docker:  https://docs.docker.com/get-docker/" ;;
-      node)   echo "    node:    https://nodejs.org (v18+ required)" ;;
+      node)   echo "    node:    https://nodejs.org (v20+ required)" ;;
     esac
   done
   echo ""

--- a/scripts/dev/shutdown.sh
+++ b/scripts/dev/shutdown.sh
@@ -20,16 +20,16 @@ cd "$IX_DIR"
 
 COMPOSE_FILE="docker-compose.standalone.yml"
 
+# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+# IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports removed: the HOME bind
+# mount is gone from docker-compose.standalone.yml because the backend is now
+# client-agnostic and never reads host files.
 if [[ "$(uname -s)" =~ MINGW|MSYS|CYGWIN ]]; then
-  export IX_HOST_MOUNT_ROOT="$(cygpath -m "$HOME")"
-  export IX_CONTAINER_MOUNT_ROOT="${HOME}"
   dc() {
     MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' \
       docker compose -f "$(cygpath -m "$IX_DIR/$COMPOSE_FILE")" "$@"
   }
 else
-  export IX_HOST_MOUNT_ROOT="${HOME}"
-  export IX_CONTAINER_MOUNT_ROOT="${HOME}"
   dc() { docker compose -f "$IX_DIR/$COMPOSE_FILE" "$@"; }
 fi
 

--- a/scripts/dev/shutdown.sh
+++ b/scripts/dev/shutdown.sh
@@ -20,7 +20,6 @@ cd "$IX_DIR"
 
 COMPOSE_FILE="docker-compose.standalone.yml"
 
-# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 # IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports removed: the HOME bind
 # mount is gone from docker-compose.standalone.yml because the backend is now
 # client-agnostic and never reads host files.

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -27,7 +27,7 @@ $IxBin = "$IxHome\bin"
 $ComposeDir = "$IxHome\backend"
 $HealthUrl = "http://localhost:8090/v1/health"
 $ArangoUrl = "http://localhost:8529/_api/version"
-$NodeMinMajor = 18
+$NodeMinMajor = 20
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -32,7 +32,6 @@ NODE_MIN_MAJOR=18
 
 # -- Windows / POSIX docker compose wrapper --
 #
-# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 # IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports removed: the HOME bind
 # mount is gone from docker-compose.standalone.yml because the backend is now
 # client-agnostic and never reads host files.

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -28,7 +28,7 @@ COMPOSE_DIR="$IX_HOME/backend"
 HEALTH_URL="http://localhost:8090/v1/health"
 ARANGO_URL="http://localhost:8529/_api/version"
 
-NODE_MIN_MAJOR=18
+NODE_MIN_MAJOR=20
 
 # -- Windows / POSIX docker compose wrapper --
 

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -31,17 +31,17 @@ ARANGO_URL="http://localhost:8529/_api/version"
 NODE_MIN_MAJOR=18
 
 # -- Windows / POSIX docker compose wrapper --
+#
+# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+# IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports removed: the HOME bind
+# mount is gone from docker-compose.standalone.yml because the backend is now
+# client-agnostic and never reads host files.
 
 case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*)
-    IX_HOST_MOUNT_ROOT="$(cygpath -m "$HOME")"
-    export IX_HOST_MOUNT_ROOT
-    export IX_CONTAINER_MOUNT_ROOT="${HOME}"
     dc() { MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' docker compose "$@"; }
     ;;
   *)
-    export IX_HOST_MOUNT_ROOT="${HOME}"
-    export IX_CONTAINER_MOUNT_ROOT="${HOME}"
     dc() { docker compose "$@"; }
     ;;
 esac


### PR DESCRIPTION
## Summary
Integration of 4 PRs for testing before merging to main:

- **#186** — feat: view port option
- **#188** — fix: node version guard and fetch error unwrap
- **#189** — feat: client-agnostic backend — workspace-relative source_uri
- **#191** — fix: dereference symlinks in CLI tarballs

Source branches are preserved — nothing is closed or deleted.

## Test plan

### 1. Fresh install (tarball symlink fix + Docker arm64 fix)
- [ ] Uninstall ix: `rm -rf ~/.ix`
- [ ] Run `curl -fsSL https://ix-infra.com/install.sh | sh`
- [ ] Verify backend starts (Docker containers healthy)
- [ ] Verify `ix` CLI extracts and runs: `ix status`

**Note:** This requires a new release tag to produce a fixed tarball. Until then, test CLI from source:
```bash
cd Ix && npm install && npm run build && npm link
```

### 2. Client-agnostic backend (#189)
- [ ] `ix map --silent` in a project — verify source_uri is workspace-relative (no absolute HOME paths)
- [ ] `ix ingest` works with the new multi-source detection
- [ ] `ix load` command works
- [ ] Docker compose has no host bind mounts (check `docker inspect` on memory-layer container)

### 3. View port option (#186)
- [ ] `ix view --port 9090` — verify compass opens on custom port
- [ ] `ix view` — verify default port still works

### 4. Node version guard (#188)
- [ ] With Node < 18: verify `ix` shows a clear error message instead of crashing
- [ ] API fetch errors show unwrapped messages instead of raw response objects