### PR TITLE
Couple co-ingested repos on a package import — recall fix (Ix#225)

### DIFF
--- a/core-ingestion/src/__tests__/resolveEdges.test.ts
+++ b/core-ingestion/src/__tests__/resolveEdges.test.ts
@@ -811,4 +811,45 @@ describe('resolveEdges', () => {
       expect(edges.filter(e => e.predicate === 'CALLS' && repoOf(e.srcFilePath) !== repoOf(e.dstFilePath))).toEqual([]);
     });
   });
+
+  // Recall: a genuine dependency that imports another member's PACKAGE must couple
+  // the repos even when the consumer uses a dynamic/property API that resolves no
+  // symbol call (the real-world ora -> chalk via `chalk[color]` case). The import
+  // specifier IS the dependency, so emit a cross-repo IMPORTS edge to the dep
+  // member's entry file. Precision: relative imports and non-member packages must
+  // NOT couple, and single-repo resolution is a no-op.
+  describe('package-import cross-repo edge', () => {
+    const repoOf = (fp: string) => fp.split('/')[0];
+    const packageOf = (mod: string) => {
+      if (!mod || mod.startsWith('.') || mod.startsWith('/')) return undefined;
+      return (mod === '@acme/widget' || mod === 'widget') ? 'lib' : undefined;
+    };
+    const lib = () => fileResult('lib/core.ts', SupportedLanguages.TypeScript, [entity('makeWidget', SupportedLanguages.TypeScript)]);
+    // dstName 'widget' matches no in-repo file, so resolution falls to the package path.
+    const consumer = (importRaw: string) =>
+      fileResult('app/main.ts', SupportedLanguages.TypeScript,
+        [entity('run', SupportedLanguages.TypeScript)],
+        [{ srcName: 'main.ts', dstName: 'widget', predicate: 'IMPORTS', importRaw }]);
+
+    it('couples a consumer to a dep member on a package import even with no resolved symbol call', () => {
+      const edges = resolveEdges([consumer('@acme/widget'), lib()], undefined, undefined, { repoOf, packageOf });
+      const cross = edges.filter(e => repoOf(e.srcFilePath) !== repoOf(e.dstFilePath));
+      expect(cross).toEqual([expect.objectContaining({ srcFilePath: 'app/main.ts', dstFilePath: 'lib/core.ts', predicate: 'IMPORTS' })]);
+    });
+
+    it('does NOT couple on a relative import (./widget is intra-repo, not a member package)', () => {
+      const edges = resolveEdges([consumer('./widget'), lib()], undefined, undefined, { repoOf, packageOf });
+      expect(edges.filter(e => repoOf(e.srcFilePath) !== repoOf(e.dstFilePath))).toEqual([]);
+    });
+
+    it('does NOT couple on an import of a non-member package', () => {
+      const edges = resolveEdges([consumer('left-pad'), lib()], undefined, undefined, { repoOf, packageOf });
+      expect(edges.filter(e => repoOf(e.srcFilePath) !== repoOf(e.dstFilePath))).toEqual([]);
+    });
+
+    it('is a no-op for single-repo resolution (no co-ingest opts)', () => {
+      const edges = resolveEdges([consumer('@acme/widget'), lib()]);
+      expect(edges.filter(e => repoOf(e.srcFilePath) !== repoOf(e.dstFilePath) && e.predicate === 'IMPORTS')).toEqual([]);
+    });
+  });
 });

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -2365,6 +2365,32 @@ export function resolveEdges(
     });
     return kept.length > 0 ? kept : candidates;
   };
+
+  // A deterministic "entry file" per member repo: the file a cross-repo package
+  // import couples to when no specific symbol resolves (e.g. a dynamic/property
+  // API like `chalk[color]`). Prefers an index/main-style basename, then the
+  // shallowest path, then lexical order — a total order, so it is independent of
+  // the parse/iteration order. Only built for co-ingest (repoOf present).
+  let entryFileOf: Map<string, string> | undefined;
+  if (repoOf) {
+    entryFileOf = new Map<string, string>();
+    const ENTRY_NAMES = new Set(['index', 'main', 'mod', 'lib', '__init__', 'app', 'init']);
+    const entryScore = (fp: string): [number, number, string] => {
+      const norm = fp.replace(/\\/g, '/');
+      const base = nodePath.basename(norm).replace(/\.[^.]+$/, '').toLowerCase();
+      return [ENTRY_NAMES.has(base) ? 0 : 1, norm.split('/').length, norm];
+    };
+    const better = (a: [number, number, string], b: [number, number, string]) =>
+      a[0] !== b[0] ? a[0] < b[0] : a[1] !== b[1] ? a[1] < b[1] : a[2] < b[2];
+    const bestScore = new Map<string, [number, number, string]>();
+    for (const r of results) {
+      const repo = repoOf(r.filePath);
+      if (repo === undefined) continue;
+      const s = entryScore(r.filePath);
+      const cur = bestScore.get(repo);
+      if (!cur || better(s, cur)) { bestScore.set(repo, s); entryFileOf.set(repo, r.filePath); }
+    }
+  }
   // fileQKeys: seed from global index (cross-batch files), then batch entries override.
   // Mirrors the entityQKey computation in buildPatch so nodeIds match exactly.
   const fileQKeys = globalIndex
@@ -2855,8 +2881,30 @@ export function resolveEdges(
           stats.skippedAmbiguous++;
           continue;
         }
-        // importMatches.length === 0: if dstName is a PascalCase symbol (class/function name
-        // captured via import.name from "from X import ClassName"), fall through to Tier 2/3
+        // importMatches.length === 0: no in-repo file resolves the import.
+        // Cross-repo package import (co-ingest): the specifier names another
+        // co-ingested member's published package (packageOf), so emit an IMPORTS
+        // edge to that member's entry file. This couples genuinely-dependent repos
+        // even when the consumer uses a dynamic/property API that resolves no
+        // symbol call (e.g. ora -> chalk via `chalk[color]`). Ground truth: the
+        // import specifier IS the dependency. Down-weighted by G3 at the map layer;
+        // the post-resolution dep gate keeps it (the same import seeds repoDeps).
+        // No-op for single-repo (no repoOf/entryFileOf).
+        if (repoOf && packageOf && entryFileOf) {
+          const srcRepo = repoOf(srcFilePath);
+          const mod = typeof rel.importRaw === 'string' ? rel.importRaw : rel.dstName;
+          const depRepo = mod ? packageOf(mod) : undefined;
+          if (srcRepo !== undefined && depRepo !== undefined && depRepo !== srcRepo) {
+            const entryFp = entryFileOf.get(depRepo);
+            if (entryFp && entryFp !== srcFilePath) {
+              resolved.push({ srcFilePath, srcName: rel.srcName, dstFilePath: entryFp, dstName: rel.dstName, dstQualifiedKey: fileEntityName(entryFp), predicate: 'IMPORTS', confidence: 0.7 });
+              stats.resolvedImport++;
+              continue;
+            }
+          }
+        }
+        // if dstName is a PascalCase symbol (class/function name captured via
+        // import.name from "from X import ClassName"), fall through to Tier 2/3
         // symbol resolution so the edge connects to the actual class node rather than a file.
         if (srcLanguage !== SupportedLanguages.Python || !/^[A-Z]/.test(rel.dstName)) continue;
         // fall through to Tier 1b → Tier 2 → Tier 3 below


### PR DESCRIPTION
## Problem

A genuine cross-repo dependency that imports another member's **package** produced **zero** edges when the consumer used a dynamic / property API that resolves no symbol call. Measured on a real labeled corpus (chalk + its consumers ora/boxen + 4 unrelated repos), recall was **0.50**: `boxen→chalk` resolved (via a `chalk.dim` member call) but `ora→chalk` was missed entirely (ora uses `chalk[color]`), so ora would never cluster with chalk.

## Fix

In `resolveEdges`' IMPORTS branch, when no in-repo file resolves the import **and** the specifier names another co-ingested member's published package (`packageOf`), emit an IMPORTS edge to that member's **entry file**. The import specifier *is* the dependency — ground truth, not a guess.

- Entry file chosen **deterministically** (index/main-style basename → shallowest path → lexical), independent of parse order.
- Down-weighted by G3 (cross-repo IMPORTS ×0.3) at the map layer; the existing post-resolution dep gate keeps it (the same import seeds `repoDeps`).
- **No-op for single-repo** ingests (no `repoOf`/`entryFileOf`).

## Measured (new `map_eval` harness, real + synthetic corpora)

- Corpus recall **0.50 → 1.00**, precision **stays 1.000** — all unrelated pairs 0, including ora↔boxen (share chalk but don't import each other).
- Synthetic fixtures: genuine pairs gain real IMPORTS edges; **traps (`js-trap`, `go-unrelated`) stay 0**.
- Backend e2e: `ora→chalk` (4) + `boxen→chalk` (2) edges land on **real nodes, 0 dangling**; re-map ×3 and full reset+reingest+remap **byte-identical** (determinism held).
- +4 `resolveEdges` tests; core-ingestion **189 pass / 39 baseline**, ix-cli **505**.

Core-ingestion only; no backend or schema change.