### PR TITLE
fix(pro-loader): await the async Pro command registrar

### DIFF
--- a/ix-cli/src/cli/register/pro-loader.ts
+++ b/ix-cli/src/cli/register/pro-loader.ts
@@ -10,7 +10,14 @@ export async function tryLoadProCommands(program: Command): Promise<boolean> {
     const mod = await dynamicImport("@ix/pro/register");
 
     if (mod?.registerProCommands) {
-      mod.registerProCommands(program);
+      // registerProCommands is async: it dynamically imports each command so
+      // one broken command can't disable them all. It MUST be awaited here.
+      // main.ts calls program.parse() synchronously right after this resolves,
+      // so without the await the dynamic imports are still pending and NO pro
+      // command is registered in time — every `ix <pro-cmd>` then fails with
+      // "unknown command". (Older sync versions of registerProCommands did not
+      // need the await; awaiting is safe for both.)
+      await mod.registerProCommands(program);
       return true;
     }
 


### PR DESCRIPTION
## Summary

The Pro plugin's command registrar is async, but the loader called it without `await`. Since `main.ts` runs `program.parse()` synchronously right after `tryLoadProCommands` resolves, registration was still pending at parse time and Pro commands were not available.

This adds the missing `await`. It is safe whether the registrar is sync or async.

## Verification

Built and ran the CLI against a locally-linked Pro plugin: with the `await`, Pro commands register correctly; without it, they are absent.