### PR TITLE
fix(readme): point badge URLs at current repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 <p align="center"><em>Your context saver and virtual cartographer.</em></p>
 
 <p align="center">
-  <img src="https://img.shields.io/github/stars/ix-infrastructure/IX-Memory" />
-  <img src="https://img.shields.io/github/license/ix-infrastructure/IX-Memory" />
-  <img src="https://img.shields.io/github/actions/workflow/status/ix-infrastructure/IX-Memory/ci.yml?label=tests" />
+  <img src="https://img.shields.io/github/stars/ix-infrastructure/Ix" />
+  <img src="https://img.shields.io/github/license/ix-infrastructure/Ix" />
+  <img src="https://img.shields.io/github/actions/workflow/status/ix-infrastructure/Ix/ci.yml?label=tests" />
   <img src="https://img.shields.io/badge/platform-windows%20%7C%20macOS%20%7C%20linux-lightgrey" />
 </p>
 


### PR DESCRIPTION
## Context — part of a coordinated fix

This PR is one of three coordinated changes to stop auto-reported `[IX Error]` issues that were spamming all 8 watchers/subscribers of this repo via email.

**Background:** The `ix-claude-plugin` v2.3.0 shipped March 28 with a phone-home feature that created GitHub issues here whenever any `ix` command failed. The code was removed April 8 (ix-claude-plugin#5), but the plugin version was never bumped — so every user's cache still runs the old phone-home code. 22 auto-reports have been filed since the fix merged, most recent April 17.

Claude Code doesn't auto-update plugins on version change (users must explicitly run `/plugin update`), so a server-side kill switch was needed.

**The kill switch:** The old phone-home code targeted `ix-infrastructure/IX-Memory`, which was a GitHub rename-redirect to this repo. We've reclaimed the `IX-Memory` name with a private, issues-disabled decoy repo — stale plugin writes now silently fail instead of landing here.

Side effect: the redirect is permanently broken. Any URL previously pointing to `ix-infrastructure/IX-Memory` no longer resolves to `Ix`.

## This PR

Updates 3 shields.io badge URLs in `README.md` from `ix-infrastructure/IX-Memory` → `ix-infrastructure/Ix` so stars, license, and CI badges keep rendering.

## Coordinated PRs

- ix-claude-plugin#9 — bump plugin to 2.3.1 (merged; prerequisite for `/plugin update` to pull clean code)
- ix-claude-plugin#10 — doc link cleanup
- ix-opencode-plugin#1 — doc link cleanup

## Test plan

- [ ] Merge
- [ ] Confirm README badges render correctly

cc @KageBinary @josephismikhail