### PR TITLE
fix(cli): handle rg exit 2 in ix text instead of dumping Node stack

### DIFF
--- a/ix-cli/src/cli/commands/text.ts
+++ b/ix-cli/src/cli/commands/text.ts
@@ -66,11 +66,21 @@ export function registerTextCommand(program: Command): void {
           stderr("Error: ripgrep (rg) is not installed. Install it: https://github.com/BurntSushi/ripgrep#installation");
           process.exit(1);
         }
+        // rg exit 1 = no matches; render as empty result set
         if (err.code === 1 || err.status === 1) {
           formatTextResults([], opts.format);
-        } else {
-          throw err;
+          return;
         }
+        // rg exit 2 = usage/regex error (e.g. literal "\n" in regex,
+        // unbalanced escape). Surface rg's stderr verbatim so the caller
+        // sees the actual cause instead of a raw Node stack.
+        const rgStderr = typeof err.stderr === "string" ? err.stderr.trim() : "";
+        const firstLine = rgStderr.split("\n", 1)[0] ?? "";
+        stderr(`Error: ripgrep failed${firstLine ? `: ${firstLine}` : ""}`);
+        if (rgStderr && rgStderr !== firstLine) {
+          stderr(rgStderr);
+        }
+        process.exit(1);
       }
     });
 }


### PR DESCRIPTION
## Summary
- `ix text`'s catch block only handled `ENOENT` (no rg) and exit 1 (no matches). Any other rg failure — most commonly exit 2 from regex syntax errors — fell through to `throw err`, dumping a raw Node `internal/errors` stack to the user.
- The ix-claude-plugin auto-reporter has filed this twice (#196 + recurrence) when its hook fed `ix text` malformed patterns (multi-line shell command bodies, trailing backslash escapes).
- Now surfaces rg's own stderr verbatim and exits 1 cleanly. ENOENT and "no matches" paths unchanged.

## Reproduction (before)
```
$ ix text $'foo\nbar'
node:internal/errors:983
  const err = new Error(message);
              ^
... (raw Node stack)
```

## After
```
$ ix text $'foo\nbar'
Error: ripgrep failed: rg: the literal "\n" is not allowed in a regex
rg: the literal "\n" is not allowed in a regex

Consider enabling multiline mode with the --multiline flag (or -U for short).
When multiline mode is enabled, new line characters can be matched.
$ echo $?
1
```

## Test plan
- [x] Multi-line pattern: clear error, exit 1
- [x] Unbalanced escape (`case \`): clear error showing rg's regex parse error, exit 1
- [x] No matches: still prints "No text matches found." with exit 0
- [x] `vitest run` — 435/436 pass (one pre-existing unrelated failure in `resolver-type-preference.test.ts`, same on main)
- [x] `npm run build` clean

Fixes #196