### PR TITLE
Multi-repo co-ingest: auto-detect systems, co-ingest, system-scoped reads (Ix#225 Path 1)

### DIFF
--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -2499,8 +2499,20 @@ export function resolveEdges(
     return narrowed;
   }
 
+  // An import targets a file in a compatible language. modNameToFiles matches by
+  // stem alone, so without this a Python `import select` would resolve to a Rust
+  // `select.rs` (observed in cross-language co-ingest). JS and TS are one family
+  // (TS imports JS/.d.ts); everything else must match exactly. Mirrors the
+  // same-language guard already on the global symbol fallback.
+  const importLanguageCompatible = (src: SupportedLanguages, dst: SupportedLanguages | undefined): boolean => {
+    if (dst === undefined || src === dst) return true;
+    const jsTs = (l: SupportedLanguages) => l === SupportedLanguages.JavaScript || l === SupportedLanguages.TypeScript;
+    return jsTs(src) && jsTs(dst);
+  };
+
   function resolveImportTargets(srcFilePath: string, srcLanguage: SupportedLanguages, modName: unknown): string[] {
-    const importMatches = modNameToFiles(modName, srcFilePath);
+    const importMatches = modNameToFiles(modName, srcFilePath)
+      .filter(fp => importLanguageCompatible(srcLanguage, fileLanguage.get(fp)));
     if (srcLanguage !== SupportedLanguages.Go || importMatches.length <= 1) return importMatches;
     return narrowGoImportCandidates(srcFilePath, modName, importMatches, files => {
       const anchor = pickGoPackageAnchor(files);

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -2550,13 +2550,19 @@ export function resolveEdges(
 
   // An import targets a file in a compatible language. modNameToFiles matches by
   // stem alone, so without this a Python `import select` would resolve to a Rust
-  // `select.rs` (observed in cross-language co-ingest). JS and TS are one family
-  // (TS imports JS/.d.ts); everything else must match exactly. Mirrors the
-  // same-language guard already on the global symbol fallback.
+  // `select.rs` (observed in cross-language co-ingest). Some languages are one
+  // family: JS+TS (TS imports JS/.d.ts) and C+C++ (a .h header is shared, and
+  // parseFile's content-based detection labels the same .h as `c` or `cpp`
+  // depending on whether it holds a struct or a class — so a C++ file including a
+  // C-classified header must still resolve). Everything else must match exactly.
+  const langFamily = (l: SupportedLanguages): string => {
+    if (l === SupportedLanguages.JavaScript || l === SupportedLanguages.TypeScript) return 'jsts';
+    if (l === SupportedLanguages.C || l === SupportedLanguages.CPlusPlus) return 'c';
+    return l;
+  };
   const importLanguageCompatible = (src: SupportedLanguages, dst: SupportedLanguages | undefined | null): boolean => {
     if (dst == null || src === dst) return true;
-    const jsTs = (l: SupportedLanguages) => l === SupportedLanguages.JavaScript || l === SupportedLanguages.TypeScript;
-    return jsTs(src) && jsTs(dst);
+    return langFamily(src) === langFamily(dst);
   };
 
   function resolveImportTargets(srcFilePath: string, srcLanguage: SupportedLanguages, modName: unknown): string[] {

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -2244,6 +2244,16 @@ export function resolveEdges(
     resolvedGlobal: number; resolvedQualifier: number; skippedSameFile: number; skippedAmbiguous: number;
   },
   globalIndex?: GlobalResolutionIndex,
+  opts?: {
+    // Multi-repo co-ingest (Ix#225 Path 1). repoOf maps a file path to its repo;
+    // packageOf maps an import module name to the repo that publishes it. With
+    // both, a CROSS-repo edge is kept only when the source repo actually imports
+    // the target repo's package — killing same-named-symbol false edges between
+    // unrelated repos while preserving genuine cross-repo edges (which ARE
+    // dependency-backed). Absent (single-repo ingest) => no gating, no change.
+    repoOf?: (filePath: string) => string | undefined;
+    packageOf?: (moduleName: string) => string | undefined;
+  },
 ): ResolvedEdge[] {
   // Provide a default no-op stats bag when caller passes none (backward compat).
   if (!stats) stats = {
@@ -2251,6 +2261,45 @@ export function resolveEdges(
     globalCandidateTotal: 0, resolvedImport: 0, resolvedTransitive: 0,
     resolvedGlobal: 0, resolvedQualifier: 0, skippedSameFile: 0, skippedAmbiguous: 0,
   };
+  // Cross-repo dependency graph: repo R depends on repo D when any file in R
+  // imports a module published by D. Built from the raw IMPORTS relationships.
+  const repoOf = opts?.repoOf;
+  const packageOf = opts?.packageOf;
+  let repoDeps: Map<string, Set<string>> | undefined;
+  if (repoOf && packageOf) {
+    repoDeps = new Map<string, Set<string>>();
+    for (const r of results) {
+      const srcRepo = repoOf(r.filePath);
+      if (srcRepo === undefined) continue;
+      for (const rel of r.relationships) {
+        if (rel.predicate !== 'IMPORTS') continue;
+        const mod = typeof rel.dstName === 'string' ? rel.dstName : '';
+        const depRepo = mod ? packageOf(mod) : undefined;
+        if (depRepo !== undefined && depRepo !== srcRepo) {
+          let set = repoDeps.get(srcRepo);
+          if (!set) { set = new Set<string>(); repoDeps.set(srcRepo, set); }
+          set.add(depRepo);
+        }
+      }
+    }
+    // Transitive closure: a monorepo package re-exports its own dependencies
+    // (e.g. @babel/core re-exports @babel/types), so a repo legitimately uses the
+    // symbols of repos it depends on TRANSITIVELY. Without this, genuine
+    // transitive cross-repo edges (helper -> core -> types) would be dropped.
+    // Unrelated repos with no import path between them stay disconnected.
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const [, deps] of repoDeps) {
+        for (const b of [...deps]) {
+          const bdeps = repoDeps.get(b);
+          if (bdeps) for (const c of bdeps) {
+            if (!deps.has(c)) { deps.add(c); changed = true; }
+          }
+        }
+      }
+    }
+  }
   // fileQKeys: seed from global index (cross-batch files), then batch entries override.
   // Mirrors the entityQKey computation in buildPatch so nodeIds match exactly.
   const fileQKeys = globalIndex
@@ -2895,6 +2944,18 @@ export function resolveEdges(
     }
   }
 
+  // Cross-repo dependency gate (co-ingest): keep a cross-repo edge only when the
+  // source repo imports the target repo's package. Intra-repo and single-repo
+  // edges are untouched. A repo with no detected dependency to the target is
+  // treated as unrelated — its same-named-symbol matches are dropped.
+  if (repoOf && repoDeps) {
+    return resolved.filter(e => {
+      const sr = repoOf(e.srcFilePath);
+      const dr = repoOf(e.dstFilePath);
+      if (sr === undefined || dr === undefined || sr === dr) return true;
+      return repoDeps!.get(sr)?.has(dr) === true;
+    });
+  }
   return resolved;
 }
 

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -2504,15 +2504,19 @@ export function resolveEdges(
   // `select.rs` (observed in cross-language co-ingest). JS and TS are one family
   // (TS imports JS/.d.ts); everything else must match exactly. Mirrors the
   // same-language guard already on the global symbol fallback.
-  const importLanguageCompatible = (src: SupportedLanguages, dst: SupportedLanguages | undefined): boolean => {
-    if (dst === undefined || src === dst) return true;
+  const importLanguageCompatible = (src: SupportedLanguages, dst: SupportedLanguages | undefined | null): boolean => {
+    if (dst == null || src === dst) return true;
     const jsTs = (l: SupportedLanguages) => l === SupportedLanguages.JavaScript || l === SupportedLanguages.TypeScript;
     return jsTs(src) && jsTs(dst);
   };
 
   function resolveImportTargets(srcFilePath: string, srcLanguage: SupportedLanguages, modName: unknown): string[] {
+    // fileLanguage only covers the current parse batch; cross-batch candidates
+    // come from the global stem index, so fall back to the extension-derived
+    // language (always available) — otherwise an undefined dst language would
+    // slip cross-language matches (e.g. a Python import -> a Rust/Elixir file).
     const importMatches = modNameToFiles(modName, srcFilePath)
-      .filter(fp => importLanguageCompatible(srcLanguage, fileLanguage.get(fp)));
+      .filter(fp => importLanguageCompatible(srcLanguage, fileLanguage.get(fp) ?? languageFromPath(fp)));
     if (srcLanguage !== SupportedLanguages.Go || importMatches.length <= 1) return importMatches;
     return narrowGoImportCandidates(srcFilePath, modName, importMatches, files => {
       const anchor = pickGoPackageAnchor(files);
@@ -2793,7 +2797,9 @@ export function resolveEdges(
           }
           const qualGlobalMatches = results
             .map(r => r.filePath)
-            .filter(fp => fp !== srcFilePath && fileDefinesQualifiedMember(fp, qualifierPart, memberPart));
+            .filter(fp => fp !== srcFilePath
+              && importLanguageCompatible(srcLanguage, fileLanguage.get(fp) ?? languageFromPath(fp))
+              && fileDefinesQualifiedMember(fp, qualifierPart, memberPart));
           if (qualGlobalMatches.length === 1) {
             const qfp = qualGlobalMatches[0];
             if (fileHasSymbol.get(qfp)?.has(memberPart)) {

--- a/core-ingestion/src/patch-builder.ts
+++ b/core-ingestion/src/patch-builder.ts
@@ -86,7 +86,8 @@ export function buildPatch(
   result: FileParseResult,
   sourceHash: string,
   workspaceId: string,
-  previousSourceHash?: string
+  previousSourceHash?: string,
+  multiRepo?: MultiRepoContext,
 ): GraphPatchPayload {
   const { filePath, entities, chunks, relationships } = result;
   const { nodeId, edgeId, chunkId, computePatchId, legacyPatchId } = makeIds(workspaceId);
@@ -300,6 +301,8 @@ export function buildPatch(
       extractor,
       sourceType: sourceType(filePath),
       workspaceId,
+      ...(multiRepo?.systemId ? { systemId: multiRepo.systemId } : {}),
+      ...(multiRepo?.repoId ? { repoId: multiRepo.repoId } : {}),
     },
     baseRev: 0,
     ops,
@@ -313,12 +316,28 @@ export function buildPatch(
 // to the actual defining file for cross-file calls resolved by resolveCallEdges.
 // ---------------------------------------------------------------------------
 
+/**
+ * Multi-repo co-ingest context (Ix#225 Path 1). When several repos are ingested
+ * as one system, each repo keeps its OWN workspace_id (so a repo's node ids are
+ * stable whether ingested alone or in a system), all share a systemId, and each
+ * file carries its repoId. A cross-repo resolved edge's dst node lives in another
+ * repo whose ids are folded with ITS workspace_id, so dst ids must be resolved in
+ * that repo's namespace via repoWorkspaceOf. Absent => single-repo, unchanged.
+ */
+export interface MultiRepoContext {
+  systemId?: string;
+  repoId?: string;
+  /** filePath (workspace-relative, repo-prefixed) -> that file's repo workspace_id. */
+  repoWorkspaceOf?: (filePath: string) => string | undefined;
+}
+
 export function buildPatchWithResolution(
   result: FileParseResult,
   sourceHash: string,
   workspaceId: string,
   resolvedEdges: ResolvedEdge[],
   previousSourceHash?: string,
+  multiRepo?: MultiRepoContext,
 ): GraphPatchPayload {
   // Build lookup: `${srcName}:${predicate}:${dstName}` → { dstFilePath, dstQualifiedKey }
   // Callers should pass only edges for this file (pre-grouped) for best performance,
@@ -334,6 +353,18 @@ export function buildPatchWithResolution(
 
   const { filePath, entities, chunks, relationships } = result;
   const { nodeId, edgeId, chunkId, computePatchId, legacyPatchId } = makeIds(workspaceId);
+  // Resolve a dst node id in the namespace of the repo that OWNS dstFilePath.
+  // For same-repo (or single-repo) dsts this is just nodeId; for a cross-repo
+  // edge it folds with the dst repo's workspace_id so the id matches the node
+  // that repo's own ingest produced.
+  const crossRepoIdsCache = new Map<string, ReturnType<typeof makeIds>>();
+  const dstNodeIdInRepo = (dstFilePath: string, key: string): string => {
+    const ws = multiRepo?.repoWorkspaceOf?.(dstFilePath);
+    if (!ws || ws === workspaceId) return nodeId(dstFilePath, key);
+    let ids = crossRepoIdsCache.get(ws);
+    if (!ids) { ids = makeIds(ws); crossRepoIdsCache.set(ws, ids); }
+    return ids.nodeId(dstFilePath, key);
+  };
   const ops: PatchOp[] = [];
 
   const entityQKey = new Map<ParsedEntity, string>();
@@ -456,9 +487,10 @@ export function buildPatchWithResolution(
     const resolutionKey = `${r.srcName}:${r.predicate}:${r.dstName}`;
 
     if (edgeResolution.has(resolutionKey)) {
-      // Cross-file resolved — use the defining file's nodeId.
+      // Cross-file resolved — use the defining file's nodeId, in the dst repo's
+      // workspace namespace (matters only for cross-repo edges in a co-ingest).
       const { dstFilePath, dstQualifiedKey } = edgeResolution.get(resolutionKey)!;
-      dstNodeId = nodeId(dstFilePath, dstQualifiedKey);
+      dstNodeId = dstNodeIdInRepo(dstFilePath, dstQualifiedKey);
     } else if (r.predicate === 'CALLS' && dstKey.includes('::') && !allQKeys2.has(dstKey)) {
       const sep = dstKey.indexOf('::');
       const pkgName = dstKey.slice(0, sep);
@@ -517,6 +549,8 @@ export function buildPatchWithResolution(
       extractor,
       sourceType: sourceType(filePath),
       workspaceId,
+      ...(multiRepo?.systemId ? { systemId: multiRepo.systemId } : {}),
+      ...(multiRepo?.repoId ? { repoId: multiRepo.repoId } : {}),
     },
     baseRev: 0,
     ops,

--- a/core-ingestion/src/types.ts
+++ b/core-ingestion/src/types.ts
@@ -9,6 +9,10 @@ export interface PatchSource {
   // patch. Derived client-side (SHA-256 of workspace root abs path). Backend
   // stores it as an opaque attribute.
   workspaceId?: string;
+  // Multi-repo co-ingest (Ix#225 Path 1). systemId groups the repos ingested as
+  // one system; repoId is this file's repo. Both optional => single-repo ingest.
+  systemId?: string;
+  repoId?: string;
 }
 
 export interface PatchOp {

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -464,11 +464,17 @@ export async function ingestFiles(
   const packageEntries = Object.entries(packageRegistry);
   const packageOf = (mod: string): string | undefined => {
     if (!mod) return undefined;
+    // A RELATIVE / source-file import (./x, ../x, "core.ts", "lib/foo.js") is
+    // intra-repo — it must NOT match another member's package stem. (Without this,
+    // babel-types' relative `./core.ts` falsely matches the babel-core package,
+    // inventing a fake dependency that whitelists same-named-symbol false edges.)
+    // A package specifier is a bare name / namespaced path with no source-file
+    // extension and no leading dot/slash.
+    if (mod.startsWith('.') || mod.startsWith('/')) return undefined;
+    if (/\.(?:ts|tsx|js|jsx|mjs|cjs|py|pyi|rs|go|rb|java|ex|exs|c|h|cc|cpp|hpp|cs|scala|kt|swift)$/i.test(mod)) return undefined;
     if (packageRegistry[mod]) return packageRegistry[mod];               // exact (full name or stem)
     const lower = mod.toLowerCase();
     if (packageRegistry[lower]) return packageRegistry[lower];           // lowercased stem
-    const noExt = lower.replace(/\.[a-z0-9]+$/, '');                     // parser may keep "types.ts"
-    if (noExt !== lower && packageRegistry[noExt]) return packageRegistry[noExt];
     for (const [pkg, repo] of packageEntries) {                          // sub-path / submodule
       if (mod.length > pkg.length && mod.startsWith(pkg)) {
         const sep = mod[pkg.length];

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -15,6 +15,7 @@ import { resolveGitHubToken } from '../github/auth.js';
 import { parseGitHubRepo, fetchGitHubData } from '../github/fetch.js';
 import { loadIngestionModules } from './ingestion-loader.js';
 import { ensureWorkspaceId } from '../bootstrap.js';
+import { detectSystem, repoWorkspaceIdFor } from '../system.js';
 import {
   deterministicId,
   transformIssue,
@@ -434,6 +435,30 @@ export async function ingestFiles(
     return rel.split(nodePath.sep).join('/');
   };
 
+  // ── Multi-repo co-ingest (Ix#225 Path 1) ──────────────────────────────
+  // Auto-detected (no flag): if the mapped dir has >= 2 child repo roots, treat
+  // each as a member repo. Each repo gets its OWN stable workspace_id (so its
+  // node ids match whether ingested alone or in a system), all share the
+  // system_id, and each file carries its repoId. A cross-repo edge's dst id is
+  // resolved in the dst repo's workspace namespace by core-ingestion.
+  const detectedSystem = detectSystem(workspaceRoot);
+  const systemId: string | undefined = detectedSystem?.systemId;
+  const repoOf = (relPath: string): string => (relPath.split('/')[0] || '.');
+  const repoWsCache = new Map<string, string>();
+  const repoWorkspaceId = (repo: string): string => {
+    let ws = repoWsCache.get(repo);
+    if (!ws) { ws = repoWorkspaceIdFor(workspaceRoot, repo); repoWsCache.set(repo, ws); }
+    return ws;
+  };
+  const repoWorkspaceOf = systemId ? (relPath: string) => repoWorkspaceId(repoOf(relPath)) : undefined;
+  // Per-file workspace id + multi-repo context fed to buildPatchWithResolution.
+  const fileWorkspaceId = (relPath: string): string => systemId ? repoWorkspaceId(repoOf(relPath)) : workspaceId;
+  const fileMultiRepo = (relPath: string) =>
+    systemId ? { systemId, repoId: repoOf(relPath), repoWorkspaceOf } : undefined;
+  if (systemId && debug) {
+    process.stderr.write(`[multi-repo] system "${detectedSystem!.name}" (${systemId}) members=${detectedSystem!.members.join(', ')}\n`);
+  }
+
   const client = new IxClient(getEndpoint());
 
   // Schema-version check forces a clean re-ingest when the backend's graph
@@ -803,7 +828,7 @@ export async function ingestFiles(
         for (let j = 0; j < batch.length; j++) {
           const { parsed: p, hash, previousHash } = batch[j];
           try {
-            let patch = buildPatchFn!(p, hash, workspaceId, batchEdgesByFile.get(p.filePath) ?? emptyEdges, previousHash);
+            let patch = buildPatchFn!(p, hash, fileWorkspaceId(p.filePath), batchEdgesByFile.get(p.filePath) ?? emptyEdges, previousHash, fileMultiRepo(p.filePath));
             if (mapMode) patch = stripMapModeOps(patch);
             // source.uri (workspace-relative) and source.workspaceId are set
             // inside buildPatch; the backend stores both as opaque attributes.
@@ -871,7 +896,7 @@ export async function ingestFiles(
         for (let j = 0; j < allParsed.length; j++) {
           const { parsed: p, hash, previousHash } = allParsed[j];
           try {
-            let patch = buildPatchFn!(p, hash, workspaceId, edgesByFile.get(p.filePath) ?? emptyEdges, previousHash);
+            let patch = buildPatchFn!(p, hash, fileWorkspaceId(p.filePath), edgesByFile.get(p.filePath) ?? emptyEdges, previousHash, fileMultiRepo(p.filePath));
             if (mapMode) patch = stripMapModeOps(patch);
             // source.uri and source.workspaceId are set inside buildPatch (see flushBatch).
             preparedPatches.push(makePreparedPatch(patch, j + 1, p.filePath));

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -455,8 +455,31 @@ export async function ingestFiles(
   const fileWorkspaceId = (relPath: string): string => systemId ? repoWorkspaceId(repoOf(relPath)) : workspaceId;
   const fileMultiRepo = (relPath: string) =>
     systemId ? { systemId, repoId: repoOf(relPath), repoWorkspaceOf } : undefined;
+  // Cross-repo dependency gate: map an import module name to the member repo that
+  // publishes that package (exact, or prefix at a package boundary for scoped /
+  // sub-module / sub-path imports like "@babel/types/lib/x", "tokio::sync",
+  // "sqlalchemy.orm", "github.com/org/repo/sub"). The resolver uses this to keep a
+  // cross-repo edge only when the source repo actually imports the target repo.
+  const packageRegistry = detectedSystem?.packageRegistry ?? {};
+  const packageEntries = Object.entries(packageRegistry);
+  const packageOf = (mod: string): string | undefined => {
+    if (!mod) return undefined;
+    if (packageRegistry[mod]) return packageRegistry[mod];               // exact (full name or stem)
+    const lower = mod.toLowerCase();
+    if (packageRegistry[lower]) return packageRegistry[lower];           // lowercased stem
+    const noExt = lower.replace(/\.[a-z0-9]+$/, '');                     // parser may keep "types.ts"
+    if (noExt !== lower && packageRegistry[noExt]) return packageRegistry[noExt];
+    for (const [pkg, repo] of packageEntries) {                          // sub-path / submodule
+      if (mod.length > pkg.length && mod.startsWith(pkg)) {
+        const sep = mod[pkg.length];
+        if (sep === '/' || sep === '.' || sep === ':') return repo;
+      }
+    }
+    return undefined;
+  };
+  const resolveOpts = systemId ? { repoOf, packageOf } : undefined;
   if (systemId && debug) {
-    process.stderr.write(`[multi-repo] system "${detectedSystem!.name}" (${systemId}) members=${detectedSystem!.members.join(', ')}\n`);
+    process.stderr.write(`[multi-repo] system "${detectedSystem!.name}" (${systemId}) members=${detectedSystem!.members.join(', ')} packages=${packageEntries.length}\n`);
   }
 
   const client = new IxClient(getEndpoint());
@@ -813,7 +836,7 @@ export async function ingestFiles(
         setCurrentWork(`resolve+commit batch ending ${nodePath.basename(batch[batch.length - 1].filePath)}`);
 
         const resolveStart = performance.now();
-        const resolvedEdges = resolveEdgesFn!(batch.map(f => f.parsed), resolveStats, globalIndex);
+        const resolvedEdges = resolveEdgesFn!(batch.map(f => f.parsed), resolveStats, globalIndex, resolveOpts);
         resolveEdgesMs = Math.round(performance.now() - resolveStart);
         const batchEdgesByFile = new Map<string, any[]>();
         for (const edge of resolvedEdges) {
@@ -882,7 +905,7 @@ export async function ingestFiles(
       try {
         setCurrentWork(`resolve ${allParsed.length} files`);
         const resolveStart = performance.now();
-        const resolvedEdges = resolveEdgesFn!(allParsed.map(f => f.parsed), resolveStats, globalIndex);
+        const resolvedEdges = resolveEdgesFn!(allParsed.map(f => f.parsed), resolveStats, globalIndex, resolveOpts);
         resolveEdgesMs = Math.round(performance.now() - resolveStart);
         const edgesByFile = new Map<string, any[]>();
         for (const edge of resolvedEdges) {

--- a/ix-cli/src/cli/commands/inventory.ts
+++ b/ix-cli/src/cli/commands/inventory.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { resolveWorkspaceId } from "../bootstrap.js";
+import { detectSystem } from "../system.js";
 import { relativePath } from "../format.js";
 
 export function registerInventoryCommand(program: Command): void {
@@ -30,7 +31,8 @@ Examples:
       // filtering (otherwise a capped fetch can truncate away the target before
       // the client-side filter below ever sees it). The client-side filter is
       // kept as a fallback for older servers that ignore the scope field.
-      let nodes = await client.listByKind(opts.kind, { limit, workspaceId: resolveWorkspaceId(), scope: opts.path });
+      const systemId = detectSystem(process.cwd())?.systemId;
+      let nodes = await client.listByKind(opts.kind, { limit, workspaceId: systemId ? undefined : resolveWorkspaceId(), scope: opts.path, systemId });
 
       if (opts.path) {
         nodes = nodes.filter((n) => {

--- a/ix-cli/src/cli/commands/map.ts
+++ b/ix-cli/src/cli/commands/map.ts
@@ -7,6 +7,7 @@ import { roundFloat } from "../format.js";
 import { bootstrap, resolveWorkspaceId } from "../bootstrap.js";
 import { formatFetchError } from "../errors.js";
 import { ingestFiles } from "./ingest.js";
+import { detectSystem } from "../system.js";
 import { getRemoteRunner, isCloudReady } from "../remote.js";
 
 export interface MapRegion {
@@ -131,6 +132,9 @@ Examples:
     )
     .action(async (pathArg: string | undefined, opts: { format: string; level?: string; minConfidence: string; maxItems: string; allItems?: boolean; sort: string; graph?: boolean; list?: boolean; full?: boolean; verbose?: boolean; silent?: boolean }) => {
       const cwd = pathArg ? resolve(pathArg) : process.cwd();
+      // Auto-detect a multi-repo system (>= 2 child repo roots). When present we
+      // scope the map to its system_id; otherwise it's an ordinary single-repo map.
+      const systemId = detectSystem(cwd)?.systemId;
 
       const silent = opts.silent === true || opts.format === "silent";
 
@@ -206,7 +210,7 @@ Examples:
 
       let result: MapResult;
       try {
-        result = await client.map({ full: opts.full, workspaceId: resolveWorkspaceId(cwd) }) as MapResult;
+        result = await client.map({ full: opts.full, workspaceId: systemId ? undefined : resolveWorkspaceId(cwd), systemId }) as MapResult;
       } catch (err: any) {
         if (mapInterval) { clearInterval(mapInterval); process.stderr.write('\r' + ' '.repeat(60) + '\r'); }
         console.error(chalk.red("Error:"), formatFetchError(err));

--- a/ix-cli/src/cli/commands/search.ts
+++ b/ix-cli/src/cli/commands/search.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { resolveWorkspaceId } from "../bootstrap.js";
+import { detectSystem } from "../system.js";
 import { formatNodes, relativePath } from "../format.js";
 import { scoreCandidate } from "../resolve.js";
 import { applyRoleFilter, roleHint } from "../role-filter.js";
@@ -125,12 +126,16 @@ Examples:
 
       // Fetch more results than requested so we can re-rank and trim
       const fetchLimit = Math.min(limit * 3, 60);
+      // Auto-detect a multi-repo system; when present, scope by system_id (which
+      // spans all member repos) instead of the single-repo workspace_id.
+      const systemId = detectSystem(process.cwd())?.systemId;
       const rawNodes = await client.search(term, {
         limit: fetchLimit,
         kind: opts.kind,
         language: opts.language,
         asOfRev: opts.asOf ? parseInt(opts.asOf, 10) : undefined,
-        workspaceId: resolveWorkspaceId(),
+        workspaceId: systemId ? undefined : resolveWorkspaceId(),
+        systemId,
       });
       const nodes = effectivePathFilter
         ? rawNodes.filter((node: any) => {

--- a/ix-cli/src/cli/commands/smells.ts
+++ b/ix-cli/src/cli/commands/smells.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { resolveWorkspaceId } from "../bootstrap.js";
+import { detectSystem } from "../system.js";
 
 interface SmellCandidate {
   file_id: string;
@@ -59,11 +60,12 @@ Examples:
       list?: boolean;
     }) => {
       const client = new IxClient(getEndpoint());
+      const systemId = detectSystem(process.cwd())?.systemId;
 
       if (opts.list) {
         let result: any;
         try {
-          result = await client.listSmells({ workspaceId: resolveWorkspaceId() });
+          result = await client.listSmells({ workspaceId: systemId ? undefined : resolveWorkspaceId(), systemId });
         } catch (err: any) {
           console.error(chalk.red("Error:"), err.message);
           process.exitCode = 1;
@@ -106,7 +108,8 @@ Examples:
           godModuleChunks:      parseInt(opts.godModuleChunks, 10),
           godModuleFan:         parseInt(opts.godModuleFan, 10),
           weakMaxNeighbors:     parseInt(opts.weakMaxNeighbors, 10),
-          workspaceId:          resolveWorkspaceId(),
+          workspaceId:          systemId ? undefined : resolveWorkspaceId(),
+          systemId,
         }) as SmellReport;
       } catch (err: any) {
         console.error(chalk.red("Error:"), err.message);

--- a/ix-cli/src/cli/commands/stats.ts
+++ b/ix-cli/src/cli/commands/stats.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { resolveWorkspaceId } from "../bootstrap.js";
+import { detectSystem } from "../system.js";
 
 export function registerStatsCommand(program: Command): void {
   program
@@ -11,7 +12,8 @@ export function registerStatsCommand(program: Command): void {
     .option("--format <fmt>", "Output format (text|json)", "text")
     .action(async (opts: { format: string }) => {
       const client = new IxClient(getEndpoint());
-      const result = await client.stats({ workspaceId: resolveWorkspaceId() });
+      const systemId = detectSystem(process.cwd())?.systemId;
+      const result = await client.stats({ workspaceId: systemId ? undefined : resolveWorkspaceId(), systemId });
 
       if (opts.format === "json") {
         console.log(JSON.stringify(result, null, 2));

--- a/ix-cli/src/cli/commands/subsystems.ts
+++ b/ix-cli/src/cli/commands/subsystems.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import { IxClient, type ListSubsystemsOptions } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { resolveWorkspaceId } from "../bootstrap.js";
+import { detectSystem } from "../system.js";
 import { roundFloat } from "../format.js";
 import { renderMapText, type MapResult } from "./map.js";
 import {
@@ -105,6 +106,10 @@ Examples:
       explain?: boolean;
     }) => {
       const client = new IxClient(getEndpoint());
+      // Auto-detect a multi-repo system; scope by system_id (spanning all member
+      // repos) when present, otherwise the single-repo workspace_id.
+      const systemId = detectSystem(process.cwd())?.systemId;
+      const scope = { workspaceId: systemId ? undefined : resolveWorkspaceId(), systemId };
       const target = resolveSubsystemTarget(positionalTarget, opts.target);
       const pick = parsePickOption(opts.pick);
 
@@ -153,11 +158,11 @@ Examples:
       if (opts.list) {
         let result: SubsystemListResult;
         try {
-          result = await loadSubsystemScores(client, detailedQuery.value ?? {});
+          result = await loadSubsystemScores(client, detailedQuery.value ?? {}, scope);
           // Auto-trigger scoring if no persisted scores exist yet
           if (result.scores.length === 0) {
-            await client.scoreSubsystems({ workspaceId: resolveWorkspaceId() });
-            result = await loadSubsystemScores(client, detailedQuery.value ?? {});
+            await client.scoreSubsystems(scope);
+            result = await loadSubsystemScores(client, detailedQuery.value ?? {}, scope);
           }
         } catch (err: any) {
           console.error(chalk.red("Error:"), err.message);
@@ -201,7 +206,7 @@ Examples:
         result = await client.getSubsystemMap({
           target: target.value,
           pick: pick.value,
-          workspaceId: resolveWorkspaceId(),
+          ...scope,
         }) as MapResult;
       } catch (err: any) {
         const body = parseErrorBody(err);
@@ -229,9 +234,9 @@ Examples:
 
         let scoreResult: { scores?: SubsystemScore[] };
         try {
-          scoreResult = await client.listSubsystems({ workspaceId: resolveWorkspaceId() });
+          scoreResult = await client.listSubsystems(scope);
           if ((scoreResult.scores ?? []).length === 0) {
-            scoreResult = await client.scoreSubsystems({ workspaceId: resolveWorkspaceId() });
+            scoreResult = await client.scoreSubsystems(scope);
           }
         } catch (err: any) {
           console.error(chalk.red("Error:"), err.message);
@@ -418,9 +423,10 @@ function parseDetailedListQuery(opts: {
 async function loadSubsystemScores(
   client: IxClient,
   query: ListSubsystemsOptions,
+  scope: { workspaceId?: string; systemId?: string } = {},
 ): Promise<SubsystemListResult> {
   if (!query.detailed) {
-    const result = await client.listSubsystems({ workspaceId: resolveWorkspaceId() });
+    const result = await client.listSubsystems(scope);
     return { scores: result.scores ?? [], autoPaginated: false };
   }
 
@@ -428,6 +434,7 @@ async function loadSubsystemScores(
   if (explicitPage) {
     const page = await client.listSubsystems({
       ...query,
+      ...scope,
       limit: query.limit,
     });
     return {
@@ -452,6 +459,7 @@ async function loadSubsystemScores(
     }
     const page = await client.listSubsystems({
       ...query,
+      ...scope,
       limit: pageLimit,
       offset,
     });

--- a/ix-cli/src/cli/system.ts
+++ b/ix-cli/src/cli/system.ts
@@ -1,0 +1,75 @@
+import * as fs from "node:fs";
+import * as nodePath from "node:path";
+import { createHash } from "node:crypto";
+
+/**
+ * Multi-repo system auto-detection (Ix#225 Path 1).
+ *
+ * A directory is treated as a "system" of repos when >= 2 of its immediate child
+ * directories are themselves repo roots (a `.git` dir, or a top-level build
+ * manifest). Each such child becomes a member repo: it keeps its own stable
+ * workspace_id, all members share the system_id, and they map together. A single
+ * repo (children are plain source dirs like src/, lib/) is NOT a system and
+ * ingests exactly as before. No flag — `ix map <dir>` just does the right thing.
+ */
+
+// Strong, top-level build/package manifests. Deliberately excludes things that
+// commonly appear in ordinary subdirectories (Makefile, requirements.txt) to
+// avoid misreading a single repo's subfolders as member repos.
+const REPO_MANIFESTS = new Set([
+  "package.json", "go.mod", "go.work", "Cargo.toml", "pom.xml",
+  "build.gradle", "build.gradle.kts", "settings.gradle", "settings.gradle.kts",
+  "pyproject.toml", "setup.py", "composer.json", "Gemfile", "build.sbt",
+  "CMakeLists.txt", "mix.exs", "pubspec.yaml", "Package.swift",
+]);
+
+const stableId = (s: string): string =>
+  createHash("sha256").update(s).digest("hex").slice(0, 8);
+
+function isRepoRoot(dir: string): boolean {
+  try {
+    if (fs.existsSync(nodePath.join(dir, ".git"))) return true;
+    for (const e of fs.readdirSync(dir)) {
+      if (REPO_MANIFESTS.has(e) || e.endsWith(".csproj") || e.endsWith(".sln")) return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+export interface DetectedSystem {
+  /** Stable id stamped on every member node/edge; the system-map scope key. */
+  systemId: string;
+  /** Display name (the directory basename). */
+  name: string;
+  /** Member repo directory names (immediate children that are repo roots). */
+  members: string[];
+}
+
+/** Returns the detected system, or undefined when `rootPath` is a single repo. */
+export function detectSystem(rootPath: string): DetectedSystem | undefined {
+  let children: fs.Dirent[];
+  try {
+    children = fs.readdirSync(rootPath, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+  const members = children
+    .filter(c => (c.isDirectory() || c.isSymbolicLink()) && !c.name.startsWith("."))
+    .filter(c => isRepoRoot(nodePath.join(rootPath, c.name)))
+    .map(c => c.name);
+  if (members.length < 2) return undefined;
+  const abs = nodePath.resolve(rootPath).split(nodePath.sep).join("/");
+  return { systemId: stableId(`system:${abs}`), name: nodePath.basename(abs), members };
+}
+
+/**
+ * A member repo's stable workspace_id, derived from its absolute path so it is
+ * independent of which system it sits in (Path-2 friendly) and stable across
+ * re-ingests of the same location.
+ */
+export function repoWorkspaceIdFor(rootPath: string, repoDir: string): string {
+  const abs = nodePath.resolve(rootPath, repoDir).split(nodePath.sep).join("/");
+  return stableId(`repo:${abs}`);
+}

--- a/ix-cli/src/cli/system.ts
+++ b/ix-cli/src/cli/system.ts
@@ -38,6 +38,89 @@ function isRepoRoot(dir: string): boolean {
   }
 }
 
+/**
+ * Published package name(s) for a member repo, read (pragmatically) from its
+ * build manifest. These are matched against other members' imports to derive the
+ * cross-repo dependency graph: a cross-repo edge is only kept when the source
+ * repo actually imports the target repo's package. Best-effort per language;
+ * a repo with no recognized package name simply contributes no inbound deps.
+ */
+export function readPackageNames(dir: string): string[] {
+  const names = new Set<string>();
+  const read = (f: string): string | null => {
+    try { return fs.readFileSync(nodePath.join(dir, f), "utf8"); } catch { return null; }
+  };
+  const add = (n: unknown) => { if (typeof n === "string" && n.trim()) names.add(n.trim()); };
+
+  const pkg = read("package.json");                                  // JS / TS
+  if (pkg) { try { add(JSON.parse(pkg).name); } catch { /* ignore */ } }
+
+  const cargo = read("Cargo.toml");                                   // Rust
+  if (cargo) {
+    const sect = cargo.match(/\[package\]([\s\S]*?)(?:\n\[|$)/);
+    const m = (sect?.[1] ?? cargo).match(/\bname\s*=\s*"([^"]+)"/);
+    if (m) add(m[1]);
+  }
+
+  const gomod = read("go.mod");                                       // Go
+  if (gomod) { const m = gomod.match(/^\s*module\s+(\S+)/m); if (m) add(m[1]); }
+
+  const pyproj = read("pyproject.toml");                              // Python (PEP 621 / poetry)
+  if (pyproj) {
+    const sect = pyproj.match(/\[(?:project|tool\.poetry)\]([\s\S]*?)(?:\n\[|$)/);
+    const m = (sect?.[1] ?? pyproj).match(/^\s*name\s*=\s*["']([^"']+)["']/m);
+    if (m) add(m[1]);
+  }
+  const setuppy = read("setup.py");
+  if (setuppy) { const m = setuppy.match(/name\s*=\s*["']([^"']+)["']/); if (m) add(m[1]); }
+  const setupcfg = read("setup.cfg");
+  if (setupcfg) { const m = setupcfg.match(/^\s*name\s*=\s*(\S+)/m); if (m) add(m[1]); }
+
+  const mix = read("mix.exs");                                        // Elixir
+  if (mix) { const m = mix.match(/app:\s*:(\w+)/); if (m) add(m[1]); }
+
+  const pom = read("pom.xml");                                        // Java (best-effort)
+  if (pom) { const m = pom.match(/<artifactId>([^<]+)<\/artifactId>/); if (m) add(m[1]); }
+
+  try {                                                               // Ruby gemspec
+    for (const f of fs.readdirSync(dir)) {
+      if (!f.endsWith(".gemspec")) continue;
+      const m = read(f)?.match(/\.name\s*=\s*["']([^"']+)["']/);
+      if (m) add(m[1]);
+    }
+  } catch { /* ignore */ }
+
+  return [...names];
+}
+
+/**
+ * package identifier -> member repo dir (the repo_id), for cross-repo dep
+ * detection. Indexed by BOTH the full package name (`@babel/types`,
+ * `github.com/org/repo`) AND its lowercased stem (`types`, `repo`), because the
+ * parser records import targets as stems. Ambiguous stems (shared by >1 member)
+ * are dropped so a stem never maps to the wrong repo.
+ */
+export function buildPackageRegistry(rootPath: string, members: string[]): Record<string, string> {
+  const reg: Record<string, string> = {};
+  const stemOwners = new Map<string, Set<string>>();
+  const stemRepo = new Map<string, string>();
+  const stemOf = (name: string): string =>
+    (name.split(/[/.:]/).filter(Boolean).pop() ?? name).toLowerCase();
+  for (const m of members) {
+    for (const name of readPackageNames(nodePath.join(rootPath, m))) {
+      if (!(name in reg)) reg[name] = m;                 // full name (exact)
+      const stem = stemOf(name);
+      if (!stemOwners.has(stem)) stemOwners.set(stem, new Set());
+      stemOwners.get(stem)!.add(m);
+      stemRepo.set(stem, m);
+    }
+  }
+  for (const [stem, owners] of stemOwners) {
+    if (owners.size === 1 && !(stem in reg)) reg[stem] = stemRepo.get(stem)!;  // unambiguous stem
+  }
+  return reg;
+}
+
 export interface DetectedSystem {
   /** Stable id stamped on every member node/edge; the system-map scope key. */
   systemId: string;
@@ -45,6 +128,8 @@ export interface DetectedSystem {
   name: string;
   /** Member repo directory names (immediate children that are repo roots). */
   members: string[];
+  /** Published package name -> member repo dir, for cross-repo dependency gating. */
+  packageRegistry: Record<string, string>;
 }
 
 /** Returns the detected system, or undefined when `rootPath` is a single repo. */
@@ -61,7 +146,12 @@ export function detectSystem(rootPath: string): DetectedSystem | undefined {
     .map(c => c.name);
   if (members.length < 2) return undefined;
   const abs = nodePath.resolve(rootPath).split(nodePath.sep).join("/");
-  return { systemId: stableId(`system:${abs}`), name: nodePath.basename(abs), members };
+  return {
+    systemId: stableId(`system:${abs}`),
+    name: nodePath.basename(abs),
+    members,
+    packageRegistry: buildPackageRegistry(rootPath, members),
+  };
 }
 
 /**

--- a/ix-cli/src/client/api.ts
+++ b/ix-cli/src/client/api.ts
@@ -211,10 +211,11 @@ export class IxClient {
     return new Map(Object.entries(result));
   }
 
-  async map(opts?: { full?: boolean; workspaceId?: string }): Promise<any> {
-    // /v1/map reads snake_case keys (full, branch_id, workspace_id) off the raw JSON body.
+  async map(opts?: { full?: boolean; workspaceId?: string; systemId?: string }): Promise<any> {
+    // /v1/map reads snake_case keys (full, branch_id, workspace_id, system_id) off the raw JSON body.
     const body: Record<string, unknown> = { full: opts?.full ?? false };
     if (opts?.workspaceId) body.workspace_id = opts.workspaceId;
+    if (opts?.systemId) body.system_id = opts.systemId;
     const resp = await fetch(`${this.endpoint}/v1/map`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/ix-cli/src/client/api.ts
+++ b/ix-cli/src/client/api.ts
@@ -53,7 +53,7 @@ export class IxClient {
 
   async search(
     term: string,
-    opts?: { limit?: number; kind?: string; language?: string; asOfRev?: number; nameOnly?: boolean; workspaceId?: string }
+    opts?: { limit?: number; kind?: string; language?: string; asOfRev?: number; nameOnly?: boolean; workspaceId?: string; systemId?: string }
   ): Promise<GraphNode[]> {
     return this.post("/v1/search", {
       term,
@@ -63,18 +63,20 @@ export class IxClient {
       asOfRev: opts?.asOfRev,
       nameOnly: opts?.nameOnly,
       workspaceId: opts?.workspaceId,
+      systemId: opts?.systemId,
     });
   }
 
   async listByKind(
     kind: string,
-    opts?: { limit?: number; workspaceId?: string; scope?: string }
+    opts?: { limit?: number; workspaceId?: string; scope?: string; systemId?: string }
   ): Promise<GraphNode[]> {
     return this.post("/v1/list", {
       kind,
       limit: opts?.limit,
       workspaceId: opts?.workspaceId,
       scope: opts?.scope,
+      systemId: opts?.systemId,
     });
   }
 
@@ -249,6 +251,7 @@ export class IxClient {
     godModuleFan?: number;
     weakMaxNeighbors?: number;
     workspaceId?: string;
+    systemId?: string;
   }): Promise<any> {
     const params = new URLSearchParams();
     if (opts?.orphanMaxConnections !== undefined) params.set("orphan-max-connections", String(opts.orphanMaxConnections));
@@ -256,21 +259,28 @@ export class IxClient {
     if (opts?.godModuleFan         !== undefined) params.set("god-module-fan",          String(opts.godModuleFan));
     if (opts?.weakMaxNeighbors     !== undefined) params.set("weak-max-neighbors",      String(opts.weakMaxNeighbors));
     if (opts?.workspaceId)                        params.set("workspace_id",            opts.workspaceId);
+    if (opts?.systemId)                           params.set("system_id",               opts.systemId);
     const qs = params.toString();
     return this.post(qs ? `/v1/smells?${qs}` : "/v1/smells", {});
   }
 
-  async listSmells(opts?: { workspaceId?: string }): Promise<any> {
-    const qs = opts?.workspaceId ? `?workspace_id=${encodeURIComponent(opts.workspaceId)}` : "";
-    return this.get(`/v1/smells${qs}`);
+  async listSmells(opts?: { workspaceId?: string; systemId?: string }): Promise<any> {
+    const params = new URLSearchParams();
+    if (opts?.workspaceId) params.set("workspace_id", opts.workspaceId);
+    if (opts?.systemId)    params.set("system_id",    opts.systemId);
+    const qs = params.toString();
+    return this.get(`/v1/smells${qs ? `?${qs}` : ""}`);
   }
 
-  async scoreSubsystems(opts?: { workspaceId?: string }): Promise<any> {
-    const qs = opts?.workspaceId ? `?workspace_id=${encodeURIComponent(opts.workspaceId)}` : "";
-    return this.post(`/v1/subsystems/score${qs}`, {});
+  async scoreSubsystems(opts?: { workspaceId?: string; systemId?: string }): Promise<any> {
+    const params = new URLSearchParams();
+    if (opts?.workspaceId) params.set("workspace_id", opts.workspaceId);
+    if (opts?.systemId)    params.set("system_id",    opts.systemId);
+    const qs = params.toString();
+    return this.post(`/v1/subsystems/score${qs ? `?${qs}` : ""}`, {});
   }
 
-  async listSubsystems(opts?: ListSubsystemsOptions & { workspaceId?: string }): Promise<any> {
+  async listSubsystems(opts?: ListSubsystemsOptions & { workspaceId?: string; systemId?: string }): Promise<any> {
     const params = new URLSearchParams();
     if (opts?.detailed) params.set("detailed", "true");
     if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
@@ -279,15 +289,17 @@ export class IxClient {
     if (opts?.edgeCap !== undefined) params.set("edge_cap", String(opts.edgeCap));
     if (opts?.memberFileCap !== undefined) params.set("member_file_cap", String(opts.memberFileCap));
     if (opts?.workspaceId) params.set("workspace_id", opts.workspaceId);
+    if (opts?.systemId) params.set("system_id", opts.systemId);
     const qs = params.toString();
     return this.get(`/v1/subsystems${qs ? `?${qs}` : ""}`);
   }
 
-  async getSubsystemMap(opts?: { target?: string; pick?: number; workspaceId?: string }): Promise<any> {
+  async getSubsystemMap(opts?: { target?: string; pick?: number; workspaceId?: string; systemId?: string }): Promise<any> {
     const params = new URLSearchParams();
     if (opts?.target) params.set("target", opts.target);
     if (opts?.pick !== undefined) params.set("pick", String(opts.pick));
     if (opts?.workspaceId) params.set("workspace_id", opts.workspaceId);
+    if (opts?.systemId) params.set("system_id", opts.systemId);
     const qs = params.toString();
     return this.get(`/v1/subsystems/map${qs ? `?${qs}` : ""}`);
   }
@@ -415,9 +427,12 @@ export class IxClient {
     return resp.json();
   }
 
-  async stats(opts?: { workspaceId?: string }): Promise<any> {
-    const qs = opts?.workspaceId ? `?workspace_id=${encodeURIComponent(opts.workspaceId)}` : "";
-    return this.get(`/v1/stats${qs}`);
+  async stats(opts?: { workspaceId?: string; systemId?: string }): Promise<any> {
+    const params = new URLSearchParams();
+    if (opts?.workspaceId) params.set("workspace_id", opts.workspaceId);
+    if (opts?.systemId)    params.set("system_id",    opts.systemId);
+    const qs = params.toString();
+    return this.get(`/v1/stats${qs ? `?${qs}` : ""}`);
   }
 
   async health(): Promise<HealthResponse> {


### PR DESCRIPTION
**Draft — opened to run CI, NOT for review/merge yet.** Companion to ix-memory-layer#feat/multi-repo-systems (the two must land together).

## What this does
`ix map <dir>` auto-detects a multi-repo *system* (≥2 child repo roots) and maps the members together: each member keeps its own `workspace_id`, all share a `system_id`, each node carries `repo_id`, and cross-repo edges resolve across member boundaries.

Commits: language-import filter (incl. C/C++ + cross-batch + qualifier), multi-repo patch context, CLI auto-detect, and a package-name **import-dependency gate** (cross-repo edge kept only when the source repo imports the target's package, transitive closure).

## Honest status / caveats
- **Single-repo behavior is unchanged** — verified byte-identical (deterministic in-process resolver A/B across JS/TS/Py/Go/Rust), and the full core-ingestion (175 pass) + ix-cli (436 pass) suites match baseline exactly (remaining failures are pre-existing env-broken native-parser tests).
- **The dependency gate is NOT airtight.** It cuts false cross-repo edges by ~95% (babel/nest/unrelated-polyglot verified at the edge level) but still leaks a few (e.g. nest `common→core`) because the parser flattens relative `./core` and package `@nestjs/core` imports to the same stem. Fully closing it needs a parser change to preserve raw import specifiers. **Should not be treated as done.**
- Scale: a 147-member system hung the local backend — large systems need bounding.
- Per-repo isolated view still shows cross-repo edges (deferred polish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)