### PR TITLE
Fix co-ingest: ambiguous cross-repo symbol resolved to a phantom same-file dst (Ix#225)

### DIFF
--- a/core-ingestion/src/__tests__/resolveEdges.test.ts
+++ b/core-ingestion/src/__tests__/resolveEdges.test.ts
@@ -777,5 +777,38 @@ describe('resolveEdges', () => {
         { repoOf, packageOf: () => undefined });
       expect(edges.filter(e => repoOf(e.srcFilePath) !== repoOf(e.dstFilePath))).toEqual([]);
     });
+
+    // Ambiguous cross-repo symbol: `coreFn` is defined identically in repo-a AND
+    // repo-c. A bare call from repo-b must fold onto the member repo-b DEPENDS on,
+    // not be skipped as ambiguous (which left it unresolved and the patch builder
+    // then fell back to a phantom same-file dst = a dangling edge). Ix#225.
+    const coreFileIn = (repo: string) =>
+      fileResult(`${repo}/src/core.ts`, SupportedLanguages.TypeScript, [
+        entity('coreFn', SupportedLanguages.TypeScript),
+      ]);
+    const bareCaller = () =>
+      fileResult('repo-b/src/index.ts', SupportedLanguages.TypeScript,
+        [entity('run', SupportedLanguages.TypeScript)],
+        [{ srcName: 'run', dstName: 'coreFn', predicate: 'CALLS' }]);
+
+    it('disambiguates an ambiguous cross-repo symbol via the declared dependency (repo-b depends on repo-a, not repo-c)', () => {
+      const edges = resolveEdges([bareCaller(), coreFileIn('repo-a'), coreFileIn('repo-c')], undefined, undefined,
+        { repoOf, packageOf: () => undefined, declaredRepoDeps: { 'repo-b': ['repo-a'] } });
+      const cross = edges.filter(e => e.predicate === 'CALLS' && repoOf(e.srcFilePath) !== repoOf(e.dstFilePath));
+      expect(cross).toHaveLength(1);
+      expect(cross[0]).toMatchObject({ srcName: 'run', dstName: 'coreFn', dstFilePath: 'repo-a/src/core.ts' });
+    });
+
+    it('stays under-connected (no cross-repo edge) when the source repo depends on BOTH defining repos (genuinely ambiguous)', () => {
+      const edges = resolveEdges([bareCaller(), coreFileIn('repo-a'), coreFileIn('repo-c')], undefined, undefined,
+        { repoOf, packageOf: () => undefined, declaredRepoDeps: { 'repo-b': ['repo-a', 'repo-c'] } });
+      expect(edges.filter(e => e.predicate === 'CALLS' && repoOf(e.srcFilePath) !== repoOf(e.dstFilePath))).toEqual([]);
+    });
+
+    it('emits no cross-repo edge to an ambiguous symbol when the source repo depends on NEITHER defining repo', () => {
+      const edges = resolveEdges([bareCaller(), coreFileIn('repo-a'), coreFileIn('repo-c')], undefined, undefined,
+        { repoOf, packageOf: () => undefined });
+      expect(edges.filter(e => e.predicate === 'CALLS' && repoOf(e.srcFilePath) !== repoOf(e.dstFilePath))).toEqual([]);
+    });
   });
 });

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -2345,6 +2345,26 @@ export function resolveEdges(
       }
     }
   }
+  // Disambiguate multiple candidates using the declared-dependency graph: a symbol
+  // defined identically in several members (e.g. two repos each export `init`)
+  // resolves to the one the SOURCE repo actually depends on. Same-repo and
+  // unknown-repo candidates are always kept; cross-repo candidates survive only if
+  // the source repo depends on their repo. This mirrors the post-resolution
+  // cross-repo gate below, but is applied DURING resolution so an ambiguous-by-name
+  // match folds onto the real cross-repo node instead of being skipped (which left
+  // the call unresolved -> a phantom same-file dst / dangling edge, Ix#225). No-op
+  // for single-repo ingests (no repoDeps) and for unambiguous matches (<= 1).
+  const narrowByRepoDeps = (candidates: string[], srcFilePath: string): string[] => {
+    if (!repoOf || !repoDeps || candidates.length <= 1) return candidates;
+    const sr = repoOf(srcFilePath);
+    if (sr === undefined) return candidates;
+    const kept = candidates.filter(fp => {
+      const dr = repoOf!(fp);
+      if (dr === undefined || dr === sr) return true;
+      return repoDeps!.get(sr)?.has(dr) === true;
+    });
+    return kept.length > 0 ? kept : candidates;
+  };
   // fileQKeys: seed from global index (cross-batch files), then batch entries override.
   // Mirrors the entityQKey computation in buildPatch so nodeIds match exactly.
   const fileQKeys = globalIndex
@@ -2921,7 +2941,7 @@ export function resolveEdges(
       for (const fp of importedFilePaths) {
         if (fileHasSymbol.get(fp)?.has(dstName)) importMatches.push(fp);
       }
-      const narrowedImportMatches = narrowCCandidates(importMatches, srcFilePath, srcLanguage, srcName, dstName);
+      const narrowedImportMatches = narrowByRepoDeps(narrowCCandidates(importMatches, srcFilePath, srcLanguage, srcName, dstName), srcFilePath);
 
       if (narrowedImportMatches.length === 1) {
         const fp = narrowedImportMatches[0];
@@ -2948,7 +2968,7 @@ export function resolveEdges(
       for (const fp of transitiveFilePaths) {
         if (fileHasSymbol.get(fp)?.has(dstName)) transitiveMatches.push(fp);
       }
-      const narrowedTransitiveMatches = narrowCCandidates(transitiveMatches, srcFilePath, srcLanguage, srcName, dstName);
+      const narrowedTransitiveMatches = narrowByRepoDeps(narrowCCandidates(transitiveMatches, srcFilePath, srcLanguage, srcName, dstName), srcFilePath);
 
       if (narrowedTransitiveMatches.length === 1) {
         const fp = narrowedTransitiveMatches[0];
@@ -2978,7 +2998,7 @@ export function resolveEdges(
       }
       stats.globalCandidateTotal += globalMatches.length;
 
-      const resolvedMatches = narrowCCandidates(globalMatches, srcFilePath, srcLanguage, srcName, dstName);
+      const resolvedMatches = narrowByRepoDeps(narrowCCandidates(globalMatches, srcFilePath, srcLanguage, srcName, dstName), srcFilePath);
 
       if (resolvedMatches.length === 1) {
         const fp = resolvedMatches[0];


### PR DESCRIPTION
## Problem

In a multi-repo co-ingest, a cross-repo CALL to a symbol **defined identically in two members** (e.g. two repos each export `init`/`coreFn`) was left unresolved. `resolveEdges`' global/transitive fallback saw more than one candidate, declared it ambiguous, and skipped it. The patch builder then fell back to a **same-file dst** (`patch-builder.ts`), emitting a phantom/dangling edge to a node that does not exist in the caller's file.

The declared-dependency graph already knew which member the caller's repo depends on, but it was only applied as a **post-resolution filter**, too late: the edge had already been dropped during resolution.

## Fix

Apply the dependency graph **during** resolution. A new `narrowByRepoDeps` narrows a multi-candidate set to same-repo + depended-on-repo candidates before the single-match check, so an ambiguous-by-name match folds onto the real cross-repo node instead of being skipped.

- **No-op for single-repo** ingests (no `repoDeps`) and unambiguous matches (≤ 1 candidate).
- **Never narrows to empty**; a caller that depends on *both* defining repos stays genuinely ambiguous and under-connected (favor under-connection over a wrong guess).
- Mirrors the existing post-resolution cross-repo gate, so it can never add an edge that gate would drop.

## Verification

- **Repro proven**: the new `disambiguate` test fails on `main`, passes with the fix.
- 3 new `resolveEdges` tests (disambiguate / depends-on-both / depends-on-neither).
- **Real multi-repo A/B** (DB-free resolver harness): the ambiguous fixture recovers the genuine `svcb → svca` edge (main: edge lost); the `go`/`js`/`rust` genuine + trap fixtures are **byte-identical** main vs branch (no regression, the false-positive trap stays 0).
- core-ingestion 185 pass (+3), ix-cli 505 pass, `tsc` clean.

Core-ingestion only; no backend or schema change.