### PR TITLE
fix(cli): rename subsystem -> subsystems in ix help

### DIFF
--- a/ix-cli/src/cli/__tests__/help-coverage.test.ts
+++ b/ix-cli/src/cli/__tests__/help-coverage.test.ts
@@ -14,7 +14,7 @@ const ossHelp = buildHelpText();
 
 const REQUIRED_COMMANDS = [
   "search", "locate", "explain", "impact", "overview", "watch",
-  "read", "inventory", "rank", "history", "diff", "smells", "subsystem",
+  "read", "inventory", "rank", "history", "diff", "smells", "subsystems",
   "map", "trace", "status", "stats", "doctor", "docker",
 ];
 

--- a/ix-cli/src/cli/help-text.ts
+++ b/ix-cli/src/cli/help-text.ts
@@ -19,7 +19,7 @@ const OSS_HELP = [
   ``,
   chalk.bold(`Explore:`),
   `  trace <symbol>        Trace flow`,
-  `  subsystem             Explore structure`,
+  `  subsystems            Explore structure`,
   `  inventory             List components`,
   `  rank                  Rank importance`,
   `  history <target>      Show history`,


### PR DESCRIPTION
## Summary
- The OSS help block in `ix-cli/src/cli/help-text.ts` listed the command as `subsystem`, but the actual command registered in `subsystems.ts` is `subsystems`. Users copying from `ix help` got "command not found".
- Updated the help text and the matching entry in `help-coverage.test.ts`.

## Test plan
- [x] `npx vitest run src/cli/__tests__/help-coverage.test.ts src/cli/__tests__/help-topics.test.ts` passes (11/11)
- [x] `npm run build` clean

Fixes #212