### PR TITLE
Add R language support and tests

### DIFF
--- a/core-ingestion/package-lock.json
+++ b/core-ingestion/package-lock.json
@@ -31,8 +31,29 @@
         "vitest": "^4.1.0"
       },
       "optionalDependencies": {
+        "@davisvaughan/tree-sitter-r": "^1.2.0",
         "tree-sitter-kotlin": "^0.3.8",
         "tree-sitter-swift": "^0.6.0"
+      }
+    },
+    "node_modules/@davisvaughan/tree-sitter-r": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@davisvaughan/tree-sitter-r/-/tree-sitter-r-1.2.0.tgz",
+      "integrity": "sha512-KnvUaJJS6h1oCcRaq8fFb/xYyvqodMcE5M48vYmIWW7uOJCFkNwaHdGXuLzTipOWfXGzrKuq4EFRifHphLu9GQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.2.1",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emnapi/core": {
@@ -41,7 +62,6 @@
       "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -53,7 +73,6 @@
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -415,7 +434,6 @@
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1001,7 +1019,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1170,7 +1187,6 @@
       "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.8.0"
@@ -1513,7 +1529,6 @@
       "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/core-ingestion/package.json
+++ b/core-ingestion/package.json
@@ -33,7 +33,8 @@
   },
   "optionalDependencies": {
     "tree-sitter-kotlin": "^0.3.8",
-    "tree-sitter-swift": "^0.6.0"
+    "tree-sitter-swift": "^0.6.0",
+    "@davisvaughan/tree-sitter-r": "^1.2.0"
   },
   "devDependencies": {
     "@emnapi/core": "1.9.2",

--- a/core-ingestion/src/__tests__/queries.r.test.ts
+++ b/core-ingestion/src/__tests__/queries.r.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseFile } from '../index.js';
+
+describe('R queries', () => {
+  it('captures function definitions via <- and = assignment', () => {
+    const result = parseFile(
+      '/repo/script.R',
+      `
+my_func <- function(x, y) {
+  x + y
+}
+
+helper = function() {
+  invisible(NULL)
+}
+
+global_fn <<- function(z) z * 2
+      `,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.entities.map(e => e.name)).toEqual(
+      expect.arrayContaining(['my_func', 'helper', 'global_fn']),
+    );
+  });
+
+  it('captures library, require, and source imports', () => {
+    const result = parseFile(
+      '/repo/analysis.R',
+      `
+library(dplyr)
+require(ggplot2)
+source("utils.R")
+      `,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.relationships).toContainEqual({
+      srcName: 'analysis.R',
+      dstName: 'dplyr',
+      predicate: 'IMPORTS',
+    });
+    expect(result!.relationships).toContainEqual({
+      srcName: 'analysis.R',
+      dstName: 'ggplot2',
+      predicate: 'IMPORTS',
+    });
+    expect(result!.relationships).toContainEqual({
+      srcName: 'analysis.R',
+      dstName: 'utils.R',
+      predicate: 'IMPORTS',
+    });
+  });
+
+  it('captures direct function calls', () => {
+    const result = parseFile(
+      '/repo/script.R',
+      `
+process <- function(df) {
+  filtered <- filter(df, x > 0)
+  print(filtered)
+  nrow(filtered)
+}
+      `,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.relationships).toContainEqual({
+      srcName: 'process',
+      dstName: 'print',
+      predicate: 'CALLS',
+    });
+    expect(result!.relationships).toContainEqual({
+      srcName: 'process',
+      dstName: 'nrow',
+      predicate: 'CALLS',
+    });
+  });
+
+  it('captures dollar-sign method calls', () => {
+    const result = parseFile(
+      '/repo/script.R',
+      `
+run <- function(obj) {
+  obj$initialize()
+  obj$compute(x = 1)
+}
+      `,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.relationships).toContainEqual({
+      srcName: 'run',
+      dstName: 'initialize',
+      predicate: 'CALLS',
+    });
+    expect(result!.relationships).toContainEqual({
+      srcName: 'run',
+      dstName: 'compute',
+      predicate: 'CALLS',
+    });
+  });
+});

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -33,6 +33,7 @@ function tryLoadGrammar(pkg: string): any {
 }
 const Kotlin = tryLoadGrammar('tree-sitter-kotlin');
 const Swift = tryLoadGrammar('tree-sitter-swift');
+const R = tryLoadGrammar('@davisvaughan/tree-sitter-r');
 
 import { SupportedLanguages, languageFromPath } from './languages.js';
 import { LANGUAGE_QUERIES } from './queries.js';
@@ -105,6 +106,7 @@ const GRAMMAR_MAP: Partial<Record<SupportedLanguages, any>> = {
   [SupportedLanguages.Scala]: Scala,
   ...(Kotlin ? { [SupportedLanguages.Kotlin]: Kotlin } : {}),
   ...(Swift ? { [SupportedLanguages.Swift]: Swift } : {}),
+  ...(R ? { [SupportedLanguages.R]: R } : {}),
 };
 
 // Capture key prefix → NodeKind string

--- a/core-ingestion/src/languages.ts
+++ b/core-ingestion/src/languages.ts
@@ -19,6 +19,7 @@ export enum SupportedLanguages {
   JSON = 'json',
   TOML = 'toml',
   Markdown = 'markdown',
+  R = 'r',
 }
 
 const EXT_MAP: Record<string, SupportedLanguages> = {
@@ -54,6 +55,7 @@ const EXT_MAP: Record<string, SupportedLanguages> = {
   '.toml': SupportedLanguages.TOML,
   '.md':   SupportedLanguages.Markdown,
   '.markdown': SupportedLanguages.Markdown,
+  '.r':        SupportedLanguages.R,
 };
 
 export function languageFromPath(filePath: string): SupportedLanguages | null {

--- a/core-ingestion/src/queries.ts
+++ b/core-ingestion/src/queries.ts
@@ -1164,6 +1164,39 @@ export const SCALA_QUERIES = `
   (#match? @call.name "^[A-Z]"))
 `;
 
+// R queries - works with @davisvaughan/tree-sitter-r
+export const R_QUERIES = `
+; Function definitions: foo <- function(x, y) { ... }
+; Matches <-, <<-, = assignment forms (operator field is anonymous)
+(binary_operator
+  lhs: (identifier) @name
+  rhs: (function_definition)) @definition.function
+
+; library(pkg) and require(pkg) → IMPORTS
+; Arg is a bare identifier (unquoted package name) wrapped in argument.value
+(call
+  function: (identifier) @_fn
+  arguments: (arguments
+    (argument value: (identifier) @import.source))
+  (#match? @_fn "^(library|require)$")) @import
+
+; source("file.R") → IMPORTS (quoted file path string)
+(call
+  function: (identifier) @_fn
+  arguments: (arguments
+    (argument value: (string) @import.source))
+  (#match? @_fn "^source$")) @import
+
+; Direct function calls: foo(...)
+(call
+  function: (identifier) @call.name) @call
+
+; Method calls via $ operator: obj$method(...)
+(call
+  function: (extract_operator
+    rhs: (identifier) @call.name)) @call
+`;
+
 export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
   [SupportedLanguages.TypeScript]: TYPESCRIPT_QUERIES,
   [SupportedLanguages.JavaScript]: JAVASCRIPT_QUERIES,
@@ -1185,5 +1218,6 @@ export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
   [SupportedLanguages.JSON]: '',
   [SupportedLanguages.TOML]: '',
   [SupportedLanguages.Markdown]: '',
+  [SupportedLanguages.R]: R_QUERIES,
 };
  


### PR DESCRIPTION
Enable parsing of R files in core-ingestion: add @davisvaughan/tree-sitter-r as an optional dependency, update package.json (and lockfile), load and register the R grammar in index.ts, add R to SupportedLanguages and the extension map, implement Tree-sitter queries for R (functions, imports, calls, $-calls) in queries.ts, and add unit tests (src/__tests__/queries.r.test.ts) to validate extraction of definitions, imports, and calls.

## Summary
What does this PR change?

## Type
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
-

## Validation
How did you test this?

## Checklist
- [ ] Tests pass
- [ ] Smoke tests pass
- [ ] No raw errors introduced
- [ ] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
