### PR TITLE
fix: stamp backend/compass versions on install

### DIFF
--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -58,6 +58,24 @@ function Get-LatestVersion {
     }
 }
 
+function Get-BackendLatestVersion {
+    try {
+        $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$GithubOrg/ix-memory-layer-dist/releases/latest" -ErrorAction Stop
+        return $release.tag_name -replace '^v', ''
+    } catch {
+        return $null
+    }
+}
+
+function Get-CompassLatestVersion {
+    try {
+        $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$GithubOrg/ix-compass-dist/releases/latest" -ErrorAction Stop
+        return $release.tag_name -replace '^v', ''
+    } catch {
+        return $null
+    }
+}
+
 # ══════════════════════════════════════════════════════════════════════════════
 #  MAIN
 # ══════════════════════════════════════════════════════════════════════════════
@@ -288,6 +306,20 @@ if ($existingVersion -eq $Version) {
     if ($env:Path -notlike "*$IxBin*") {
         $env:Path = "$IxBin;$env:Path"
     }
+}
+
+# ── Stamp installed versions so upgrade checker doesn't nag ──────────────────
+
+$BackendVer = Get-BackendLatestVersion
+if ($BackendVer) {
+    [System.IO.File]::WriteAllText((Join-Path $IxHome ".backend-version"), $BackendVer)
+}
+
+$CompassVer = Get-CompassLatestVersion
+if ($CompassVer) {
+    $CompassDir = Join-Path $IxHome "cli\compass"
+    New-Item -ItemType Directory -Force -Path $CompassDir | Out-Null
+    [System.IO.File]::WriteAllText((Join-Path $CompassDir ".version"), $CompassVer)
 }
 
 # ── Done ─────────────────────────────────────────────────────────────────────

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -127,6 +127,16 @@ resolve_version() {
   echo "0.1.0"
 }
 
+resolve_backend_version() {
+  _fetch "https://api.github.com/repos/${GITHUB_ORG}/ix-memory-layer-dist/releases/latest" 2>/dev/null \
+    | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"v\([^"]*\)".*/\1/p' || true
+}
+
+resolve_compass_version() {
+  _fetch "https://api.github.com/repos/${GITHUB_ORG}/ix-compass-dist/releases/latest" 2>/dev/null \
+    | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"v\([^"]*\)".*/\1/p' || true
+}
+
 # -- Detect platform --
 
 detect_platform() {
@@ -858,6 +868,16 @@ SHIM
   ensure_path
 
   info "Installed: $IX_BIN/ix"
+fi
+
+# -- Stamp installed versions so upgrade checker doesn't nag --
+
+BACKEND_VER=$(resolve_backend_version)
+COMPASS_VER=$(resolve_compass_version)
+[ -n "$BACKEND_VER" ] && printf '%s' "$BACKEND_VER" > "$IX_HOME/.backend-version"
+if [ -n "$COMPASS_VER" ]; then
+  mkdir -p "$IX_HOME/cli/compass"
+  printf '%s' "$COMPASS_VER" > "$IX_HOME/cli/compass/.version"
 fi
 
 # -- Done --


### PR DESCRIPTION
## Summary
- Fresh installs never wrote `.backend-version` or `compass/.version` files
- The upgrade checker reads those files, finds `0.0.0`, and always shows "update available" nag even on a brand new install
- Install script now resolves latest backend and compass versions from GitHub releases and writes them after install

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works