### PR TITLE
fix(cli): cap ix subsystems --list --detailed auto-pagination at 200 pages

### DIFF
--- a/ix-cli/src/cli/commands/subsystems.ts
+++ b/ix-cli/src/cli/commands/subsystems.ts
@@ -40,6 +40,7 @@ interface SubsystemListResult {
 }
 
 const DETAILED_PAGE_LIMIT = 200;
+const DETAILED_PAGE_ITERATION_CAP = 200;
 
 export function registerSubsystemsCommand(program: Command): void {
   program
@@ -439,7 +440,14 @@ async function loadSubsystemScores(
   let offset = 0;
   let lastPagination: Record<string, unknown> | undefined;
 
-  while (true) {
+  for (let iteration = 0; ; iteration++) {
+    if (iteration >= DETAILED_PAGE_ITERATION_CAP) {
+      throw new Error(
+        `detailed listing exceeded safety cap of ${DETAILED_PAGE_ITERATION_CAP} pages. ` +
+        `The memory-layer endpoint may be paginating incorrectly. ` +
+        `Re-run with explicit --offset to bypass auto-pagination.`
+      );
+    }
     const page = await client.listSubsystems({
       ...query,
       limit: pageLimit,


### PR DESCRIPTION
## Summary
- Adds a 200-iteration safety cap to the auto-pagination loop in `loadSubsystemScores` (`ix-cli/src/cli/commands/subsystems.ts`).
- A future server regression that broke the `returned < limit` termination condition would have hung the CLI indefinitely; the cap converts that failure mode into a clear, actionable error.

## Behavior on cap exceeded
```
Error: detailed listing exceeded safety cap of 200 pages. The memory-layer endpoint may be paginating incorrectly. Re-run with explicit --offset to bypass auto-pagination.
```

At the default page size of 200, the cap covers 40,000 regions; well above any realistic repo.

## Test plan
- [x] `npm run build` in `ix-cli/` passes
- [ ] Manual: `ix subsystems --list --detailed` against a healthy backend still returns all pages

Fixes #213