### PR TITLE
Gate cross-repo edges on production deps only, not dev/test deps (Ix#225)

### DIFF
--- a/ix-cli/src/cli/__tests__/system.test.ts
+++ b/ix-cli/src/cli/__tests__/system.test.ts
@@ -69,6 +69,32 @@ describe("Maven name + declared-dependency graph", () => {
     expect(readPackageDeps(nodePath.join(root, "consumer"))).toContain("acme-lib");
   });
 
+  it("readPackageDeps returns PRODUCTION deps only (dev/test deps are not architectural coupling)", () => {
+    const d = nodePath.join(root, "proddep");
+    fs.mkdirSync(d, { recursive: true });
+    fs.writeFileSync(nodePath.join(d, "package.json"), JSON.stringify({
+      name: "proddep",
+      dependencies: { "real-dep": "^1.0.0" },
+      peerDependencies: { "peer-dep": "*" },
+      optionalDependencies: { "opt-dep": "^1.0.0" },
+      devDependencies: { "test-dep": "^1.0.0" },
+    }));
+    const deps = readPackageDeps(d);
+    expect(deps).toEqual(expect.arrayContaining(["real-dep", "peer-dep", "opt-dep"]));
+    expect(deps).not.toContain("test-dep");
+  });
+
+  it("readPackageDeps excludes Cargo [dev-dependencies] and [build-dependencies]", () => {
+    const d = nodePath.join(root, "rustdep");
+    fs.mkdirSync(d, { recursive: true });
+    fs.writeFileSync(nodePath.join(d, "Cargo.toml"),
+      '[package]\nname = "rustdep"\n\n[dependencies]\nserde = "1"\n\n[dev-dependencies]\ncriterion = "0.5"\n\n[build-dependencies]\ncc = "1"\n');
+    const deps = readPackageDeps(d);
+    expect(deps).toContain("serde");
+    expect(deps).not.toContain("criterion");
+    expect(deps).not.toContain("cc");
+  });
+
   it("detectSystem builds the ground-truth repoDeps graph (consumer -> lib)", () => {
     const d = detectSystem(root)!;
     expect(d.repoDeps["consumer"]).toContain("lib");

--- a/ix-cli/src/cli/system.ts
+++ b/ix-cli/src/cli/system.ts
@@ -197,17 +197,29 @@ export function readPackageDeps(dir: string): string[] {
   };
   const add = (n: unknown) => { if (typeof n === "string" && n.trim()) deps.add(n.trim()); };
 
+  // PRODUCTION deps only. The declared-dependency graph gates cross-repo edges,
+  // i.e. it asserts "repo A's code genuinely depends on repo B's code." dev/test
+  // and build-tool deps are NOT production architecture: every repo dev-depends on
+  // its test/build tooling, and treating those as coupling falsely merges
+  // unrelated repos into one system (e.g. express dev-depends on morgan only for
+  // its tests; chalk dev-depends on execa; lodash dev-depends on chalk) and lets
+  // symbol-name collisions slip the gate. So devDependencies / Cargo
+  // [dev-dependencies] / [build-dependencies] are intentionally excluded; runtime
+  // peer/optional deps are kept (they are real runtime coupling).
   const pkg = read("package.json");                                  // JS / TS
   if (pkg) { try {
     const j = JSON.parse(pkg);
-    for (const s of ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"])
+    for (const s of ["dependencies", "peerDependencies", "optionalDependencies"])
       if (j[s] && typeof j[s] === "object") for (const k of Object.keys(j[s])) add(k);
   } catch { /* ignore */ } }
 
   const cargo = read("Cargo.toml");                                  // Rust
   if (cargo) {
-    for (const sect of cargo.matchAll(/\[(?:dev-|build-)?dependencies(?:\.[^\]\n]+)?\]([\s\S]*?)(?:\n\[|$)/g)) {
-      for (const dm of sect[1].matchAll(/^\s*([A-Za-z0-9_-]+)\s*(?:=|\.)/gm)) add(dm[1]);
+    // Match [dependencies], [dependencies.x], [target.'cfg'.dependencies], but
+    // skip [dev-dependencies] / [build-dependencies] (not runtime coupling).
+    for (const sect of cargo.matchAll(/\[([^\]\n]*\bdependencies\b[^\]\n]*)\]([\s\S]*?)(?:\n\[|$)/g)) {
+      if (/\b(?:dev|build)-dependencies\b/.test(sect[1])) continue;
+      for (const dm of sect[2].matchAll(/^\s*([A-Za-z0-9_-]+)\s*(?:=|\.)/gm)) add(dm[1]);
     }
   }
 


### PR DESCRIPTION
## Problem

The declared-dependency graph gates cross-repo edges — it asserts "repo A's code genuinely depends on repo B's code." But `readPackageDeps` included **devDependencies** (and Cargo `[dev-dependencies]`/`[build-dependencies]`), so test/build tooling counted as architectural coupling. Every repo dev-depends on its test deps, which (a) falsely groups unrelated repos into one system and (b) lets symbol-name collisions slip the gate.

Found by **stress-testing the co-ingest resolver on a 15-repo corpus**: `express` dev-depends on `morgan` (only for its tests), so a symbol collision (`express compileTrust → morgan compile`) survived the gate. Likewise `chalk` dev-depends on `execa`, `lodash` dev-depends on `chalk`. None is production architecture.

## Fix

`readPackageDeps` now returns `dependencies` + `peerDependencies` + `optionalDependencies` (real runtime coupling) and **excludes** `devDependencies` / Cargo `dev-`/`build-dependencies`.

## Measured (`map_eval`, 15 real repos, 105 pairs)

- Precision **0.625 → 1.000**, recall **stays 1.000**.
- Genuine production deps preserved: `flask→click`, `express→debug/cookie`, `ora/boxen→chalk`, `morgan→debug`.
- Dev-dep false pairs gone: `express↔morgan`, `chalk↔execa`, `lodash↔chalk`.
- Deterministic + order-independent; synthetic fixtures unchanged (traps stay 0).
- +2 system tests; ix-cli **507**.

CLI-only; no backend or schema change.