### PR TITLE
fix(search): ix search returns zero results when a workspace is active (#228)

### DIFF
--- a/ix-cli/src/cli/commands/search.ts
+++ b/ix-cli/src/cli/commands/search.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
-import { getActiveWorkspaceRoot, getEndpoint } from "../config.js";
+import { getEndpoint } from "../config.js";
 import { resolveWorkspaceId } from "../bootstrap.js";
 import { formatNodes, relativePath } from "../format.js";
 import { scoreCandidate } from "../resolve.js";
@@ -117,7 +117,11 @@ Examples:
     }) => {
       const client = new IxClient(getEndpoint());
       const limit = parseInt(opts.limit, 10);
-      const effectivePathFilter = opts.path ?? getActiveWorkspaceRoot();
+      // Only an explicit --path scopes results. The active workspace is already
+      // applied server-side via workspaceId (below), and provenance.sourceUri is
+      // workspace-RELATIVE, so defaulting this to the absolute getActiveWorkspaceRoot()
+      // made the substring filter below drop every match (see issue #228).
+      const effectivePathFilter = opts.path;
 
       // Fetch more results than requested so we can re-rank and trim
       const fetchLimit = Math.min(limit * 3, 60);


### PR DESCRIPTION
Fixes #228. `ix search` defaulted its client-side path filter to the absolute `getActiveWorkspaceRoot()`, but `provenance.sourceUri` is workspace-relative, so the substring filter dropped every match (count:0, totalCandidates:N). The active workspace is already scoped server-side via workspaceId, so only an explicit `--path` needs client-side filtering (a relative substring, which matches). Drops the broken default + the now-unused import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)