### PR TITLE
fix(cli): emit crosscut in map --format llm (parity with json)

### DIFF
--- a/ix-cli/src/cli/__tests__/llm-renderers.test.ts
+++ b/ix-cli/src/cli/__tests__/llm-renderers.test.ts
@@ -54,6 +54,15 @@ describe("renderMapLlm", () => {
     expect(lines[1]).not.toContain("children=");
     expect(lines[1]).not.toContain("signals=");
     expect(lines[1]).not.toContain("parent=");
+    expect(lines[1]).not.toContain("crosscut=");
+  });
+
+  it("emits crosscut only when above the 0.01 threshold (parity with json)", () => {
+    const result: MapResult = { file_count: 1, region_count: 1, levels: 1, map_rev: 1, regions: [], hierarchy: [] };
+    const cross = captureLog(() => renderMapLlm(result, [region({ id: "x", label: "X", crosscut_score: 0.153 })]));
+    expect(cross[1]).toContain("crosscut=0.15");
+    const noCross = captureLog(() => renderMapLlm(result, [region({ id: "y", label: "Y", crosscut_score: 0.005 })]));
+    expect(noCross[1]).not.toContain("crosscut=");
   });
 });
 

--- a/ix-cli/src/cli/commands/map.ts
+++ b/ix-cli/src/cli/commands/map.ts
@@ -297,6 +297,9 @@ export function renderMapLlm(result: MapResult, regions: MapRegion[]): void {
       ["children", r.child_region_count > 0 ? r.child_region_count : undefined],
       ["cohesion", roundFloat(r.cohesion)],
       ["coupling", roundFloat(r.external_coupling)],
+      // crosscut_score is emitted only when meaningful (>0.01), matching the
+      // compact JSON; consumers (e.g. the ix-architecture skill) gate on it.
+      ["crosscut", r.crosscut_score > 0.01 ? roundFloat(r.crosscut_score) : undefined],
       ["confidence", roundFloat(r.confidence)],
       ["signals", r.dominant_signals.length > 0 ? r.dominant_signals.join(",") : undefined],
     ]));


### PR DESCRIPTION
Follow-up to #206. `renderMapLlm` dropped `crosscut_score`, but:
- the compact json (`compactRegion`) keeps it when `> 0.01`, and
- the `ix-architecture` skill (Claude + Codex plugins) gates its early-stop "structurally healthy" check on `crosscut_score <= 0.1`.

Under `--format llm` the field was always absent, so that skill silently lost the cross-cutting signal and could mis-report a system as healthy. This emits `crosscut=<n>` when `> 0.01`, matching the json threshold exactly.

Found while adopting `--format llm` in the plugins (ix-claude-plugin#23 / ix-codex-plugin#5). Renderer's other dropped fields (`boundary_ratio`, `interface_node_count`) are not consumed by any skill, so they stay omitted.

tsc clean; new unit test covers crosscut above/below the 0.01 threshold; existing renderer tests unchanged (they use crosscut_score=0 → omitted).