### PR TITLE
feat(cli): Tier 3 + Tier 4 `--format llm` renderers (PR 3, #206)

### DIFF
--- a/docs/llm-format.md
+++ b/docs/llm-format.md
@@ -93,8 +93,10 @@ error code=unknown_target message="No entity named 'IngestionService' found" sug
 
 Renderers shipped: Tier 1 (`map`, `subsystems`, `impact`, `smells`,
 `overview`) plus `stats`; Tier 2 (`inventory`, `rank`, `depends`, `trace`,
-`contains`, `callers`, `callees`, `imports`, `imported-by`). Remaining commands
-accept `--format llm` and route to `text` until their renderers land (tracked
-on ix-infrastructure/Ix#206). Programmatic
+`contains`, `callers`, `callees`, `imports`, `imported-by`); Tier 3 (`search`,
+`text`, `history`, `patches`); Tier 4 (`entity`, `locate`, `diff`,
+`conflicts`). Commands whose output is verbatim source or prose (`read`,
+`explain`, `doctor`, `status`, `savings`, and `diff --content`) route
+`--format llm` to `text`, the most compact existing form. Programmatic
 consumers that need to parse output should continue to use `--format json`; the
 `llm` format is optimized for being read by a model, not parsed.

--- a/ix-cli/src/cli/__tests__/llm-tier3.test.ts
+++ b/ix-cli/src/cli/__tests__/llm-tier3.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { renderNodesLlm, renderPatchesLlm, renderTextResultsLlm, type TextResult } from "../format.js";
+import { renderSearchLlm } from "../commands/search.js";
+import { renderHistoryLlm } from "../commands/history.js";
+
+describe("renderNodesLlm", () => {
+  it("emits one node record per entity with an 8-char id", () => {
+    expect(renderNodesLlm([{ kind: "class", id: "abcdef1234567890", name: "Foo" }]))
+      .toEqual(["node kind=class id=abcdef12 name=Foo"]);
+  });
+});
+
+describe("renderPatchesLlm", () => {
+  it("emits patch records with 12-char id and quoted intent", () => {
+    const lines = renderPatchesLlm([
+      { rev: 5, patch_id: "abcdef1234567890", intent: "fix bug", timestamp: "2026-01-01", source: { uri: "src/a.ts" } },
+    ]);
+    expect(lines).toEqual(['patch rev=5 id=abcdef123456 intent="fix bug" ts=2026-01-01 source=src/a.ts']);
+  });
+});
+
+describe("renderTextResultsLlm", () => {
+  it("emits match records with trimmed (quoted) snippet and language", () => {
+    const results: TextResult[] = [
+      { path: "src/a.ts", line_start: 42, line_end: 42, snippet: "  const x = 1  ", engine: "ripgrep", score: 1, language: "typescript" },
+    ];
+    expect(renderTextResultsLlm(results)).toEqual(['match path=src/a.ts line=42 lang=typescript snippet="const x = 1"']);
+  });
+});
+
+describe("renderSearchLlm", () => {
+  it("emits a header, node rows, then diagnostic rows", () => {
+    const lines = renderSearchLlm(
+      [{ name: "Foo", kind: "class", id: "abcdef1234567890", path: "src/a.ts", score: 5 }],
+      10,
+      [{ code: "unfiltered_search", message: "broad" }],
+    );
+    expect(lines).toEqual([
+      "search count=1 candidates=10",
+      "node name=Foo kind=class id=abcdef12 path=src/a.ts score=5",
+      "diagnostic code=unfiltered_search message=broad",
+    ]);
+  });
+});
+
+describe("renderHistoryLlm", () => {
+  it("emits a header then one patch record per revision", () => {
+    const lines = renderHistoryLlm({ name: "Foo", kind: "class" }, [
+      { rev: 3, data: { timestamp: "t1", intent: "init", source: { uri: "a.ts" } } },
+    ]);
+    expect(lines).toEqual([
+      "history target=Foo kind=class count=1",
+      "patch rev=3 ts=t1 intent=init source=a.ts",
+    ]);
+  });
+});

--- a/ix-cli/src/cli/__tests__/llm-tier4.test.ts
+++ b/ix-cli/src/cli/__tests__/llm-tier4.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { renderConflictsLlm, renderDiffLlm } from "../format.js";
+import { renderEntityLlm } from "../commands/entity.js";
+import { renderLocateLlm } from "../commands/locate.js";
+
+describe("renderEntityLlm", () => {
+  it("emits an entity header and one edge row per edge", () => {
+    const lines = renderEntityLlm({
+      node: { id: "abcdef1234567890", kind: "class", name: "Foo", createdRev: 3, provenance: { sourceUri: "src/a.ts" } },
+      claims: [],
+      edges: [{ predicate: "CONTAINS", dst: "deadbeef00000000" }],
+    });
+    expect(lines[0]).toBe("entity id=abcdef1234567890 kind=class name=Foo path=src/a.ts rev=3 edges=1");
+    expect(lines[1]).toBe("edge pred=CONTAINS dst=deadbeef");
+  });
+});
+
+describe("renderConflictsLlm", () => {
+  it("emits a header then one conflict record (quoting where needed)", () => {
+    const lines = renderConflictsLlm([{ reason: "contradiction", recommendation: "fix it", claimA: "a1", claimB: "b1" }]);
+    expect(lines).toEqual([
+      "conflicts count=1",
+      'conflict reason=contradiction recommendation="fix it" claim_a=a1 claim_b=b1',
+    ]);
+  });
+});
+
+describe("renderDiffLlm", () => {
+  it("emits a header then one change record, reading removed nodes from atFromRev", () => {
+    const lines = renderDiffLlm({
+      fromRev: 1, toRev: 5,
+      changes: [
+        { changeType: "added", atToRev: { name: "Foo", kind: "class" }, summary: "new class" },
+        { changeType: "removed", atFromRev: { name: "Bar", kind: "method" } },
+      ],
+    });
+    expect(lines[0]).toBe("diff from=1 to=5 changes=2");
+    expect(lines[1]).toBe('change type=added kind=class name=Foo summary="new class"');
+    expect(lines[2]).toBe("change type=removed kind=method name=Bar");
+  });
+});
+
+describe("renderLocateLlm", () => {
+  it("emits a locate record with line range, container, and system path", () => {
+    const lines = renderLocateLlm({
+      resolvedTarget: { id: "abcdef1234567890", kind: "function", name: "verify", path: "src/a.ts" },
+      resolutionMode: "scored",
+      lineRange: { start: 10, end: 20 },
+      container: { kind: "class", name: "Auth", id: "x" },
+      systemPath: [{ name: "Auth", kind: "subsystem" }],
+      hasMapData: true,
+      diagnostics: [],
+    } as any, "verify");
+    expect(lines[0]).toBe('locate target=verify kind=function id=abcdef12 path=src/a.ts line_start=10 line_end=20 contained_in="class Auth" system_path=Auth mode=scored');
+  });
+
+  it("emits a structured error when nothing resolves", () => {
+    const lines = renderLocateLlm({ resolvedTarget: null, resolutionMode: "none", systemPath: null, diagnostics: ["No graph entity found."] } as any, "foo");
+    expect(lines).toEqual(['error code=unknown_target message="No graph entity found for \\"foo\\"."']);
+  });
+});

--- a/ix-cli/src/cli/commands/diff.ts
+++ b/ix-cli/src/cli/commands/diff.ts
@@ -9,7 +9,18 @@ import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { resolveFileOrEntity, resolveEntityFull, printResolved, looksFileLike, type ResolvedEntity } from "../resolve.js";
 import { formatDiff, relativePath, stripNulls } from "../format.js";
+import { llmLine, llmError } from "../llm.js";
 import { stderr } from "../stderr.js";
+
+/** Render a `--summary` diff as a single llm record. */
+function renderDiffSummaryLlm(result: any): string {
+  const s = result.summary || {};
+  return llmLine("diff", [
+    ["from", result.fromRev], ["to", result.toRev],
+    ["added", s.added || undefined], ["modified", s.modified || undefined],
+    ["removed", s.removed || undefined], ["total", result.total],
+  ]);
+}
 
 const execFileAsync = promisify(execFile);
 
@@ -456,8 +467,11 @@ export function registerDiffCommand(program: Command): void {
           }
         } else {
           resolved = await resolveFileOrEntity(client, target, resolveOpts);
-          if (!resolved) return;
-          printResolved(resolved);
+          if (!resolved) {
+            if (opts.format === "llm") console.log(llmError("unresolved_target", `No entity resolved for "${target}".`));
+            return;
+          }
+          if (opts.format === "text") printResolved(resolved);
         }
         entityId = resolved.id;
       }
@@ -467,6 +481,8 @@ export function registerDiffCommand(program: Command): void {
 
         if (opts.format === "json") {
           console.log(JSON.stringify(compactDiffResult(result), null, 2));
+        } else if (opts.format === "llm") {
+          console.log(renderDiffSummaryLlm(result));
         } else {
           const s = result.summary || {};
           console.log(chalk.cyan.bold(`\nDiff: rev ${result.fromRev} → ${result.toRev}`));
@@ -621,6 +637,8 @@ export function registerDiffCommand(program: Command): void {
 
       if (opts.format === "json") {
         console.log(JSON.stringify(compactDiffResult(result), null, 2));
+      } else if (opts.format === "llm") {
+        formatDiff(result, "llm");
       } else {
         if (result.truncated) {
           console.log(chalk.yellow(`Showing ${result.changes.length} of ${result.totalChanges} changes. Use --full to see all.\n`));

--- a/ix-cli/src/cli/commands/entity.ts
+++ b/ix-cli/src/cli/commands/entity.ts
@@ -3,6 +3,30 @@ import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { relativePath, stripNulls } from "../format.js";
+import { llmLine } from "../llm.js";
+
+/** Render entity details as llm records: a header line then one `edge` row per edge. */
+export function renderEntityLlm(result: any): string[] {
+  const node = result.node;
+  const path = relativePath(node.provenance?.sourceUri ?? node.provenance?.source_uri);
+  const edges = result.edges ?? [];
+  const lines = [llmLine("entity", [
+    ["id", node.id],
+    ["kind", node.kind],
+    ["name", node.name || node.attrs?.name],
+    ["path", path],
+    ["rev", node.createdRev],
+    ["claims", (result.claims ?? []).length || undefined],
+    ["edges", edges.length || undefined],
+  ])];
+  for (const e of edges) {
+    lines.push(llmLine("edge", [
+      ["pred", e.predicate],
+      ["dst", typeof e.dst === "string" ? e.dst.slice(0, 8) : e.dst],
+    ]));
+  }
+  return lines;
+}
 
 export function registerEntityCommand(program: Command): void {
   program
@@ -15,6 +39,8 @@ export function registerEntityCommand(program: Command): void {
       const result = await client.entity(resolvedId);
       if (opts.format === "json") {
         console.log(JSON.stringify(compactEntity(result), null, 2));
+      } else if (opts.format === "llm") {
+        for (const line of renderEntityLlm(result)) console.log(line);
       } else {
         const name = result.node.name || (result.node.attrs as any)?.name || "(unnamed)";
         console.log(`Entity: ${result.node.id} ${chalk.bold(name)} (${result.node.kind})`);

--- a/ix-cli/src/cli/commands/history.ts
+++ b/ix-cli/src/cli/commands/history.ts
@@ -5,6 +5,23 @@ import { getEndpoint } from "../config.js";
 import { resolveFileOrEntity, printResolved } from "../resolve.js";
 import { relativePath } from "../format.js";
 import { stderr } from "../stderr.js";
+import { llmLine, llmError } from "../llm.js";
+
+/** Render an entity's provenance chain as llm records: a header then one `patch` row per revision. */
+export function renderHistoryLlm(
+  resolved: { name: string; kind: string }, patches: any[],
+): string[] {
+  const lines = [llmLine("history", [["target", resolved.name], ["kind", resolved.kind], ["count", patches.length]])];
+  for (const p of patches) {
+    lines.push(llmLine("patch", [
+      ["rev", p.rev ?? p.data?.rev],
+      ["ts", p.data?.timestamp ?? p.timestamp],
+      ["intent", (p.data?.intent ?? p.intent) || undefined],
+      ["source", relativePath(p.data?.source?.uri) || undefined],
+    ]));
+  }
+  return lines;
+}
 
 export function registerHistoryCommand(program: Command): void {
   program
@@ -23,14 +40,23 @@ export function registerHistoryCommand(program: Command): void {
       const client = new IxClient(getEndpoint());
       const resolveOpts = { kind: opts.kind, path: opts.path, pick: opts.pick ? parseInt(opts.pick, 10) : undefined };
       const resolved = await resolveFileOrEntity(client, target, resolveOpts);
-      if (!resolved) return;
+      if (!resolved) {
+        if (opts.format === "llm") console.log(llmError("unresolved_target", `No entity resolved for "${target}".`));
+        return;
+      }
 
-      if (opts.format !== "json") printResolved(resolved);
+      if (opts.format === "text") printResolved(resolved);
 
       const result = await client.provenance(resolved.id);
+      const allPatches = Array.isArray(result) ? result : (result as any)?.patches ?? [];
+
+      if (opts.format === "llm") {
+        for (const line of renderHistoryLlm(resolved, allPatches)) console.log(line);
+        return;
+      }
 
       if (opts.format === "json") {
-        const patches = Array.isArray(result) ? result : (result as any)?.patches ?? [];
+        const patches = allPatches;
         console.log(JSON.stringify({
           resolvedTarget: { kind: resolved.kind, name: resolved.name, path: relativePath(resolved.path) },
           patches: patches.map((p: any) => ({

--- a/ix-cli/src/cli/commands/locate.ts
+++ b/ix-cli/src/cli/commands/locate.ts
@@ -9,6 +9,7 @@ import {
 import { isFileStale } from "../stale.js";
 import { stderr } from "../stderr.js";
 import { relativePath } from "../format.js";
+import { llmLine, llmError } from "../llm.js";
 import { getEffectiveSystemPath, hasMapData } from "../hierarchy.js";
 import { humanizeLabel } from "../impact/risk-semantics.js";
 import { renderSection, renderKeyValue, renderNote, renderWarning, renderBreadcrumb } from "../ui.js";
@@ -51,7 +52,7 @@ export function registerLocateCommand(program: Command): void {
       const resolveOpts = { kind: opts.kind, path: opts.path, pick: opts.pick ? parseInt(opts.pick, 10) : undefined };
 
       // Resolution with ambiguity detection
-      const { target, ambiguous } = await resolveWithAmbiguity(client, symbol, resolveOpts, isJson);
+      const { target, ambiguous } = await resolveWithAmbiguity(client, symbol, resolveOpts, opts.format);
 
       if (!target) {
         if (ambiguous) {
@@ -68,7 +69,7 @@ export function registerLocateCommand(program: Command): void {
         return;
       }
 
-      if (!isJson) printResolved(target);
+      if (opts.format === "text") printResolved(target);
 
       const isContainer = CONTAINER_KINDS.has(target.kind);
       const isFile = FILE_KINDS.has(target.kind);
@@ -158,7 +159,7 @@ async function resolveWithAmbiguity(
   client: IxClient,
   symbol: string,
   opts: { kind?: string; path?: string; pick?: number },
-  isJson: boolean,
+  format: string,
 ): Promise<{ target: ResolvedEntity | null; ambiguous: boolean }> {
   // For raw IDs and file-like targets, delegate to resolveFileOrEntity (no ambiguity)
   if (isRawId(symbol) || looksFileLike(symbol)) {
@@ -175,7 +176,7 @@ async function resolveWithAmbiguity(
   }
 
   if (result.ambiguous) {
-    if (isJson) {
+    if (format === "json") {
       console.log(JSON.stringify({
         resolvedTarget: null,
         resolutionMode: "ambiguous",
@@ -183,6 +184,10 @@ async function resolveWithAmbiguity(
         systemPath: null,
         diagnostics: result.result.diagnostics ?? [],
       }, null, 2));
+    } else if (format === "llm") {
+      console.log(llmError("ambiguous_target", `Ambiguous symbol "${symbol}".`, [
+        ["candidates", result.result.candidates.map((c, i) => `${i + 1}:${c.name}`).join(",")],
+      ]));
     } else {
       printAmbiguous(symbol, result.result, opts);
     }
@@ -210,9 +215,35 @@ function humanizeBreadcrumb(nodes: Array<{ name: string; kind: string }>): strin
 
 // ── Output ──────────────────────────────────────────────────────────────────
 
+/** Render `ix locate` output as llm records: a `locate` header (or structured error) plus `note` lines. */
+export function renderLocateLlm(output: LocateOutput, symbol: string): string[] {
+  const t = output.resolvedTarget;
+  if (!t) {
+    return [llmError("unknown_target", `No graph entity found for "${symbol}".`)];
+  }
+  const lines = [llmLine("locate", [
+    ["target", t.name],
+    ["kind", t.kind],
+    ["id", typeof t.id === "string" ? t.id.slice(0, 8) : undefined],
+    ["path", t.path],
+    ["line_start", output.lineRange?.start],
+    ["line_end", output.lineRange?.end],
+    ["contained_in", output.container ? `${output.container.kind} ${output.container.name}` : undefined],
+    ["system_path", output.hasMapData && output.systemPath && output.systemPath.length > 0 ? output.systemPath.map((n) => n.name).join(",") : undefined],
+    ["stale", output.stale ? true : undefined],
+    ["mode", output.resolutionMode],
+  ])];
+  for (const d of output.diagnostics ?? []) lines.push(llmLine("note", [["text", d]]));
+  return lines;
+}
+
 function outputLocate(output: LocateOutput, symbol: string, format: string): void {
   if (format === "json") {
     console.log(JSON.stringify(output, null, 2));
+    return;
+  }
+  if (format === "llm") {
+    for (const line of renderLocateLlm(output, symbol)) console.log(line);
     return;
   }
 

--- a/ix-cli/src/cli/commands/search.ts
+++ b/ix-cli/src/cli/commands/search.ts
@@ -7,6 +7,23 @@ import { formatNodes, relativePath } from "../format.js";
 import { scoreCandidate } from "../resolve.js";
 import { applyRoleFilter, roleHint } from "../role-filter.js";
 import { stderr } from "../stderr.js";
+import { llmLine } from "../llm.js";
+
+/** Render `ix search` as llm records: a header line then one `node` row per hit (rank = order). */
+export function renderSearchLlm(
+  results: Array<{ name: string; kind: string; id?: string; path?: string; score?: number }>,
+  totalCandidates: number, diagnostics: Array<{ code: string; message: string }>,
+): string[] {
+  const lines = [llmLine("search", [["count", results.length], ["candidates", totalCandidates]])];
+  for (const r of results) {
+    lines.push(llmLine("node", [
+      ["name", r.name], ["kind", r.kind], ["id", r.id?.slice(0, 8)],
+      ["path", r.path], ["score", r.score],
+    ]));
+  }
+  for (const d of diagnostics) lines.push(llmLine("diagnostic", [["code", d.code], ["message", d.message]]));
+  return lines;
+}
 
 /** Structural kinds that should rank higher than incidental matches. */
 const STRUCTURAL_KINDS = new Set([
@@ -156,20 +173,33 @@ Examples:
       const trimmed = roleFilteredScored.slice(0, limit);
       const ranked = trimmed.map(s => s.node);
 
+      const diagnostics: { code: string; message: string }[] = [];
+      if (!opts.kind) {
+        diagnostics.push({
+          code: "unfiltered_search",
+          message: "Results may be broad. Use --kind to filter and boost structural matches.",
+        });
+      }
+      if (hiddenTestCount > 0) {
+        diagnostics.push({
+          code: "test_candidates_hidden",
+          message: roleHint(hiddenTestCount)!,
+        });
+      }
+
+      if (opts.format === "llm") {
+        const rows = trimmed.map((s, i) => ({
+          name: s.node.name || (s.node.attrs as any)?.name || "(unnamed)",
+          kind: s.node.kind,
+          id: s.node.id,
+          path: relativePath(s.node.provenance?.sourceUri) ?? undefined,
+          score: s.rank.score,
+        }));
+        for (const line of renderSearchLlm(rows, rawNodes.length, diagnostics)) console.log(line);
+        return;
+      }
+
       if (opts.format === "json") {
-        const diagnostics: { code: string; message: string }[] = [];
-        if (!opts.kind) {
-          diagnostics.push({
-            code: "unfiltered_search",
-            message: "Results may be broad. Use --kind to filter and boost structural matches.",
-          });
-        }
-        if (hiddenTestCount > 0) {
-          diagnostics.push({
-            code: "test_candidates_hidden",
-            message: roleHint(hiddenTestCount)!,
-          });
-        }
         console.log(JSON.stringify({
           results: trimmed.map((s, i) => ({
             id: s.node.id,

--- a/ix-cli/src/cli/format.ts
+++ b/ix-cli/src/cli/format.ts
@@ -130,9 +130,22 @@ export function formatContext(result: any, format: string): void {
   console.log();
 }
 
+/** Render a flat node list as llm `node` records. */
+export function renderNodesLlm(nodes: any[]): string[] {
+  return nodes.map((n) => llmLine("node", [
+    ["kind", n.kind],
+    ["id", typeof n.id === "string" ? n.id.slice(0, 8) : undefined],
+    ["name", n.name || n.attrs?.name || n.attrs?.title || "(unnamed)"],
+  ]));
+}
+
 export function formatNodes(nodes: any[], format: string): void {
   if (format === "json") {
     console.log(JSON.stringify(nodes, null, 2));
+    return;
+  }
+  if (format === "llm") {
+    for (const line of renderNodesLlm(nodes)) console.log(line);
     return;
   }
   if (nodes.length === 0) {
@@ -204,6 +217,17 @@ export function formatBugs(nodes: any[], format: string): void {
   }
 }
 
+/** Render patch records as llm `patch` lines. */
+export function renderPatchesLlm(patches: any[]): string[] {
+  return patches.map((p) => llmLine("patch", [
+    ["rev", p.rev],
+    ["id", p.patch_id?.slice(0, 12)],
+    ["intent", p.intent || undefined],
+    ["ts", p.timestamp],
+    ["source", relativePath(p.source?.uri) || undefined],
+  ]));
+}
+
 export function formatPatches(patches: any[], format: string): void {
   if (format === "json") {
     const compact = patches.map(p => ({
@@ -214,6 +238,10 @@ export function formatPatches(patches: any[], format: string): void {
       source: relativePath(p.source?.uri) || undefined,
     }));
     console.log(JSON.stringify(compact, null, 2));
+    return;
+  }
+  if (format === "llm") {
+    for (const line of renderPatchesLlm(patches)) console.log(line);
     return;
   }
   if (patches.length === 0) {
@@ -281,9 +309,30 @@ export function formatIntents(intents: any[], format: string): void {
   }
 }
 
+/** Render a revision diff as llm records: a header then one `change` row per entity change. */
+export function renderDiffLlm(result: any): string[] {
+  const changes = result.changes ?? [];
+  const lines = [llmLine("diff", [["from", result.fromRev], ["to", result.toRev], ["changes", changes.length]])];
+  for (const c of changes) {
+    const node = c.changeType === "removed" ? c.atFromRev : c.atToRev;
+    const name = node?.name || node?.attrs?.name || c.entityId?.substring(0, 8);
+    lines.push(llmLine("change", [
+      ["type", c.changeType],
+      ["kind", node?.kind],
+      ["name", name],
+      ["summary", c.summary || undefined],
+    ]));
+  }
+  return lines;
+}
+
 export function formatDiff(result: any, format: string): void {
   if (format === "json") {
     console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  if (format === "llm") {
+    for (const line of renderDiffLlm(result)) console.log(line);
     return;
   }
   console.log(chalk.cyan.bold(`\nDiff: rev ${result.fromRev} → ${result.toRev}`));
@@ -352,6 +401,17 @@ export interface TextResult {
   symbol_hint?: string;
 }
 
+/** Render lexical search hits as llm `match` records (one per line). */
+export function renderTextResultsLlm(results: TextResult[]): string[] {
+  return results.map((r) => llmLine("match", [
+    ["path", relativePath(r.path) ?? r.path],
+    ["line", r.line_start],
+    ["lang", r.language],
+    ["symbol", r.symbol_hint],
+    ["snippet", r.snippet.trim()],
+  ]));
+}
+
 export function formatTextResults(results: TextResult[], format: string): void {
   if (format === "json") {
     const compact = results.map(r => ({
@@ -359,6 +419,10 @@ export function formatTextResults(results: TextResult[], format: string): void {
       path: relativePath(r.path) ?? r.path,
     }));
     console.log(JSON.stringify(compact, null, 2));
+    return;
+  }
+  if (format === "llm") {
+    for (const line of renderTextResultsLlm(results)) console.log(line);
     return;
   }
   if (results.length === 0) {
@@ -531,9 +595,27 @@ export function formatEdgeResults(
   }
 }
 
+/** Render detected conflicts as llm `conflict` records. */
+export function renderConflictsLlm(conflicts: any[]): string[] {
+  const lines = [llmLine("conflicts", [["count", conflicts.length]])];
+  for (const c of conflicts) {
+    lines.push(llmLine("conflict", [
+      ["reason", c.reason],
+      ["recommendation", c.recommendation],
+      ["claim_a", c.claimA],
+      ["claim_b", c.claimB],
+    ]));
+  }
+  return lines;
+}
+
 export function formatConflicts(conflicts: any[], format: string): void {
   if (format === "json") {
     console.log(JSON.stringify(conflicts, null, 2));
+    return;
+  }
+  if (format === "llm") {
+    for (const line of renderConflictsLlm(conflicts)) console.log(line);
     return;
   }
   if (conflicts.length === 0) {


### PR DESCRIPTION
PR 3 of the #206 rollout — stacked on #233 (Tier 2). Completes the renderer work: **every** `--format`-capable command now emits compact llm output, or routes to `text` where output is verbatim source/prose.

## Tier 3 (`search`, `text`, `history`, `patches`)
- Shared renderers in `format.ts` (`renderNodesLlm`, `renderTextResultsLlm`, `renderPatchesLlm`) wire `formatNodes` / `formatTextResults` / `formatPatches`.
- `search`: dedicated header + scored `node` rows + `diagnostic` rows. `history`: header + `patch` rows with a structured resolution-error path.

## Tier 4 (`entity`, `locate`, `diff`, `conflicts`)
- `entity`: header + one `edge` row per edge. `conflicts` / `diff` via shared `renderConflictsLlm` / `renderDiffLlm`. `locate`: a `locate` record (line range, container, system path) with structured `ambiguous_target` / `unknown_target` errors.
- `diff`: structured `--summary` and graph-change records; `--content` (verbatim textual diff, like `ix read`) routes to text. Resolution failures emit `unresolved_target`.

## Routing-to-text commands
`read`, `explain`, `doctor`, `status`, `savings`, and `diff --content` route `--format llm` to `text` — their output is source code or prose that compression would only damage. Documented in `docs/llm-format.md`.

## Verification
- `tsc --noEmit` clean. 10 new unit tests (5 + 5); full suite 485 pass, 1 pre-existing failure (`resolver-type-preference`).
- Verified live on the isolated `ix-ml-e2e` backend: `search`, `text`, `entity`, `locate` (file), `conflicts` all render correctly; structured errors confirmed. `diff`'s endpoint isn't provisioned on the minimal local backend (500), so its renderer is covered by unit tests only.

With this, all four tiers of #206 are implemented across PRs #232 → #233 → this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)