### PR TITLE
fix(cli): emit workspace-relative source_uri from `ix watch`

### DIFF
--- a/ix-cli/src/cli/commands/watch.ts
+++ b/ix-cli/src/cli/commands/watch.ts
@@ -35,6 +35,26 @@ function hashContent(content: string): string {
   return crypto.createHash("sha256").update(content).digest("hex");
 }
 
+/**
+ * Convert an absolute path to a workspace-relative POSIX path. This is the
+ * canonical source_uri and the basis for every deterministic node/edge/chunk
+ * id, so it must match what `ix ingest` emits (see toWorkspaceRelative in
+ * ingest.ts). Forcing POSIX separators keeps ids stable across operating
+ * systems and never embeds an absolute host path.
+ */
+function toWorkspaceRelative(root: string, absPath: string): string {
+  return path.relative(root, absPath).split(path.sep).join("/");
+}
+
+/**
+ * Derive the workspace id from the workspace root's absolute path. Matches the
+ * value `ix ingest` stamps onto every patch (sha256 of the workspace root) so
+ * the two ingest paths agree on source identity.
+ */
+function workspaceIdFor(root: string): string {
+  return crypto.createHash("sha256").update(root).digest("hex");
+}
+
 export function registerWatchCommand(program: Command): void {
   program
     .command("watch")
@@ -50,6 +70,7 @@ export function registerWatchCommand(program: Command): void {
       }
 
       const root = resolveWorkspaceRoot(opts.root);
+      const workspaceId = workspaceIdFor(root);
       const watchPath = opts.path
         ? path.resolve(root, opts.path)
         : root;
@@ -81,7 +102,10 @@ export function registerWatchCommand(program: Command): void {
 
       async function ingestFile(filePath: string): Promise<void> {
         const [{ parseFile }, { buildPatch }] = await loadWatchIngestionModules();
-        const rel = path.relative(root, filePath);
+        // Workspace-relative POSIX path drives source_uri and node identity; it
+        // must match `ix ingest` or the same file ingested via watch vs ingest
+        // would mint divergent node ids and reintroduce absolute-path coupling.
+        const relPath = toWorkspaceRelative(root, filePath);
 
         // Re-read content at actual ingest time (not at event time)
         const content = readFileContent(filePath);
@@ -90,22 +114,23 @@ export function registerWatchCommand(program: Command): void {
         // Skip if content hash is unchanged since last ingest
         const hash = hashContent(content);
         if (lastHash.get(filePath) === hash) {
-          console.log(`${chalk.dim("[watch]")} unchanged (hash): ${rel}`);
+          console.log(`${chalk.dim("[watch]")} unchanged (hash): ${relPath}`);
           return;
         }
 
         try {
-          const parsed = parseFile(filePath, content);
+          const parsed = parseFile(relPath, content);
           if (!parsed) {
-            console.log(`${chalk.dim("[watch]")} skipped (unsupported): ${rel}`);
+            console.log(`${chalk.dim("[watch]")} skipped (unsupported): ${relPath}`);
             return;
           }
           const patch = buildPatch(parsed, hash);
+          if (patch?.source) patch.source.workspaceId = workspaceId;
           const result = await client.commitPatch(patch);
           lastHash.set(filePath, hash);
-          console.log(`${chalk.cyan("[watch]")} ingested: ${chalk.bold(rel)} → rev ${result.rev}`);
+          console.log(`${chalk.cyan("[watch]")} ingested: ${chalk.bold(relPath)} → rev ${result.rev}`);
         } catch (err: any) {
-          console.error(`${chalk.red("[watch]")} error ingesting ${rel}: ${err.message}`);
+          console.error(`${chalk.red("[watch]")} error ingesting ${relPath}: ${err.message}`);
         }
       }
 
@@ -162,6 +187,7 @@ async function pollMode(
   client: IxClient
 ): Promise<void> {
   const [{ parseFile }, { buildPatch }] = await loadWatchIngestionModules();
+  const workspaceId = workspaceIdFor(root);
   const mtimes = new Map<string, number>();
 
   function collectFiles(dir: string): string[] {
@@ -210,17 +236,18 @@ async function pollMode(
     }
 
     for (const f of changed) {
-      const rel = path.relative(root, f);
-      console.log(`${chalk.dim("[watch]")} changed: ${rel}`);
+      const relPath = toWorkspaceRelative(root, f);
+      console.log(`${chalk.dim("[watch]")} changed: ${relPath}`);
       try {
         const content = readFileContent(f);
         if (!content) continue;
-        const parsed = parseFile(f, content);
+        const parsed = parseFile(relPath, content);
         if (!parsed) continue;
         const hash = hashContent(content);
         const patch = buildPatch(parsed, hash);
+        if (patch?.source) patch.source.workspaceId = workspaceId;
         const result = await client.commitPatch(patch);
-        console.log(`${chalk.cyan("[watch]")} ingested: ${chalk.bold(rel)} → rev ${result.rev}`);
+        console.log(`${chalk.cyan("[watch]")} ingested: ${chalk.bold(relPath)} → rev ${result.rev}`);
       } catch (err: any) {
         console.error(`${chalk.red("[watch]")} error: ${err.message}`);
       }


### PR DESCRIPTION
## Background: where #167 actually stands

Issue #167 ("Backend should not depend on HOME or host filesystem mirroring") was **valid when filed, but already substantially addressed**. The client-agnostic backend migration (memory-layer `b443c33`, CLI shipped via #193) means:

- The backend performs **no host filesystem access**. `StalenessDetector` is now a pure graph/hash comparison; nothing reads client files.
- `source_uri` is a **workspace-relative** opaque key (schema v2), not an absolute host path. `ix ingest` already converts paths to workspace-relative POSIX and stamps a `workspaceId`.
- Cloud and the published-image standalone compose already run with **no HOME mount**.

Auditing what was left to actually close #167 surfaced two residual gaps:

1. The dev `docker-compose.yml` still declared a now-dead HOME mirror mount. Fixed in the companion PR: **ix-infrastructure/ix-memory-layer#37**.
2. **`ix watch` was never migrated** off absolute paths. That is this PR.

## The bug this PR fixes

`ix watch` (both the `fs.watch` handler and the polling fallback) passed the **absolute** file path to `parseFile` and called `buildPatch` without a `workspaceId`. Because node/edge/chunk ids are hashed from the path (`patch-builder.ts`) and `source_uri` is set from it, watch-committed nodes:

- embedded **absolute host paths** in the graph (the exact coupling #167 is about), and
- minted **different node ids than `ix ingest`** for the same file, so watching a file after ingesting it created divergent/duplicate identity.

## The fix

Mirror `ingest.ts` exactly:

- Convert to a workspace-relative POSIX path (`toWorkspaceRelative`) before calling `parseFile`, so `source_uri` and every deterministic id match `ix ingest`.
- Stamp `source.workspaceId = sha256(workspaceRoot)` on every patch.

Applied to both ingest sites (`ingestFile` and `pollMode`).

## Not in scope (flagged for a decision)

`workspaceId` is currently a **no-op on the backend**: the CLI sends it but `PatchSource` (Scala) has no field for it, so it is dropped. This PR keeps `ix watch` consistent with `ix ingest` (both send it), but does **not** wire it through server-side, because doing so changes node identity and forces a re-ingest. Whether to make `workspace_id` a real server-side scoping key is a separate design decision worth its own issue/PR.

## Verification

- `tsc --noEmit` passes for `ix-cli`.
- Change is isolated to `watch.ts`; mirrors the already-shipped `ingest.ts` logic.

## Linkage

Refs #167. Closing #167 needs this PR **and** ix-memory-layer#37 (the mount removal lives in the other repo, so no auto-close keyword is used here to avoid closing the issue prematurely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)