### PR TITLE
fix(inventory): send --path as server-side scope

### DIFF
--- a/ix-cli/src/cli/commands/inventory.ts
+++ b/ix-cli/src/cli/commands/inventory.ts
@@ -26,7 +26,11 @@ Examples:
       const client = new IxClient(getEndpoint());
       const limit = parseInt(opts.limit, 10);
 
-      let nodes = await client.listByKind(opts.kind, { limit, workspaceId: resolveWorkspaceId() });
+      // Pass --path as a server-side scope so the LIMIT is applied AFTER path
+      // filtering (otherwise a capped fetch can truncate away the target before
+      // the client-side filter below ever sees it). The client-side filter is
+      // kept as a fallback for older servers that ignore the scope field.
+      let nodes = await client.listByKind(opts.kind, { limit, workspaceId: resolveWorkspaceId(), scope: opts.path });
 
       if (opts.path) {
         nodes = nodes.filter((n) => {

--- a/ix-cli/src/client/api.ts
+++ b/ix-cli/src/client/api.ts
@@ -68,12 +68,13 @@ export class IxClient {
 
   async listByKind(
     kind: string,
-    opts?: { limit?: number; workspaceId?: string }
+    opts?: { limit?: number; workspaceId?: string; scope?: string }
   ): Promise<GraphNode[]> {
     return this.post("/v1/list", {
       kind,
       limit: opts?.limit,
       workspaceId: opts?.workspaceId,
+      scope: opts?.scope,
     });
   }
 


### PR DESCRIPTION
Pairs with ix-memory-layer #11 (findNodesByKind scope filter). `ix inventory --path` previously fetched a LIMIT-capped node set then filtered by path client-side, so entities beyond the cap were silently missed on large repos. This sends the path as `scope` so the server filters before LIMIT; the client-side filter is kept as a fallback for older servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)