### PR TITLE
v0.6.0: install fixes, client-agnostic backend, view port option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,8 +89,8 @@ jobs:
         run: |
           STAGING="ix-${{ steps.version.outputs.version }}-linux-amd64"
           mkdir -p "$STAGING/cli" "$STAGING/core-ingestion" "$STAGING/compass"
-          cp -r ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
-          cp -r core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
+          cp -rL ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
+          cp -rL core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
           [ -d system-compass/dist ] && cp -r system-compass/dist/* "$STAGING/compass/" || true
           cat > "$STAGING/ix" <<'WRAPPER'
           #!/bin/sh
@@ -105,8 +105,8 @@ jobs:
         run: |
           STAGING="ix-${{ steps.version.outputs.version }}-linux-arm64"
           mkdir -p "$STAGING/cli" "$STAGING/core-ingestion" "$STAGING/compass"
-          cp -r ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
-          cp -r core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
+          cp -rL ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
+          cp -rL core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
           [ -d system-compass/dist ] && cp -r system-compass/dist/* "$STAGING/compass/" || true
           cat > "$STAGING/ix" <<'WRAPPER'
           #!/bin/sh
@@ -121,8 +121,8 @@ jobs:
         run: |
           STAGING="ix-${{ steps.version.outputs.version }}-darwin-amd64"
           mkdir -p "$STAGING/cli" "$STAGING/core-ingestion" "$STAGING/compass"
-          cp -r ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
-          cp -r core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
+          cp -rL ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
+          cp -rL core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
           [ -d system-compass/dist ] && cp -r system-compass/dist/* "$STAGING/compass/" || true
           cat > "$STAGING/ix" <<'WRAPPER'
           #!/bin/sh
@@ -137,8 +137,8 @@ jobs:
         run: |
           STAGING="ix-${{ steps.version.outputs.version }}-darwin-arm64"
           mkdir -p "$STAGING/cli" "$STAGING/core-ingestion" "$STAGING/compass"
-          cp -r ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
-          cp -r core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
+          cp -rL ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
+          cp -rL core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
           [ -d system-compass/dist ] && cp -r system-compass/dist/* "$STAGING/compass/" || true
           cat > "$STAGING/ix" <<'WRAPPER'
           #!/bin/sh
@@ -153,8 +153,8 @@ jobs:
         run: |
           STAGING="ix-${{ steps.version.outputs.version }}-windows-amd64"
           mkdir -p "$STAGING/cli" "$STAGING/core-ingestion" "$STAGING/compass"
-          cp -r ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
-          cp -r core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
+          cp -rL ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
+          cp -rL core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
           [ -d system-compass/dist ] && cp -r system-compass/dist/* "$STAGING/compass/" || true
           cat > "$STAGING/ix.cmd" <<'WRAPPER'
           @echo off

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ gemini extensions install https://github.com/ix-infrastructure/ix-gemini-plugin
 ## Requirements
 
 - macOS, Linux, or Windows
+- Node.js 20 or newer
 - Git installed
 - Docker (for full functionality)
 

--- a/core-ingestion/src/types.ts
+++ b/core-ingestion/src/types.ts
@@ -1,4 +1,3 @@
-// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 export interface PatchSource {
   // uri is the provenance source URI. In the client-agnostic backend design it
   // is a workspace-relative path (POSIX separators), not an absolute host path.

--- a/core-ingestion/src/types.ts
+++ b/core-ingestion/src/types.ts
@@ -1,8 +1,15 @@
+// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 export interface PatchSource {
+  // uri is the provenance source URI. In the client-agnostic backend design it
+  // is a workspace-relative path (POSIX separators), not an absolute host path.
   uri: string;
   sourceHash?: string;
   extractor: string;
   sourceType: string;
+  // workspaceId uniquely identifies the workspace whose files produced this
+  // patch. Derived client-side (SHA-256 of workspace root abs path). Backend
+  // stores it as an opaque attribute.
+  workspaceId?: string;
 }
 
 export interface PatchOp {

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -1,5 +1,3 @@
-# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
-#
 # docker-compose.standalone.yml — Remote install (no repo checkout needed)
 #
 # Used by: curl -fsSL .../install.sh | bash

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -4,13 +4,6 @@
 # Location when installed: ~/.ix/backend/docker-compose.yml
 #
 # Uses published Docker images — no local build step required.
-#
-# NOTE: the previous HOME bind mount (${IX_HOST_MOUNT_ROOT:-$HOME}) has been
-# removed. The backend no longer reads host files — staleness detection is now
-# a pure graph comparison (see ix-memory-layer StalenessDetector) and
-# provenance.source_uri is workspace-relative, so the container never needs
-# visibility into the client's filesystem. This closes the privacy hole where
-# the entire user HOME directory was bind-mounted into the backend container.
 
 services:
   arangodb:
@@ -37,9 +30,6 @@ services:
       - backend
     ports:
       - "127.0.0.1:8090:8090"
-    # No host bind mount: the backend is client-agnostic and never reads host
-    # files. If you are on an old backend image that still expects the HOME
-    # bind mount, upgrade to the client-agnostic image (schema_version >= 2).
     environment:
       ARANGO_HOST: arangodb
       ARANGO_PORT: "8529"

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -1,9 +1,18 @@
+# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+#
 # docker-compose.standalone.yml — Remote install (no repo checkout needed)
 #
 # Used by: curl -fsSL .../install.sh | bash
 # Location when installed: ~/.ix/backend/docker-compose.yml
 #
 # Uses published Docker images — no local build step required.
+#
+# NOTE: the previous HOME bind mount (${IX_HOST_MOUNT_ROOT:-$HOME}) has been
+# removed. The backend no longer reads host files — staleness detection is now
+# a pure graph comparison (see ix-memory-layer StalenessDetector) and
+# provenance.source_uri is workspace-relative, so the container never needs
+# visibility into the client's filesystem. This closes the privacy hole where
+# the entire user HOME directory was bind-mounted into the backend container.
 
 services:
   arangodb:
@@ -30,11 +39,9 @@ services:
       - backend
     ports:
       - "127.0.0.1:8090:8090"
-    volumes:
-      - type: bind
-        source: ${IX_HOST_MOUNT_ROOT:-$HOME}
-        target: ${IX_CONTAINER_MOUNT_ROOT:-$HOME}
-        read_only: true
+    # No host bind mount: the backend is client-agnostic and never reads host
+    # files. If you are on an old backend image that still expects the HOME
+    # bind mount, upgrade to the client-agnostic image (schema_version >= 2).
     environment:
       ARANGO_HOST: arangodb
       ARANGO_PORT: "8529"

--- a/ix-cli/package.json
+++ b/ix-cli/package.json
@@ -12,6 +12,9 @@
   "bin": {
     "ix": "dist/cli/main.js"
   },
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "scripts": {
     "build": "node scripts/build-core-ingestion.mjs && node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
     "test": "node scripts/build-core-ingestion.mjs && vitest run --exclude test/parser.test.ts && node test/parser.smoke.mjs",

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -1,4 +1,3 @@
-// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 import * as nodePath from 'node:path';
 import * as fs from 'node:fs';
 import * as crypto from 'node:crypto';
@@ -400,8 +399,6 @@ export async function ingestFiles(
     ? path
     : nodePath.resolve(resolveWorkspaceRoot(opts.root), path);
 
-  // NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
-  //
   // Workspace identity for client-agnostic backend.
   //
   // The backend used to dereference provenance.source_uri against the host
@@ -421,9 +418,9 @@ export async function ingestFiles(
 
   const client = new IxClient(getEndpoint());
 
-  // NEEDS HEAVY REVIEW: schema-version check forces a clean re-ingest when the
-  // backend's graph format has changed in a way that invalidates existing node
-  // IDs (e.g. the absolute→relative source_uri migration).
+  // Schema-version check forces a clean re-ingest when the backend's graph
+  // format has changed in a way that invalidates existing node IDs (e.g. the
+  // absolute→relative source_uri migration).
   const CLIENT_EXPECTED_SCHEMA_VERSION = 2;
   try {
     const health = await client.health();
@@ -790,10 +787,10 @@ export async function ingestFiles(
           try {
             let patch = buildPatchFn!(p, hash, batchEdgesByFile.get(p.filePath) ?? emptyEdges, previousHash);
             if (mapMode) patch = stripMapModeOps(patch);
-            // NEEDS HEAVY REVIEW: tag every patch with the workspace_id. The
-            // backend stores this as an opaque attribute. The source.uri has
-            // already been set to the workspace-relative path upstream in
-            // buildPatch (because we passed the relative path to parseFile).
+            // Tag every patch with the workspace_id. The backend stores this
+            // as an opaque attribute. The source.uri has already been set to
+            // the workspace-relative path upstream in buildPatch (because we
+            // passed the relative path to parseFile).
             if (patch?.source) patch.source.workspaceId = workspaceId;
             preparedPatches.push(makePreparedPatch(patch, j + 1, p.filePath));
           } catch (err) {
@@ -861,7 +858,7 @@ export async function ingestFiles(
           try {
             let patch = buildPatchFn!(p, hash, edgesByFile.get(p.filePath) ?? emptyEdges, previousHash);
             if (mapMode) patch = stripMapModeOps(patch);
-            // NEEDS HEAVY REVIEW: tag with workspace_id (see flushBatch).
+            // Tag with workspace_id (see flushBatch).
             if (patch?.source) patch.source.workspaceId = workspaceId;
             preparedPatches.push(makePreparedPatch(patch, j + 1, p.filePath));
           } catch (err) {
@@ -936,9 +933,9 @@ export async function ingestFiles(
             if (debug) process.stderr.write(`\n  [skip minified-likely] ${filePath}\n`);
             continue;
           }
-          // NEEDS HEAVY REVIEW: parseFile receives the workspace-relative path
-          // so every deterministic ID derived in buildPatch (node/edge/chunk/
-          // patch) hashes relative paths. This makes graph IDs portable across
+          // parseFile receives the workspace-relative path so every
+          // deterministic ID derived in buildPatch (node/edge/chunk/patch)
+          // hashes relative paths. This makes graph IDs portable across
           // machines and removes backend dependence on host paths.
           parseable.push({ filePath: toWorkspaceRelative(filePath), absFilePath: filePath, source: sourceText, hash, previousHash });
         }
@@ -966,9 +963,9 @@ export async function ingestFiles(
               if (texts[j] != null) sources.set(batch[j], texts[j]!);
             }
           }
-          // NEEDS HEAVY REVIEW: global resolution index is now keyed on
-          // workspace-relative paths so that edge resolution matches the
-          // relative paths we pass into parseFile.
+          // Global resolution index is keyed on workspace-relative paths so
+          // that edge resolution matches the relative paths we pass into
+          // parseFile.
           const relSources = new Map<string, string>();
           for (const [abs, text] of sources) relSources.set(toWorkspaceRelative(abs), text);
           const relFilePaths = filePaths.map(toWorkspaceRelative);
@@ -1011,8 +1008,8 @@ export async function ingestFiles(
       // Build global resolution index from all repo file paths before the parse loop
       // so cross-batch imports resolve correctly even in streaming per-chunk mode.
       // Read all Go files in parallel to maximize I/O throughput.
-      // NEEDS HEAVY REVIEW: index keys are workspace-relative to match the
-      // relative paths we pass into parseFile below.
+      // Index keys are workspace-relative to match the relative paths we pass
+      // into parseFile below.
       {
         const goIndexStart = performance.now();
         const sources = new Map<string, string>();
@@ -1047,9 +1044,9 @@ export async function ingestFiles(
 
         // Read files asynchronously and dispatch to parse pool as each file completes.
         // This keeps workers busy while I/O is still in flight for other files.
-        // NEEDS HEAVY REVIEW: fd.filePath is the workspace-relative path, which
-        // is what parseFile and all downstream ID derivations see. absFilePath
-        // is kept only so error messages still point at the file on disk.
+        // fd.filePath is the workspace-relative path, which is what parseFile
+        // and all downstream ID derivations see. absFilePath is kept only so
+        // error messages still point at the file on disk.
         const readAndDispatch = chunk.map(async (absFilePath, idx) => {
           try {
             const st = await fs.promises.stat(absFilePath);
@@ -1212,8 +1209,6 @@ export async function ingestFiles(
 // Load existing hashes from the server for change detection
 // ---------------------------------------------------------------------------
 
-// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
-//
 // The backend now stores workspace-relative source_uri values. The CLI still
 // tracks files internally by absolute path (needed for fs reads), so this
 // helper converts to relative before the wire call and maps the server's

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -1,3 +1,4 @@
+// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 import * as nodePath from 'node:path';
 import * as fs from 'node:fs';
 import * as crypto from 'node:crypto';
@@ -399,7 +400,45 @@ export async function ingestFiles(
     ? path
     : nodePath.resolve(resolveWorkspaceRoot(opts.root), path);
 
+  // NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+  //
+  // Workspace identity for client-agnostic backend.
+  //
+  // The backend used to dereference provenance.source_uri against the host
+  // filesystem (via a broad HOME bind mount). We now emit workspace-relative
+  // paths as the canonical source_uri, and pass a workspace_id derived from
+  // the workspace root's absolute path. The backend treats both as opaque
+  // strings; it never reads host files.
+  const workspaceRoot = fs.statSync(resolvedPath).isDirectory()
+    ? resolvedPath
+    : nodePath.dirname(resolvedPath);
+  const workspaceId = crypto.createHash('sha256').update(workspaceRoot).digest('hex');
+  const toWorkspaceRelative = (absPath: string): string => {
+    // Force workspace-local POSIX separators so IDs are stable across OS.
+    const rel = nodePath.relative(workspaceRoot, absPath);
+    return rel.split(nodePath.sep).join('/');
+  };
+
   const client = new IxClient(getEndpoint());
+
+  // NEEDS HEAVY REVIEW: schema-version check forces a clean re-ingest when the
+  // backend's graph format has changed in a way that invalidates existing node
+  // IDs (e.g. the absolute→relative source_uri migration).
+  const CLIENT_EXPECTED_SCHEMA_VERSION = 2;
+  try {
+    const health = await client.health();
+    const serverVersion = (health as any)?.schema_version;
+    if (typeof serverVersion === 'number' && serverVersion !== CLIENT_EXPECTED_SCHEMA_VERSION) {
+      process.stderr.write(
+        `\n  [schema mismatch] backend schema_version=${serverVersion}, ` +
+        `client expects ${CLIENT_EXPECTED_SCHEMA_VERSION}. Forcing full re-ingest.\n`,
+      );
+      opts.force = true;
+    }
+  } catch (err) {
+    if (debug) process.stderr.write(`\n  [schema check skipped] ${err}\n`);
+  }
+
   const start = performance.now();
 
   // Worker pool for parallel file parsing across CPU cores
@@ -532,7 +571,7 @@ export async function ingestFiles(
     // so the cache wasn't cleared). Invalidate the cache so files are re-ingested.
     if (!opts.force && mtimeCache.size > 0) {
       const samplePaths = [...mtimeCache.keys()].slice(0, 5);
-      const sampleHashes = await loadExistingHashes(client, samplePaths, debug);
+      const sampleHashes = await loadExistingHashes(client, samplePaths, toWorkspaceRelative, debug);
       if (sampleHashes.size === 0) {
         mtimeCache.clear();
         if (debug) process.stderr.write(`\n  DB reset detected — invalidating mtime cache\n`);
@@ -564,7 +603,7 @@ export async function ingestFiles(
     // Phase: hash lookup — only needed when mtime-changed files exist.
     let knownHashes: Map<string, string>;
     if (opts.force || mtimeChangedPaths.length > 0) {
-      knownHashes = await loadExistingHashes(client, opts.force ? filePaths : mtimeChangedPaths, debug);
+      knownHashes = await loadExistingHashes(client, opts.force ? filePaths : mtimeChangedPaths, toWorkspaceRelative, debug);
       if (debug) process.stderr.write(`\n  Source hash lookup: ${knownHashes.size} known hashes (${mtimeChangedPaths.length} mtime-changed)\n`);
     } else {
       // All files are mtime-clean — skip server round-trip entirely.
@@ -751,6 +790,11 @@ export async function ingestFiles(
           try {
             let patch = buildPatchFn!(p, hash, batchEdgesByFile.get(p.filePath) ?? emptyEdges, previousHash);
             if (mapMode) patch = stripMapModeOps(patch);
+            // NEEDS HEAVY REVIEW: tag every patch with the workspace_id. The
+            // backend stores this as an opaque attribute. The source.uri has
+            // already been set to the workspace-relative path upstream in
+            // buildPatch (because we passed the relative path to parseFile).
+            if (patch?.source) patch.source.workspaceId = workspaceId;
             preparedPatches.push(makePreparedPatch(patch, j + 1, p.filePath));
           } catch (err) {
             parseErrors++;
@@ -817,6 +861,8 @@ export async function ingestFiles(
           try {
             let patch = buildPatchFn!(p, hash, edgesByFile.get(p.filePath) ?? emptyEdges, previousHash);
             if (mapMode) patch = stripMapModeOps(patch);
+            // NEEDS HEAVY REVIEW: tag with workspace_id (see flushBatch).
+            if (patch?.source) patch.source.workspaceId = workspaceId;
             preparedPatches.push(makePreparedPatch(patch, j + 1, p.filePath));
           } catch (err) {
             parseErrors++;
@@ -877,7 +923,10 @@ export async function ingestFiles(
         buildPatchFn = patchBuilder.buildPatchWithResolution as Function;
 
         // Pre-filter minified files (main thread) then parse in parallel via worker pool.
-        const parseable: Array<{ filePath: string; source: string; hash: string; previousHash: string | undefined }> = [];
+        // filePath here is the workspace-relative path (what goes to parseFile
+        // and downstream into buildPatch → source_uri). absFilePath is the
+        // absolute path retained for any on-disk ops (reads already happened).
+        const parseable: Array<{ filePath: string; absFilePath: string; source: string; hash: string; previousHash: string | undefined }> = [];
         for (const { filePath, bytes, hash, previousHash } of changedPaths) {
           const sourceText = bytes.toString('utf-8');
           if (isLikelyMinifiedSource(sourceText)) {
@@ -887,7 +936,11 @@ export async function ingestFiles(
             if (debug) process.stderr.write(`\n  [skip minified-likely] ${filePath}\n`);
             continue;
           }
-          parseable.push({ filePath, source: sourceText, hash, previousHash });
+          // NEEDS HEAVY REVIEW: parseFile receives the workspace-relative path
+          // so every deterministic ID derived in buildPatch (node/edge/chunk/
+          // patch) hashes relative paths. This makes graph IDs portable across
+          // machines and removes backend dependence on host paths.
+          parseable.push({ filePath: toWorkspaceRelative(filePath), absFilePath: filePath, source: sourceText, hash, previousHash });
         }
 
         progressPhase   = 'Parsing';
@@ -913,13 +966,23 @@ export async function ingestFiles(
               if (texts[j] != null) sources.set(batch[j], texts[j]!);
             }
           }
-          globalIndex = (ingestion.buildGlobalResolutionIndex as Function)(filePaths, sources);
+          // NEEDS HEAVY REVIEW: global resolution index is now keyed on
+          // workspace-relative paths so that edge resolution matches the
+          // relative paths we pass into parseFile.
+          const relSources = new Map<string, string>();
+          for (const [abs, text] of sources) relSources.set(toWorkspaceRelative(abs), text);
+          const relFilePaths = filePaths.map(toWorkspaceRelative);
+          globalIndex = (ingestion.buildGlobalResolutionIndex as Function)(relFilePaths, relSources);
           sources.clear();
+          relSources.clear();
         }
 
         let pendingFlush: Promise<void> = Promise.resolve();
         for (let i = 0; i < parseable.length; i += PARSE_STREAM_CHUNK) {
           const chunk = parseable.slice(i, i + PARSE_STREAM_CHUNK);
+          // parseFile receives the workspace-relative path (f.filePath), so
+          // every deterministic ID in the resulting patch hashes relative
+          // paths. f.absFilePath is retained only for debug/error display.
           const parseResults = await Promise.all(
             chunk.map(f =>
               ensureParsePool().parse(f.filePath, f.source).then(r => { progressCurrent++; return r; }),
@@ -948,6 +1011,8 @@ export async function ingestFiles(
       // Build global resolution index from all repo file paths before the parse loop
       // so cross-batch imports resolve correctly even in streaming per-chunk mode.
       // Read all Go files in parallel to maximize I/O throughput.
+      // NEEDS HEAVY REVIEW: index keys are workspace-relative to match the
+      // relative paths we pass into parseFile below.
       {
         const goIndexStart = performance.now();
         const sources = new Map<string, string>();
@@ -957,10 +1022,11 @@ export async function ingestFiles(
           const batch = goFiles.slice(i, i + GO_READ_CONCURRENCY);
           const texts = await Promise.all(batch.map(fp => fs.promises.readFile(fp, 'utf-8').catch(() => null)));
           for (let j = 0; j < batch.length; j++) {
-            if (texts[j] != null) sources.set(batch[j], texts[j]!);
+            if (texts[j] != null) sources.set(toWorkspaceRelative(batch[j]), texts[j]!);
           }
         }
-        globalIndex = ingestion.buildGlobalResolutionIndex(filePaths, sources);
+        const relFilePaths = filePaths.map(toWorkspaceRelative);
+        globalIndex = ingestion.buildGlobalResolutionIndex(relFilePaths, sources);
         sources.clear();
         timings.goIndexMs = Math.round(performance.now() - goIndexStart);
       }
@@ -981,28 +1047,32 @@ export async function ingestFiles(
 
         // Read files asynchronously and dispatch to parse pool as each file completes.
         // This keeps workers busy while I/O is still in flight for other files.
-        const readAndDispatch = chunk.map(async (filePath, idx) => {
+        // NEEDS HEAVY REVIEW: fd.filePath is the workspace-relative path, which
+        // is what parseFile and all downstream ID derivations see. absFilePath
+        // is kept only so error messages still point at the file on disk.
+        const readAndDispatch = chunk.map(async (absFilePath, idx) => {
           try {
-            const st = await fs.promises.stat(filePath);
+            const st = await fs.promises.stat(absFilePath);
             if (st.size === 0) { filesSkipped++; return; }
             if (st.size > MAX_FILE_BYTES) { tooLarge++; return; }
-            const bytes = await fs.promises.readFile(filePath);
+            const bytes = await fs.promises.readFile(absFilePath);
             const hash = sha256(bytes);
-            if (!opts.force && knownHashes.get(filePath) === hash) { filesSkipped++; return; }
-            const previousHash = knownHashes.get(filePath);
+            if (!opts.force && knownHashes.get(absFilePath) === hash) { filesSkipped++; return; }
+            const previousHash = knownHashes.get(absFilePath);
             const sourceText = bytes.toString('utf-8');
             if (isLikelyMinifiedSource(sourceText)) {
               minifiedLikely++;
               filesSkipped++;
-              if (debug) process.stderr.write(`\n  [skip minified-likely] ${filePath}\n`);
+              if (debug) process.stderr.write(`\n  [skip minified-likely] ${absFilePath}\n`);
               return;
             }
-            const fd: NonNullable<FileData> = { filePath, source: sourceText, hash, previousHash: previousHash !== hash ? previousHash : undefined };
+            const relFilePath = toWorkspaceRelative(absFilePath);
+            const fd: NonNullable<FileData> = { filePath: relFilePath, source: sourceText, hash, previousHash: previousHash !== hash ? previousHash : undefined };
             fileData[idx] = fd;
             parsePromises[idx] = ensureParsePool().parse(fd.filePath, fd.source).then(r => { progressCurrent++; return r; });
           } catch (err) {
             parseErrors++;
-            process.stderr.write(`\n  [read error] ${filePath}: ${err}\n`);
+            process.stderr.write(`\n  [read error] ${absFilePath}: ${err}\n`);
           }
         });
         await Promise.all(readAndDispatch);
@@ -1142,9 +1212,34 @@ export async function ingestFiles(
 // Load existing hashes from the server for change detection
 // ---------------------------------------------------------------------------
 
-async function loadExistingHashes(client: IxClient, filePaths: string[], debug = false): Promise<Map<string, string>> {
+// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+//
+// The backend now stores workspace-relative source_uri values. The CLI still
+// tracks files internally by absolute path (needed for fs reads), so this
+// helper converts to relative before the wire call and maps the server's
+// response back onto the caller's absolute keys.
+async function loadExistingHashes(
+  client: IxClient,
+  filePaths: string[],
+  toRelative: (absPath: string) => string,
+  debug = false,
+): Promise<Map<string, string>> {
   try {
-    return await client.getSourceHashes(filePaths);
+    const relPaths: string[] = new Array(filePaths.length);
+    const relToAbs = new Map<string, string>();
+    for (let i = 0; i < filePaths.length; i++) {
+      const abs = filePaths[i];
+      const rel = toRelative(abs);
+      relPaths[i] = rel;
+      relToAbs.set(rel, abs);
+    }
+    const serverHashes = await client.getSourceHashes(relPaths);
+    const out = new Map<string, string>();
+    for (const [rel, hash] of serverHashes) {
+      const abs = relToAbs.get(rel);
+      if (abs !== undefined) out.set(abs, hash);
+    }
+    return out;
   } catch (err) {
     if (debug) process.stderr.write(`\n  [hash lookup failed] ${err}\n`);
     return new Map();

--- a/ix-cli/src/cli/commands/map.ts
+++ b/ix-cli/src/cli/commands/map.ts
@@ -5,6 +5,7 @@ import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { roundFloat } from "../format.js";
 import { bootstrap } from "../bootstrap.js";
+import { formatFetchError } from "../errors.js";
 import { ingestFiles } from "./ingest.js";
 
 export interface MapRegion {
@@ -159,7 +160,7 @@ Examples:
           mapMode: true,
         });
       } catch (err: any) {
-        console.error(chalk.red("Error:"), err.message ?? err);
+        console.error(chalk.red("Error:"), formatFetchError(err));
         process.exitCode = 1;
         return;
       }
@@ -183,7 +184,7 @@ Examples:
         result = await client.map({ full: opts.full }) as MapResult;
       } catch (err: any) {
         if (mapInterval) { clearInterval(mapInterval); process.stderr.write('\r' + ' '.repeat(60) + '\r'); }
-        console.error(chalk.red("Error:"), err.message ?? err);
+        console.error(chalk.red("Error:"), formatFetchError(err));
         process.exitCode = 1;
         return;
       }

--- a/ix-cli/src/cli/commands/read.ts
+++ b/ix-cli/src/cli/commands/read.ts
@@ -1,9 +1,10 @@
+// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Command } from "commander";
 import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
-import { getEndpoint, resolveWorkspaceRoot } from "../config.js";
+import { absoluteFromSourceUri, getEndpoint, resolveWorkspaceRoot } from "../config.js";
 import { resolveEntityFull } from "../resolve.js";
 import { stderr } from "../stderr.js";
 import { isFileStale } from "../stale.js";
@@ -181,19 +182,23 @@ Examples:
       const symbolResult = await trySymbolMatch(client, rawTarget, { kind: opts.kind, path: opts.path, pick: opts.pick ? parseInt(opts.pick, 10) : undefined });
       if (symbolResult.type === "resolved") {
         const { node, sourceUri } = symbolResult;
-        const stale = sourceUri ? await checkStale(client, sourceUri) : false;
+        // NEEDS HEAVY REVIEW: sourceUri coming from the graph is now
+        // workspace-relative (client-agnostic backend). Resolve it against the
+        // active workspace root before any fs call.
+        const absSourceUri = sourceUri ? absoluteFromSourceUri(sourceUri, opts.root) : null;
+        const stale = absSourceUri ? await checkStale(client, absSourceUri) : false;
 
         // If the source file exists, extract the symbol's lines
-        if (sourceUri && fs.existsSync(sourceUri)) {
+        if (absSourceUri && fs.existsSync(absSourceUri)) {
           const lineStart = node.attrs?.lineStart ?? node.attrs?.line_start ?? 1;
           const lineEnd = node.attrs?.lineEnd ?? node.attrs?.line_end;
-          const fileContent = fs.readFileSync(sourceUri, "utf-8");
+          const fileContent = fs.readFileSync(absSourceUri, "utf-8");
           const allLines = fileContent.split("\n");
           const effectiveEnd = lineEnd ?? allLines.length;
           const content = allLines.slice(lineStart - 1, effectiveEnd).join("\n");
           const result: ReadResult = {
             targetType: "symbol",
-            path: sourceUri,
+            path: absSourceUri,
             lineStart,
             lineEnd: effectiveEnd,
             content,
@@ -211,7 +216,7 @@ Examples:
           const lines = String(attrContent).split("\n");
           const result: ReadResult = {
             targetType: "symbol",
-            path: sourceUri ?? "(no source file)",
+            path: absSourceUri ?? sourceUri ?? "(no source file)",
             lineStart: 1,
             lineEnd: lines.length,
             content: String(attrContent),
@@ -223,7 +228,7 @@ Examples:
           return;
         }
 
-        stderr(`Source file not found for symbol: ${node.name} (${sourceUri ?? "no provenance"})`);
+        stderr(`Source file not found for symbol: ${node.name} (${absSourceUri ?? sourceUri ?? "no provenance"})`);
         return;
       }
 

--- a/ix-cli/src/cli/commands/read.ts
+++ b/ix-cli/src/cli/commands/read.ts
@@ -1,4 +1,3 @@
-// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Command } from "commander";
@@ -182,9 +181,9 @@ Examples:
       const symbolResult = await trySymbolMatch(client, rawTarget, { kind: opts.kind, path: opts.path, pick: opts.pick ? parseInt(opts.pick, 10) : undefined });
       if (symbolResult.type === "resolved") {
         const { node, sourceUri } = symbolResult;
-        // NEEDS HEAVY REVIEW: sourceUri coming from the graph is now
-        // workspace-relative (client-agnostic backend). Resolve it against the
-        // active workspace root before any fs call.
+        // sourceUri coming from the graph is workspace-relative under the
+        // client-agnostic backend. Resolve it against the active workspace
+        // root before any fs call.
         const absSourceUri = sourceUri ? absoluteFromSourceUri(sourceUri, opts.root) : null;
         const stale = absSourceUri ? await checkStale(client, absSourceUri) : false;
 

--- a/ix-cli/src/cli/commands/view.ts
+++ b/ix-cli/src/cli/commands/view.ts
@@ -13,13 +13,8 @@ import { fileURLToPath } from "url";
 import { createConnection } from "net";
 
 const IX_HOME = process.env.IX_HOME || join(homedir(), ".ix");
-const STATE_FILE = join(IX_HOME, "compass.json");
+const PID_FILE = join(IX_HOME, "compass.pid");
 const BACKEND_URL = "http://localhost:8090";
-
-interface CompassState {
-  pid: number;
-  port: number;
-}
 
 /** Resolve the compass dist directory — installed path first, then dev fallback. */
 function findCompassDist(): string | null {
@@ -35,23 +30,17 @@ function findCompassDist(): string | null {
   return null;
 }
 
-/** Read state from file and check if the process is alive. */
-function readAliveState(): CompassState | null {
-  if (!existsSync(STATE_FILE)) return null;
+/** Read PID from file and check if the process is alive. */
+function readAlivePid(): number | null {
+  if (!existsSync(PID_FILE)) return null;
+  const pid = parseInt(readFileSync(PID_FILE, "utf-8").trim(), 10);
+  if (isNaN(pid)) return null;
   try {
-    const state: CompassState = JSON.parse(
-      readFileSync(STATE_FILE, "utf-8").trim(),
-    );
-    if (!state.pid || !state.port) return null;
-    process.kill(state.pid, 0); // signal 0 = existence check
-    return state;
+    process.kill(pid, 0); // signal 0 = existence check
+    return pid;
   } catch {
-    // Stale or corrupt state file
-    try {
-      unlinkSync(STATE_FILE);
-    } catch {
-      /* ignore */
-    }
+    // Stale PID file
+    try { unlinkSync(PID_FILE); } catch { /* ignore */ }
     return null;
   }
 }
@@ -64,9 +53,7 @@ function isPortInUse(port: number): Promise<boolean> {
       conn.end();
       resolve(true);
     });
-    conn.on("error", () => {
-      resolve(false);
-    });
+    conn.on("error", () => resolve(false));
   });
 }
 
@@ -149,13 +136,8 @@ const server = http.createServer((req, res) => {
   });
 });
 
-server.on("error", (err) => {
-  process.exit(1);
-});
-
 server.listen(PORT, () => {
-  // Signal readiness to parent via stdout
-  process.stdout.write("READY");
+  // Server ready — parent already detached
 });
 `;
 }
@@ -178,26 +160,24 @@ function openBrowser(url: string): void {
 export function registerViewCommand(program: Command): void {
   const view = program
     .command("view")
-    .description("Open the Ix System Compass visualizer");
+    .description("Open the Ix System Compass visualizer")
+    .option("-p, --port <port>", "Port to serve on", "8080");
 
   view
     .command("start", { isDefault: true })
     .description("Start the visualizer (default)")
-    .option("-p, --port <port>", "Port to serve on", "8080")
     .option("--no-open", "Don't auto-open browser")
     .action(async (opts) => {
-      const port = parseInt(opts.port, 10);
+      const port = parseInt(view.opts().port, 10);
       if (isNaN(port) || port < 1 || port > 65535) {
         console.error("[error] Invalid port number.");
         process.exit(1);
       }
 
-      const existing = readAliveState();
+      const existing = readAlivePid();
       if (existing) {
-        console.log(
-          `[ok] Visualizer is already running (PID ${existing.pid})`,
-        );
-        console.log(`  http://localhost:${existing.port}`);
+        console.log(`[ok] Visualizer is already running (PID ${existing})`);
+        console.log(`  http://localhost:${port}`);
         return;
       }
 
@@ -225,62 +205,21 @@ export function registerViewCommand(program: Command): void {
       const scriptPath = join(scriptDir, "compass-server.js");
       writeFileSync(scriptPath, serverScript(distDir, port));
 
-      // Spawn detached process — capture stdout for readiness signal
+      // Spawn detached process
       const child = spawn("node", [scriptPath], {
         detached: true,
-        stdio: ["ignore", "pipe", "pipe"],
+        stdio: "ignore",
       });
+      child.unref();
 
       if (!child.pid) {
         console.error("[error] Failed to start visualizer server.");
         process.exit(1);
       }
 
-      // Wait for the server to signal readiness or fail
-      const ready = await new Promise<boolean>((resolve) => {
-        const timeout = setTimeout(() => {
-          resolve(false);
-        }, 5000);
-
-        child.stdout!.on("data", (data: Buffer) => {
-          if (data.toString().includes("READY")) {
-            clearTimeout(timeout);
-            resolve(true);
-          }
-        });
-
-        child.stderr!.on("data", () => {
-          // Server wrote to stderr — likely an error
-        });
-
-        child.on("exit", () => {
-          clearTimeout(timeout);
-          resolve(false);
-        });
-      });
-
-      if (!ready) {
-        console.error(`[error] Visualizer failed to start on port ${port}.`);
-        console.error(`  The port may be in use. Use -p <port> to specify a different port.`);
-        try {
-          child.kill();
-        } catch {
-          /* ignore */
-        }
-        process.exit(1);
-      }
-
-      // Detach stdio so the parent can exit
-      child.stdout!.destroy();
-      child.stderr!.destroy();
-      child.unref();
-
-      // Save state (PID + port)
-      mkdirSync(dirname(STATE_FILE), { recursive: true });
-      writeFileSync(
-        STATE_FILE,
-        JSON.stringify({ pid: child.pid, port } as CompassState),
-      );
+      // Save PID
+      mkdirSync(dirname(PID_FILE), { recursive: true });
+      writeFileSync(PID_FILE, String(child.pid));
 
       const url = `http://localhost:${port}`;
       console.log(`[ok] Visualizer started (PID ${child.pid})`);
@@ -295,34 +234,29 @@ export function registerViewCommand(program: Command): void {
     .command("stop")
     .description("Stop the visualizer")
     .action(() => {
-      const state = readAliveState();
-      if (!state) {
+      const pid = readAlivePid();
+      if (!pid) {
         console.log("[ok] Visualizer is not running.");
         return;
       }
 
       try {
-        process.kill(state.pid, "SIGTERM");
+        process.kill(pid, "SIGTERM");
       } catch {
         // Already dead
       }
 
-      try {
-        unlinkSync(STATE_FILE);
-      } catch {
-        /* ignore */
-      }
-      console.log(`[ok] Visualizer stopped (PID ${state.pid})`);
+      try { unlinkSync(PID_FILE); } catch { /* ignore */ }
+      console.log(`[ok] Visualizer stopped (PID ${pid})`);
     });
 
   view
     .command("status")
     .description("Show visualizer status")
     .action(() => {
-      const state = readAliveState();
-      if (state) {
-        console.log(`[ok] Visualizer is running (PID ${state.pid})`);
-        console.log(`  http://localhost:${state.port}`);
+      const pid = readAlivePid();
+      if (pid) {
+        console.log(`[ok] Visualizer is running (PID ${pid})`);
       } else {
         console.log("[--] Visualizer is not running.");
         console.log("  Run 'ix view' to start it.");

--- a/ix-cli/src/cli/commands/view.ts
+++ b/ix-cli/src/cli/commands/view.ts
@@ -10,10 +10,16 @@ import {
 import { join, dirname } from "path";
 import { homedir, platform } from "os";
 import { fileURLToPath } from "url";
+import { createConnection } from "net";
 
 const IX_HOME = process.env.IX_HOME || join(homedir(), ".ix");
-const PID_FILE = join(IX_HOME, "compass.pid");
+const STATE_FILE = join(IX_HOME, "compass.json");
 const BACKEND_URL = "http://localhost:8090";
+
+interface CompassState {
+  pid: number;
+  port: number;
+}
 
 /** Resolve the compass dist directory — installed path first, then dev fallback. */
 function findCompassDist(): string | null {
@@ -29,19 +35,39 @@ function findCompassDist(): string | null {
   return null;
 }
 
-/** Read PID from file and check if the process is alive. */
-function readAlivePid(): number | null {
-  if (!existsSync(PID_FILE)) return null;
-  const pid = parseInt(readFileSync(PID_FILE, "utf-8").trim(), 10);
-  if (isNaN(pid)) return null;
+/** Read state from file and check if the process is alive. */
+function readAliveState(): CompassState | null {
+  if (!existsSync(STATE_FILE)) return null;
   try {
-    process.kill(pid, 0); // signal 0 = existence check
-    return pid;
+    const state: CompassState = JSON.parse(
+      readFileSync(STATE_FILE, "utf-8").trim(),
+    );
+    if (!state.pid || !state.port) return null;
+    process.kill(state.pid, 0); // signal 0 = existence check
+    return state;
   } catch {
-    // Stale PID file
-    try { unlinkSync(PID_FILE); } catch { /* ignore */ }
+    // Stale or corrupt state file
+    try {
+      unlinkSync(STATE_FILE);
+    } catch {
+      /* ignore */
+    }
     return null;
   }
+}
+
+/** Check whether a port is already in use. */
+function isPortInUse(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const conn = createConnection({ port, host: "127.0.0.1" });
+    conn.on("connect", () => {
+      conn.end();
+      resolve(true);
+    });
+    conn.on("error", () => {
+      resolve(false);
+    });
+  });
 }
 
 /** Generate the inline server script that serves static files + proxies /v1. */
@@ -123,8 +149,13 @@ const server = http.createServer((req, res) => {
   });
 });
 
+server.on("error", (err) => {
+  process.exit(1);
+});
+
 server.listen(PORT, () => {
-  // Server ready — parent already detached
+  // Signal readiness to parent via stdout
+  process.stdout.write("READY");
 });
 `;
 }
@@ -152,20 +183,29 @@ export function registerViewCommand(program: Command): void {
   view
     .command("start", { isDefault: true })
     .description("Start the visualizer (default)")
-    .option("--port <port>", "Port to serve on", "8080")
+    .option("-p, --port <port>", "Port to serve on", "8080")
     .option("--no-open", "Don't auto-open browser")
-    .action((opts) => {
+    .action(async (opts) => {
       const port = parseInt(opts.port, 10);
       if (isNaN(port) || port < 1 || port > 65535) {
         console.error("[error] Invalid port number.");
         process.exit(1);
       }
 
-      const existing = readAlivePid();
+      const existing = readAliveState();
       if (existing) {
-        console.log(`[ok] Visualizer is already running (PID ${existing})`);
-        console.log(`  http://localhost:${port}`);
+        console.log(
+          `[ok] Visualizer is already running (PID ${existing.pid})`,
+        );
+        console.log(`  http://localhost:${existing.port}`);
         return;
+      }
+
+      // Check if the port is already in use before attempting to start
+      if (await isPortInUse(port)) {
+        console.error(`[error] Port ${port} is already in use.`);
+        console.error(`  Use -p <port> to specify a different port.`);
+        process.exit(1);
       }
 
       const distDir = findCompassDist();
@@ -185,21 +225,62 @@ export function registerViewCommand(program: Command): void {
       const scriptPath = join(scriptDir, "compass-server.js");
       writeFileSync(scriptPath, serverScript(distDir, port));
 
-      // Spawn detached process
+      // Spawn detached process — capture stdout for readiness signal
       const child = spawn("node", [scriptPath], {
         detached: true,
-        stdio: "ignore",
+        stdio: ["ignore", "pipe", "pipe"],
       });
-      child.unref();
 
       if (!child.pid) {
         console.error("[error] Failed to start visualizer server.");
         process.exit(1);
       }
 
-      // Save PID
-      mkdirSync(dirname(PID_FILE), { recursive: true });
-      writeFileSync(PID_FILE, String(child.pid));
+      // Wait for the server to signal readiness or fail
+      const ready = await new Promise<boolean>((resolve) => {
+        const timeout = setTimeout(() => {
+          resolve(false);
+        }, 5000);
+
+        child.stdout!.on("data", (data: Buffer) => {
+          if (data.toString().includes("READY")) {
+            clearTimeout(timeout);
+            resolve(true);
+          }
+        });
+
+        child.stderr!.on("data", () => {
+          // Server wrote to stderr — likely an error
+        });
+
+        child.on("exit", () => {
+          clearTimeout(timeout);
+          resolve(false);
+        });
+      });
+
+      if (!ready) {
+        console.error(`[error] Visualizer failed to start on port ${port}.`);
+        console.error(`  The port may be in use. Use -p <port> to specify a different port.`);
+        try {
+          child.kill();
+        } catch {
+          /* ignore */
+        }
+        process.exit(1);
+      }
+
+      // Detach stdio so the parent can exit
+      child.stdout!.destroy();
+      child.stderr!.destroy();
+      child.unref();
+
+      // Save state (PID + port)
+      mkdirSync(dirname(STATE_FILE), { recursive: true });
+      writeFileSync(
+        STATE_FILE,
+        JSON.stringify({ pid: child.pid, port } as CompassState),
+      );
 
       const url = `http://localhost:${port}`;
       console.log(`[ok] Visualizer started (PID ${child.pid})`);
@@ -214,29 +295,34 @@ export function registerViewCommand(program: Command): void {
     .command("stop")
     .description("Stop the visualizer")
     .action(() => {
-      const pid = readAlivePid();
-      if (!pid) {
+      const state = readAliveState();
+      if (!state) {
         console.log("[ok] Visualizer is not running.");
         return;
       }
 
       try {
-        process.kill(pid, "SIGTERM");
+        process.kill(state.pid, "SIGTERM");
       } catch {
         // Already dead
       }
 
-      try { unlinkSync(PID_FILE); } catch { /* ignore */ }
-      console.log(`[ok] Visualizer stopped (PID ${pid})`);
+      try {
+        unlinkSync(STATE_FILE);
+      } catch {
+        /* ignore */
+      }
+      console.log(`[ok] Visualizer stopped (PID ${state.pid})`);
     });
 
   view
     .command("status")
     .description("Show visualizer status")
     .action(() => {
-      const pid = readAlivePid();
-      if (pid) {
-        console.log(`[ok] Visualizer is running (PID ${pid})`);
+      const state = readAliveState();
+      if (state) {
+        console.log(`[ok] Visualizer is running (PID ${state.pid})`);
+        console.log(`  http://localhost:${state.port}`);
       } else {
         console.log("[--] Visualizer is not running.");
         console.log("  Run 'ix view' to start it.");

--- a/ix-cli/src/cli/config.ts
+++ b/ix-cli/src/cli/config.ts
@@ -74,6 +74,23 @@ export function getActiveWorkspaceRoot(): string | undefined {
   return getDefaultWorkspace()?.root_path;
 }
 
+// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+//
+// Resolve a source_uri from the graph (which is now a workspace-relative
+// POSIX path under the client-agnostic backend design) back to an absolute
+// host filesystem path. If the input is already absolute (e.g. legacy graphs
+// or external absolute paths), it is returned as-is. Used by any command that
+// needs to actually open a file off disk (ix read, ix explain, ...).
+export function absoluteFromSourceUri(sourceUri: string, explicitRoot?: string): string {
+  if (!sourceUri) return sourceUri;
+  // Treat both POSIX abs (`/`) and Windows abs (`C:\`) as already resolved.
+  if (sourceUri.startsWith("/") || /^[A-Za-z]:[\\/]/.test(sourceUri)) return sourceUri;
+  const root = resolveWorkspaceRoot(explicitRoot);
+  // POSIX-normalize the relative segment before joining.
+  const normalized = sourceUri.replace(/\\/g, "/");
+  return require("node:path").resolve(root, normalized);
+}
+
 export function resolveWorkspaceRoot(explicitRoot?: string): string {
   // 1. Explicit --root
   if (explicitRoot) return explicitRoot;

--- a/ix-cli/src/cli/config.ts
+++ b/ix-cli/src/cli/config.ts
@@ -74,8 +74,6 @@ export function getActiveWorkspaceRoot(): string | undefined {
   return getDefaultWorkspace()?.root_path;
 }
 
-// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
-//
 // Resolve a source_uri from the graph (which is now a workspace-relative
 // POSIX path under the client-agnostic backend design) back to an absolute
 // host filesystem path. If the input is already absolute (e.g. legacy graphs

--- a/ix-cli/src/cli/errors.ts
+++ b/ix-cli/src/cli/errors.ts
@@ -70,6 +70,39 @@ export class CliResolutionError extends Error {
   }
 }
 
+/**
+ * Format an error for display, unwrapping fetch `TypeError: fetch failed`
+ * to expose the underlying transport cause (e.g. ECONNRESET, UND_ERR_SOCKET).
+ *
+ * Node's built-in fetch (undici) throws `TypeError('fetch failed')` on any
+ * transport-level failure and stashes the real error in `err.cause`. Without
+ * this unwrap, users see a bare "fetch failed" with no actionable detail —
+ * see the Node 18 EOL / undici 5.x transport-drop bug report.
+ */
+export function formatFetchError(err: unknown): string {
+  if (err === null || err === undefined) return String(err);
+  const e = err as { message?: unknown; cause?: unknown };
+  const base = typeof e.message === "string" && e.message.length > 0
+    ? e.message
+    : String(err);
+
+  if (base.toLowerCase().includes("fetch failed") && e.cause) {
+    const cause = e.cause as { code?: unknown; message?: unknown };
+    const parts: string[] = [];
+    if (typeof cause.code === "string" && cause.code.length > 0) {
+      parts.push(cause.code);
+    }
+    if (typeof cause.message === "string" && cause.message.length > 0) {
+      parts.push(cause.message);
+    } else if (parts.length === 0) {
+      parts.push(String(e.cause));
+    }
+    return `${base} (${parts.join(": ")})`;
+  }
+
+  return base;
+}
+
 export function renderCliError(err: unknown, debug = false): void {
   if (err instanceof CliUsageError || err instanceof CliResolutionError) {
     process.stderr.write(chalk.red(`Error: ${err.message}\n`));

--- a/ix-cli/src/cli/format.ts
+++ b/ix-cli/src/cli/format.ts
@@ -5,7 +5,6 @@ export type ResultSource = "graph" | "text" | "graph+text" | "heuristic";
 
 // ── JSON optimization helpers ──────────────────────────────────────────────
 
-// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 /**
  * Strip the cwd prefix from absolute paths to save tokens in JSON output.
  *

--- a/ix-cli/src/cli/format.ts
+++ b/ix-cli/src/cli/format.ts
@@ -5,9 +5,18 @@ export type ResultSource = "graph" | "text" | "graph+text" | "heuristic";
 
 // ── JSON optimization helpers ──────────────────────────────────────────────
 
-/** Strip the cwd prefix from absolute paths to save tokens in JSON output. */
+// NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+/**
+ * Strip the cwd prefix from absolute paths to save tokens in JSON output.
+ *
+ * Under the client-agnostic backend design, source_uri values are already
+ * workspace-relative. For those we return the input unchanged. Legacy absolute
+ * paths (e.g. from older graphs) are still handled the old way.
+ */
 export function relativePath(absPath: string | undefined | null): string | undefined {
   if (!absPath) return undefined;
+  // Already relative (workspace-relative path from post-migration graphs).
+  if (!absPath.startsWith("/") && !/^[A-Za-z]:[\\/]/.test(absPath)) return absPath;
   const cwd = process.cwd();
   if (absPath.startsWith(cwd + "/")) return absPath.slice(cwd.length + 1);
   // Also handle /Users/.../project/ style without trailing slash match

--- a/ix-cli/src/cli/main.ts
+++ b/ix-cli/src/cli/main.ts
@@ -9,6 +9,22 @@ import { readFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
+// Runtime Node version guard. Runs before any command work so users on an
+// unsupported Node get an actionable message instead of a cryptic "fetch
+// failed" deep inside undici.
+const MIN_NODE_MAJOR = 20;
+{
+  const current = process.versions.node;
+  const major = parseInt(current.split(".")[0] ?? "0", 10);
+  if (!Number.isFinite(major) || major < MIN_NODE_MAJOR) {
+    process.stderr.write(
+      `Ix requires Node.js ${MIN_NODE_MAJOR} or newer. You are running v${current}.\n` +
+      `Install a supported version from https://nodejs.org/ and re-run.\n`
+    );
+    process.exit(1);
+  }
+}
+
 let cliVersion = "0.0.0";
 try {
   const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/ix-cli/src/client/types.ts
+++ b/ix-cli/src/client/types.ts
@@ -150,13 +150,27 @@ export interface IngestResult {
 
 export interface HealthResponse {
   status: string;
+  // NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+  // Backend on-disk graph format version. When a client's expected version
+  // differs from this, it forces a clean re-ingest (e.g. absolute→relative
+  // source_uri migration changes every node ID).
+  schema_version?: number;
 }
 
 export interface PatchSource {
+  // uri is the provenance source URI. In the client-agnostic backend design it
+  // is a workspace-relative path (POSIX separators), not an absolute host path.
+  // The backend treats this as an opaque string key for joins/tombstones.
   uri: string;
   sourceHash?: string;
   extractor: string;
   sourceType: string;
+  // NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+  // workspaceId uniquely identifies the workspace whose files produced this
+  // patch. Derived client-side as SHA-256 of the workspace root's absolute
+  // path. Backend stores it as an opaque attribute for future multi-workspace
+  // disambiguation; it does not interpret the value.
+  workspaceId?: string;
 }
 
 export interface PatchOp {

--- a/ix-cli/src/client/types.ts
+++ b/ix-cli/src/client/types.ts
@@ -150,7 +150,6 @@ export interface IngestResult {
 
 export interface HealthResponse {
   status: string;
-  // NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
   // Backend on-disk graph format version. When a client's expected version
   // differs from this, it forces a clean re-ingest (e.g. absolute→relative
   // source_uri migration changes every node ID).
@@ -165,7 +164,6 @@ export interface PatchSource {
   sourceHash?: string;
   extractor: string;
   sourceType: string;
-  // NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
   // workspaceId uniquely identifies the workspace whose files produced this
   // patch. Derived client-side as SHA-256 of the workspace root's absolute
   // path. Backend stores it as an opaque attribute for future multi-workspace

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,11 +29,11 @@ git>=2
 #  STEP 1: Node.js (auto-installed/upgraded if missing or too old)
 # ============================================================================
 
-# Node.js >= 18 (installer targets Node 22 LTS)
+# Node.js >= 20 (installer targets Node 22 LTS)
 #   macOS:   brew install node OR official .pkg installer
 #   Linux:   NodeSource apt/dnf/yum repo (setup_22.x) OR apk
 #   Windows: manual from https://nodejs.org/
-node>=18
+node>=20
 npm>=8  # bundled with Node.js
 
 # ============================================================================

--- a/scripts/backend.sh
+++ b/scripts/backend.sh
@@ -21,11 +21,6 @@ set -euo pipefail
 IX_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$IX_DIR"
 
-# The HOME bind mount was removed from docker-compose.standalone.yml because
-# the backend is now client-agnostic and never reads host files. The
-# IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports that fed that bind mount
-# are therefore no longer needed. On Windows/MINGW we still need the dc()
-# helper so docker compose can locate the compose file from a MINGW shell.
 if [[ "$(uname -s)" =~ MINGW|MSYS|CYGWIN ]]; then
   dc() {
     MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' \

--- a/scripts/backend.sh
+++ b/scripts/backend.sh
@@ -21,23 +21,19 @@ set -euo pipefail
 IX_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$IX_DIR"
 
-# On Windows/MINGW, Docker Compose (a Windows binary) can mix POSIX and Windows
-# home paths if we rely on nested interpolation defaults in the compose file.
-# Export both sides of the bind mount explicitly instead:
-#   IX_HOST_MOUNT_ROOT      → host bind source  (cygpath -m: C:/Users/...)
-#   IX_CONTAINER_MOUNT_ROOT → container target  ($HOME: /c/Users/... or /Users/...)
-# The dc() helper passes -f with a Windows-format path so docker compose can
-# locate its file regardless of how it resolves the CWD from a MINGW shell.
+# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+#
+# The HOME bind mount was removed from docker-compose.standalone.yml because
+# the backend is now client-agnostic and never reads host files. The
+# IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports that fed that bind mount
+# are therefore no longer needed. On Windows/MINGW we still need the dc()
+# helper so docker compose can locate the compose file from a MINGW shell.
 if [[ "$(uname -s)" =~ MINGW|MSYS|CYGWIN ]]; then
-  export IX_HOST_MOUNT_ROOT="$(cygpath -m "$HOME")"
-  export IX_CONTAINER_MOUNT_ROOT="${HOME}"
   dc() {
     MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' \
       docker compose -f "$(cygpath -m "$IX_DIR/$COMPOSE_FILE")" "$@"
   }
 else
-  export IX_HOST_MOUNT_ROOT="${HOME}"
-  export IX_CONTAINER_MOUNT_ROOT="${HOME}"
   dc() { docker compose -f "$COMPOSE_FILE" "$@"; }
 fi
 

--- a/scripts/backend.sh
+++ b/scripts/backend.sh
@@ -21,8 +21,6 @@ set -euo pipefail
 IX_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$IX_DIR"
 
-# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
-#
 # The HOME bind mount was removed from docker-compose.standalone.yml because
 # the backend is now client-agnostic and never reads host files. The
 # IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports that fed that bind mount

--- a/scripts/build-cli.sh
+++ b/scripts/build-cli.sh
@@ -20,13 +20,13 @@ CLI_DIR="$IX_DIR/ix-cli"
 check_prerequisites() {
   if ! command -v node &> /dev/null; then
     echo "Error: Node.js is not installed."
-    echo "  Install: https://nodejs.org/ (v18+ required)"
+    echo "  Install: https://nodejs.org/ (v20+ required)"
     exit 1
   fi
 
   NODE_VERSION=$(node -v | sed 's/v//' | cut -d. -f1)
-  if [ "$NODE_VERSION" -lt 18 ]; then
-    echo "Error: Node.js 18+ required (found $(node -v))"
+  if [ "$NODE_VERSION" -lt 20 ]; then
+    echo "Error: Node.js 20+ required (found $(node -v))"
     exit 1
   fi
 

--- a/scripts/dev/setup.sh
+++ b/scripts/dev/setup.sh
@@ -129,7 +129,7 @@ if [ "${#MISSING_DEPS[@]}" -gt 0 ]; then
   for dep in "${MISSING_DEPS[@]}"; do
     case "$dep" in
       docker) echo "    docker:  https://docs.docker.com/get-docker/" ;;
-      node)   echo "    node:    https://nodejs.org (v18+ required)" ;;
+      node)   echo "    node:    https://nodejs.org (v20+ required)" ;;
     esac
   done
   echo ""

--- a/scripts/dev/shutdown.sh
+++ b/scripts/dev/shutdown.sh
@@ -20,16 +20,16 @@ cd "$IX_DIR"
 
 COMPOSE_FILE="docker-compose.standalone.yml"
 
+# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+# IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports removed: the HOME bind
+# mount is gone from docker-compose.standalone.yml because the backend is now
+# client-agnostic and never reads host files.
 if [[ "$(uname -s)" =~ MINGW|MSYS|CYGWIN ]]; then
-  export IX_HOST_MOUNT_ROOT="$(cygpath -m "$HOME")"
-  export IX_CONTAINER_MOUNT_ROOT="${HOME}"
   dc() {
     MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' \
       docker compose -f "$(cygpath -m "$IX_DIR/$COMPOSE_FILE")" "$@"
   }
 else
-  export IX_HOST_MOUNT_ROOT="${HOME}"
-  export IX_CONTAINER_MOUNT_ROOT="${HOME}"
   dc() { docker compose -f "$IX_DIR/$COMPOSE_FILE" "$@"; }
 fi
 

--- a/scripts/dev/shutdown.sh
+++ b/scripts/dev/shutdown.sh
@@ -20,9 +20,6 @@ cd "$IX_DIR"
 
 COMPOSE_FILE="docker-compose.standalone.yml"
 
-# IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports removed: the HOME bind
-# mount is gone from docker-compose.standalone.yml because the backend is now
-# client-agnostic and never reads host files.
 if [[ "$(uname -s)" =~ MINGW|MSYS|CYGWIN ]]; then
   dc() {
     MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' \

--- a/scripts/dev/shutdown.sh
+++ b/scripts/dev/shutdown.sh
@@ -20,7 +20,6 @@ cd "$IX_DIR"
 
 COMPOSE_FILE="docker-compose.standalone.yml"
 
-# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 # IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports removed: the HOME bind
 # mount is gone from docker-compose.standalone.yml because the backend is now
 # client-agnostic and never reads host files.

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -27,7 +27,7 @@ $IxBin = "$IxHome\bin"
 $ComposeDir = "$IxHome\backend"
 $HealthUrl = "http://localhost:8090/v1/health"
 $ArangoUrl = "http://localhost:8529/_api/version"
-$NodeMinMajor = 18
+$NodeMinMajor = 20
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -28,7 +28,7 @@ COMPOSE_DIR="$IX_HOME/backend"
 HEALTH_URL="http://localhost:8090/v1/health"
 ARANGO_URL="http://localhost:8529/_api/version"
 
-NODE_MIN_MAJOR=18
+NODE_MIN_MAJOR=20
 
 # -- Windows / POSIX docker compose wrapper --
 

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -32,10 +32,6 @@ NODE_MIN_MAJOR=20
 
 # -- Windows / POSIX docker compose wrapper --
 #
-# IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports removed: the HOME bind
-# mount is gone from docker-compose.standalone.yml because the backend is now
-# client-agnostic and never reads host files.
-
 case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*)
     dc() { MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' docker compose "$@"; }

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -32,7 +32,6 @@ NODE_MIN_MAJOR=20
 
 # -- Windows / POSIX docker compose wrapper --
 #
-# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
 # IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports removed: the HOME bind
 # mount is gone from docker-compose.standalone.yml because the backend is now
 # client-agnostic and never reads host files.

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -31,17 +31,17 @@ ARANGO_URL="http://localhost:8529/_api/version"
 NODE_MIN_MAJOR=20
 
 # -- Windows / POSIX docker compose wrapper --
+#
+# NEEDS HEAVY REVIEW: "needs heavy review as didnt verify this change for additional bug for all of this, this could be completely wrong"
+# IX_HOST_MOUNT_ROOT / IX_CONTAINER_MOUNT_ROOT exports removed: the HOME bind
+# mount is gone from docker-compose.standalone.yml because the backend is now
+# client-agnostic and never reads host files.
 
 case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*)
-    IX_HOST_MOUNT_ROOT="$(cygpath -m "$HOME")"
-    export IX_HOST_MOUNT_ROOT
-    export IX_CONTAINER_MOUNT_ROOT="${HOME}"
     dc() { MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' docker compose "$@"; }
     ;;
   *)
-    export IX_HOST_MOUNT_ROOT="${HOME}"
-    export IX_CONTAINER_MOUNT_ROOT="${HOME}"
     dc() { docker compose "$@"; }
     ;;
 esac


### PR DESCRIPTION
## Summary
Clean integration of Riley's changes only — no Tanner/Jira code.

- **#186** — feat: view port option
- **#188** — fix: node version guard and fetch error unwrap
- **#191** — fix: dereference symlinks in CLI tarballs
- **#189** (partial) — feat: client-agnostic backend (Riley's 2 commits only, no Jira/embedding/branch support

## Test plan
- [ ] Fresh install: 
╔══════════════════════════════════════════╗
║       Ix — Install                ║
╚══════════════════════════════════════════╝

  Version:  0.5.1
  Platform: darwin-arm64

-- 0. System prerequisites (git, Homebrew) --
  [32m[ok][0m Homebrew is available
  [32m[ok][0m git is available
  [32m[ok][0m ripgrep is available

-- 1. Node.js (runtime) --
  [32m[ok][0m Node.js v20.0.0 is installed (>= 18 required)

-- 2. Docker + Docker Compose --
  [32m[ok][0m Docker is ready

-- 3. Backend (ArangoDB + Memory Layer) --
  [32m[ok][0m Backend is already running and healthy
  Memory Layer: http://localhost:8090
  ArangoDB:     http://localhost:8529

-- 4. ix CLI --
  Downloading ix CLI v0.5.1 for darwin-arm64...
  URL: https://github.com/ix-infrastructure/Ix/releases/download/v0.5.1/ix-0.5.1-darwin-arm64.tar.gz
  [32m[ok][0m Extracted CLI
  [32m[ok][0m Installed: /usr/local/bin/ix

╔══════════════════════════════════════════╗
║       Ix is ready!                ║
╚══════════════════════════════════════════╝

  Backend:  http://localhost:8090
  ArangoDB: http://localhost:8529

  [32m[ok][0m ix CLI v0.5.1 is working

  Connect a project:
    cd ~/my-project && ix map .

  To uninstall:
    curl -fsSL https://ix-infra.com/uninstall.sh | sh
- [ ] 
Status
  Ix Memory:        ok
  Endpoint:         http://localhost:8090
  Revision:         57
  Last ingest:      2d ago
  Warning  23 file(s) changed since last ingest:
    .gitignore
    README.md
    docker-compose.standalone.yml
    package-lock.json
    ix-cli/package-lock.json
  Note  ... and 18 more
  Note  Run ix map to update. connects and reports healthy
- [ ] [ok] Visualizer started (PID 2065)
  http://localhost:9090 opens on custom port
- [ ] No host bind mounts on memory-layer container
- [ ] Node < 18 gives clear error
EOF
)