### PR TITLE
Path 2: separate-ingest stitcher — grouping + reads (Ix#225)

### DIFF
--- a/core-ingestion/src/patch-builder.ts
+++ b/core-ingestion/src/patch-builder.ts
@@ -53,6 +53,16 @@ function makeIds(workspaceId: string) {
   };
 }
 
+/**
+ * The node id of a file's `file` node, for a SOLO ingest (no member prefix).
+ * Exposed so the Path-2 stitcher (CLI) can reference a repo's entry node and its
+ * importing nodes by the SAME id buildPatch produces — never a recomputed guess.
+ * Mirrors buildPatch: the file node's key is the file entity name = basename.
+ */
+export function fileNodeId(workspaceId: string, filePath: string): string {
+  return makeIds(workspaceId).nodeId(filePath, nodePath.basename(filePath));
+}
+
 // ---------------------------------------------------------------------------
 // Source type from file extension
 // ---------------------------------------------------------------------------

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -15,7 +15,7 @@ import { resolveGitHubToken } from '../github/auth.js';
 import { parseGitHubRepo, fetchGitHubData } from '../github/fetch.js';
 import { loadIngestionModules } from './ingestion-loader.js';
 import { ensureWorkspaceIdState } from '../bootstrap.js';
-import { detectSystem, repoWorkspaceIdFor, lookupPackage } from '../system.js';
+import { detectSystem, repoWorkspaceIdFor, lookupPackage, readPackageNames, readPackageDeps } from '../system.js';
 import {
   deterministicId,
   transformIssue,
@@ -404,7 +404,7 @@ export async function ingestFiles(
   const mapMode = opts.mapMode === true;
   const trueStart = performance.now();
 
-  const [{ parseFile, resolveEdges, isGrammarSupported }, { buildPatchWithResolution }, { languageFromPath }] = await loadIngestionModules();
+  const [{ parseFile, resolveEdges, isGrammarSupported }, { buildPatchWithResolution, fileNodeId }, { languageFromPath }] = await loadIngestionModules();
   const moduleLoadMs = Math.round(performance.now() - trueStart);
 
 
@@ -480,6 +480,56 @@ export async function ingestFiles(
   const packageOf = (mod: string): string | undefined => lookupPackage(packageRegistry, mod);
   const declaredRepoDeps = detectedSystem?.repoDeps;
   const resolveOpts = systemId ? { repoOf, packageOf, declaredRepoDeps } : undefined;
+
+  // ── Path-2 separate-ingest stitcher (Ix#225 Half A) ──────────────────
+  // Co-ingest already forms cross-repo edges in-batch, so the stitcher only runs
+  // for a SOLO ingest: it registers this repo's published packages (provides) and
+  // its production-dep external imports (consumes), and the backend joins them
+  // bidirectionally against other separately-ingested repos to recreate the
+  // cross-repo IMPORTS edges. Production-dep gated (mirrors #244): an import only
+  // counts as a consume if the package is a declared production dependency.
+  const stitchEnabled = systemId === undefined;
+  const stitchProdDeps = stitchEnabled ? new Set<string>(readPackageDeps(workspaceRoot)) : new Set<string>();
+  const stitchConsumes: Array<{ name: string; consumerNodeId: string }> = [];
+  const stitchConsumeSeen = new Set<string>();
+  const stitchFiles: string[] = [];
+  const specToPkg = (spec: string | undefined): string | null => {
+    if (!spec || spec.startsWith('.') || spec.startsWith('/')) return null;
+    if (spec.startsWith('@')) { const parts = spec.split('/'); return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : null; }
+    return spec.split('/')[0] || null;
+  };
+  const collectStitch = (parsedFiles: Array<{ filePath: string; relationships?: Array<{ predicate: string; dstName?: string; importRaw?: string }> }>): void => {
+    for (const p of parsedFiles) {
+      stitchFiles.push(p.filePath);
+      for (const rel of (p.relationships ?? [])) {
+        if (rel.predicate !== 'IMPORTS') continue;
+        const pkg = specToPkg(typeof rel.importRaw === 'string' ? rel.importRaw : rel.dstName);
+        if (!pkg || !stitchProdDeps.has(pkg)) continue;
+        const consumerNodeId = fileNodeId(workspaceId, p.filePath);
+        const k = `${pkg} ${consumerNodeId}`;
+        if (stitchConsumeSeen.has(k)) continue;
+        stitchConsumeSeen.add(k);
+        stitchConsumes.push({ name: pkg, consumerNodeId });
+      }
+    }
+  };
+  // Deterministic entry file (index/main basename -> shallowest -> lexical): the
+  // node a cross-repo import couples to. Mirrors resolveEdges' entryFileOf so a
+  // stitched edge targets the SAME node a co-ingest would have.
+  const pickEntryFile = (files: string[]): string | undefined => {
+    const ENTRY = new Set(['index', 'main', 'mod', 'lib', '__init__', 'app', 'init']);
+    let best: string | undefined;
+    let bestScore: [number, number, string] | undefined;
+    for (const f of files) {
+      const norm = f.replace(/\\/g, '/');
+      const base = (norm.split('/').pop() ?? '').replace(/\.[^.]+$/, '').toLowerCase();
+      const score: [number, number, string] = [ENTRY.has(base) ? 0 : 1, norm.split('/').length, norm];
+      if (!bestScore || score[0] < bestScore[0] ||
+          (score[0] === bestScore[0] && (score[1] < bestScore[1] ||
+          (score[1] === bestScore[1] && score[2] < bestScore[2])))) { best = f; bestScore = score; }
+    }
+    return best;
+  };
   if (systemId && debug) {
     const depCount = declaredRepoDeps ? Object.values(declaredRepoDeps).reduce((a, d) => a + d.length, 0) : 0;
     process.stderr.write(`[multi-repo] system "${detectedSystem!.name}" (${systemId}) members=${detectedSystem!.members.join(', ')} packages=${Object.keys(packageRegistry).length} declaredDeps=${depCount}\n`);
@@ -843,6 +893,7 @@ export async function ingestFiles(
         const resolveStart = performance.now();
         const resolvedEdges = resolveEdgesFn!(batch.map(f => f.parsed), resolveStats, globalIndex, resolveOpts);
         resolveEdgesMs = Math.round(performance.now() - resolveStart);
+        if (stitchEnabled) collectStitch(batch.map(f => f.parsed));
         const batchEdgesByFile = new Map<string, any[]>();
         for (const edge of resolvedEdges) {
           let arr = batchEdgesByFile.get(edge.srcFilePath);
@@ -912,6 +963,7 @@ export async function ingestFiles(
         const resolveStart = performance.now();
         const resolvedEdges = resolveEdgesFn!(allParsed.map(f => f.parsed), resolveStats, globalIndex, resolveOpts);
         resolveEdgesMs = Math.round(performance.now() - resolveStart);
+        if (stitchEnabled) collectStitch(allParsed.map(f => f.parsed));
         const edgesByFile = new Map<string, any[]>();
         for (const edge of resolvedEdges) {
           let arr = edgesByFile.get(edge.srcFilePath);
@@ -1179,6 +1231,30 @@ export async function ingestFiles(
         if (debug) process.stderr.write(`  Cleaned up pre-migration nodes under ${previousWorkspaceId}.\n`);
       } catch (err) {
         if (debug) process.stderr.write(`  [migration cleanup skipped] ${err}\n`);
+      }
+    }
+
+    // Path-2 stitch (Ix#225 Half A): register this repo's provides/consumes and
+    // write the cross-repo IMPORTS edges to other separately-ingested repos.
+    // Best-effort: a failure (or an older backend with no /v1/stitch) never fails
+    // the ingest. Collection is over the files actually parsed this run, so it is
+    // only COMPLETE on a full ingest. Gating on filesSkipped === 0 means a partial
+    // incremental re-map (some files mtime-skipped) leaves the prior full
+    // registration intact rather than overwriting it with a partial set; a fresh
+    // map, `--force`, or a post-reset re-map re-registers. (Incremental registry
+    // updates that touch only changed files are a future refinement.)
+    if (stitchEnabled && filesSkipped === 0 && stitchFiles.length > 0 && parseErrors === 0) {
+      try {
+        const entry = pickEntryFile(stitchFiles);
+        const provides = entry
+          ? readPackageNames(workspaceRoot).map(name => ({ name, entryNodeId: fileNodeId(workspaceId, entry), entryUri: entry }))
+          : [];
+        if (provides.length > 0 || stitchConsumes.length > 0) {
+          const res = await client.stitch({ workspaceId, provides, consumes: stitchConsumes });
+          if (debug) process.stderr.write(`  [stitch] provides=${provides.length} consumes=${stitchConsumes.length} -> ${res.stitched} cross-repo edges\n`);
+        }
+      } catch (err) {
+        if (debug) process.stderr.write(`  [stitch skipped] ${err}\n`);
       }
     }
   } finally {

--- a/ix-cli/src/cli/commands/ingestion-loader.ts
+++ b/ix-cli/src/cli/commands/ingestion-loader.ts
@@ -11,6 +11,7 @@ type IngestionModule = {
 type PatchBuilderModule = {
   buildPatch: (parsed: any, hash: string, workspaceId: string, previousSourceHash?: string) => any;
   buildPatchWithResolution: (parsed: any, hash: string, workspaceId: string, resolvedEdges: any[], previousSourceHash?: string) => any;
+  fileNodeId: (workspaceId: string, filePath: string) => string;
 };
 
 type LanguagesModule = {

--- a/ix-cli/src/cli/commands/inventory.ts
+++ b/ix-cli/src/cli/commands/inventory.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { resolveWorkspaceId } from "../bootstrap.js";
-import { detectSystem } from "../system.js";
+import { resolveReadSystemId } from "../resolve.js";
 import { relativePath } from "../format.js";
 import { llmLine } from "../llm.js";
 
@@ -63,7 +63,7 @@ Examples:
       // filtering (otherwise a capped fetch can truncate away the target before
       // the client-side filter below ever sees it). The client-side filter is
       // kept as a fallback for older servers that ignore the scope field.
-      const systemId = detectSystem(process.cwd())?.systemId;
+      const systemId = await resolveReadSystemId(client);
       let nodes = await client.listByKind(opts.kind, { limit, workspaceId: systemId ? undefined : resolveWorkspaceId(), scope: opts.path, systemId });
 
       if (opts.path) {

--- a/ix-cli/src/cli/commands/map.ts
+++ b/ix-cli/src/cli/commands/map.ts
@@ -217,9 +217,22 @@ Examples:
         process.stderr.write(`\r  Computing map...  ${bar}  ${pctStr}`);
       }, 80) : null;
 
+      // Path-2 grouping (Ix#225 Half B): a co-ingest system is found by detectSystem
+      // above; a SEPARATELY-ingested repo that the stitcher joined into a system has
+      // no local marker, so look its system_id up from the backend and scope to it,
+      // making `ix map <repo>` show the whole stitched system.
+      let effectiveSystemId = systemId;
+      if (!effectiveSystemId) {
+        const ws = resolveWorkspaceId(cwd);
+        if (ws) {
+          const looked = await client.workspaceSystem(ws);
+          if (looked.systemId) effectiveSystemId = looked.systemId;
+        }
+      }
+
       let result: MapResult;
       try {
-        result = await client.map({ full: opts.full, workspaceId: systemId ? undefined : resolveWorkspaceId(cwd), systemId }) as MapResult;
+        result = await client.map({ full: opts.full, workspaceId: effectiveSystemId ? undefined : resolveWorkspaceId(cwd), systemId: effectiveSystemId }) as MapResult;
       } catch (err: any) {
         if (mapInterval) { clearInterval(mapInterval); process.stderr.write('\r' + ' '.repeat(60) + '\r'); }
         emitError(formatFetchError(err));

--- a/ix-cli/src/cli/commands/rank.ts
+++ b/ix-cli/src/cli/commands/rank.ts
@@ -2,7 +2,7 @@ import type { Command } from "commander";
 import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
-import { activeReadScope } from "../resolve.js";
+import { activeReadScope, ensureReadScope } from "../resolve.js";
 import { llmLine } from "../llm.js";
 
 type Metric = "dependents" | "callers" | "importers" | "members";
@@ -172,6 +172,7 @@ export function registerRankCommand(program: Command): void {
         const diagnostics: string[] = [];
 
         // 1. Fetch all entities of the given kind
+        await ensureReadScope(client); // fold in a Path-2 stitched system (Ix#225 Half B)
         const allNodes = await client.listByKind(opts.kind, { limit: 2000, ...activeReadScope() });
 
         if (allNodes.length === 0) {

--- a/ix-cli/src/cli/commands/read.ts
+++ b/ix-cli/src/cli/commands/read.ts
@@ -4,7 +4,7 @@ import type { Command } from "commander";
 import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
 import { absoluteFromSourceUri, getEndpoint, resolveWorkspaceRoot } from "../config.js";
-import { resolveEntityFull, activeReadScope } from "../resolve.js";
+import { resolveEntityFull, activeReadScope, ensureReadScope } from "../resolve.js";
 import { stderr } from "../stderr.js";
 import { isFileStale } from "../stale.js";
 import { relativePath } from "../format.js";
@@ -255,7 +255,8 @@ async function tryFilenameMatch(
 ): Promise<Array<{ name: string; path: string }>> {
   const basename = path.basename(target);
   const hasExtension = path.extname(basename) !== "";
-  // Scope to the active workspace / co-ingest system server-side, like trySymbolMatch.
+  // Scope to the active workspace / co-ingest system / Path-2 stitched system.
+  await ensureReadScope(client);
   const scope = activeReadScope();
 
   // Strategy 1: Search with the exact target (may include extension)

--- a/ix-cli/src/cli/commands/search.ts
+++ b/ix-cli/src/cli/commands/search.ts
@@ -3,9 +3,8 @@ import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { resolveWorkspaceId } from "../bootstrap.js";
-import { detectSystem } from "../system.js";
 import { formatNodes, relativePath } from "../format.js";
-import { scoreCandidate } from "../resolve.js";
+import { scoreCandidate, resolveReadSystemId } from "../resolve.js";
 import { applyRoleFilter, roleHint } from "../role-filter.js";
 import { stderr } from "../stderr.js";
 import { llmLine } from "../llm.js";
@@ -145,7 +144,7 @@ Examples:
       const fetchLimit = Math.min(limit * 3, 60);
       // Auto-detect a multi-repo system; when present, scope by system_id (which
       // spans all member repos) instead of the single-repo workspace_id.
-      const systemId = detectSystem(process.cwd())?.systemId;
+      const systemId = await resolveReadSystemId(client);
       const rawNodes = await client.search(term, {
         limit: fetchLimit,
         kind: opts.kind,

--- a/ix-cli/src/cli/commands/smells.ts
+++ b/ix-cli/src/cli/commands/smells.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { resolveWorkspaceId } from "../bootstrap.js";
-import { detectSystem } from "../system.js";
+import { resolveReadSystemId } from "../resolve.js";
 import { llmLine, llmError, type LlmValue } from "../llm.js";
 
 interface SmellCandidate {
@@ -61,7 +61,7 @@ Examples:
       list?: boolean;
     }) => {
       const client = new IxClient(getEndpoint());
-      const systemId = detectSystem(process.cwd())?.systemId;
+      const systemId = await resolveReadSystemId(client);
 
       if (opts.list) {
         let result: any;

--- a/ix-cli/src/cli/commands/stats.ts
+++ b/ix-cli/src/cli/commands/stats.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { resolveWorkspaceId } from "../bootstrap.js";
-import { detectSystem } from "../system.js";
+import { resolveReadSystemId } from "../resolve.js";
 import { llmLine, llmError, type LlmValue } from "../llm.js";
 
 /** Render `ix stats` as llm records: one `nodes` line and one `edges` line. */
@@ -26,7 +26,7 @@ export function registerStatsCommand(program: Command): void {
     .option("--format <fmt>", "Output format (text|json|llm)", "text")
     .action(async (opts: { format: string }) => {
       const client = new IxClient(getEndpoint());
-      const systemId = detectSystem(process.cwd())?.systemId;
+      const systemId = await resolveReadSystemId(client);
       let result;
       try {
         result = await client.stats({ workspaceId: systemId ? undefined : resolveWorkspaceId(), systemId });

--- a/ix-cli/src/cli/commands/subsystems.ts
+++ b/ix-cli/src/cli/commands/subsystems.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import { IxClient, type ListSubsystemsOptions } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { resolveWorkspaceId } from "../bootstrap.js";
-import { detectSystem } from "../system.js";
+import { resolveReadSystemId } from "../resolve.js";
 import { roundFloat } from "../format.js";
 import { llmLine, llmError } from "../llm.js";
 import { renderMapText, renderMapLlm, type MapRegion, type MapResult } from "./map.js";
@@ -109,7 +109,7 @@ Examples:
       const client = new IxClient(getEndpoint());
       // Auto-detect a multi-repo system; scope by system_id (spanning all member
       // repos) when present, otherwise the single-repo workspace_id.
-      const systemId = detectSystem(process.cwd())?.systemId;
+      const systemId = await resolveReadSystemId(client);
       const scope = { workspaceId: systemId ? undefined : resolveWorkspaceId(), systemId };
       const target = resolveSubsystemTarget(positionalTarget, opts.target);
       const pick = parsePickOption(opts.pick);

--- a/ix-cli/src/cli/commands/trace.ts
+++ b/ix-cli/src/cli/commands/trace.ts
@@ -2,7 +2,7 @@ import type { Command } from "commander";
 import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
-import { resolveFileOrEntity, isRawId, activeReadScope } from "../resolve.js";
+import { resolveFileOrEntity, isRawId, activeReadScope, ensureReadScope } from "../resolve.js";
 import type { ResolvedEntity } from "../resolve.js";
 import { stderr } from "../stderr.js";
 import { renderSection, renderKeyValue, renderResolvedHeader, colorizeKind } from "../ui.js";
@@ -89,6 +89,7 @@ export async function pickTraceTarget(
   if (target.kind !== "config_entry") return target;
   if (opts.path) return target;
 
+  await ensureReadScope(client);
   const candidates = (await client.search(symbol, {
     limit: 50,
     kind: "config_entry",

--- a/ix-cli/src/cli/resolve.ts
+++ b/ix-cli/src/cli/resolve.ts
@@ -15,7 +15,7 @@ import { resolveWorkspaceId } from "./bootstrap.js";
  * (getActiveWorkspaceRoot vs. workspace-relative source_uri) dropped every candidate
  * (issue #228, originally fixed in search.ts only).
  */
-let _scopeCache: { cwd: string; workspaceId?: string; systemId?: string } | undefined;
+let _scopeCache: { cwd: string; workspaceId?: string; systemId?: string; stitchChecked?: boolean } | undefined;
 export function activeReadScope(): { workspaceId?: string; systemId?: string } {
   return activeScope();
 }
@@ -24,8 +24,40 @@ function activeScope(): { workspaceId?: string; systemId?: string } {
   if (_scopeCache?.cwd === cwd) return _scopeCache;
   const systemId = detectSystem(cwd)?.systemId;
   const workspaceId = systemId ? undefined : resolveWorkspaceId(cwd);
-  _scopeCache = { cwd, workspaceId, systemId };
+  _scopeCache = { cwd, workspaceId, systemId, stitchChecked: false };
   return _scopeCache;
+}
+
+/**
+ * Make the read scope aware of a Path-2 STITCHED system (Ix#225 Half B): a
+ * separately-ingested repo has no local system marker (detectSystem returns none),
+ * but the stitcher may have joined it into a system server-side. Look that up once
+ * and fold it into the same cache activeScope() reads, so every read that calls
+ * this (then resolves) spans the whole stitched system — matching `ix map`.
+ * Best-effort + cached (one lookup per cwd); an older backend or a true singleton
+ * leaves the scope at workspace level. Read commands `await` this before resolving.
+ */
+export async function ensureReadScope(client: Pick<IxClient, "workspaceSystem">): Promise<void> {
+  const cwd = process.cwd();
+  if (_scopeCache?.cwd === cwd && _scopeCache.stitchChecked) return;
+  const localSystem = detectSystem(cwd)?.systemId;
+  if (localSystem) { _scopeCache = { cwd, systemId: localSystem, stitchChecked: true }; return; }
+  const ws = resolveWorkspaceId(cwd);
+  let systemId: string | undefined;
+  if (ws) {
+    try { systemId = (await client.workspaceSystem(ws)).systemId ?? undefined; } catch { /* best-effort */ }
+  }
+  _scopeCache = { cwd, workspaceId: systemId ? undefined : ws, systemId, stitchChecked: true };
+}
+
+/**
+ * The system_id an aggregate read (inventory/search/stats/smells/subsystems) should
+ * scope to: a co-ingest system (detectSystem) OR a Path-2 stitched system (backend
+ * lookup), else undefined (workspace-scoped). Drop-in for `detectSystem(cwd)?.systemId`.
+ */
+export async function resolveReadSystemId(client: Pick<IxClient, "workspaceSystem">): Promise<string | undefined> {
+  await ensureReadScope(client);
+  return activeReadScope().systemId;
 }
 
 export type ResolutionMode = "exact" | "preferred-kind" | "scored" | "ambiguous" | "heuristic";
@@ -175,6 +207,7 @@ export async function resolveEntityFull(
   // EXPLICIT --path narrows further, client-side; we no longer default the path filter
   // to the absolute workspace root, which never matched workspace-relative source_uris.
   const effectivePath = opts?.path;
+  await ensureReadScope(client); // fold in a Path-2 stitched system (Ix#225 Half B)
   const { workspaceId, systemId } = activeScope();
   const kindFilter = opts?.kind;
   const nodes = await client.search(symbol, {
@@ -627,6 +660,7 @@ async function tryFileGraphMatch(
   const targetHasPath = target.includes("/") || target.includes("\\");
   // Explicit --path only (not the absolute workspace root); scope server-side instead.
   const effectivePath = opts?.path;
+  await ensureReadScope(client); // fold in a Path-2 stitched system (Ix#225 Half B)
   const { workspaceId, systemId } = activeScope();
 
   // Search for file entities matching the basename

--- a/ix-cli/src/client/api.ts
+++ b/ix-cli/src/client/api.ts
@@ -231,6 +231,13 @@ export class IxClient {
     return this.post('/v1/stitch', payload);
   }
 
+  // Path-2 grouping (Ix#225 Half B): the system_id a workspace currently belongs
+  // to (null if a singleton). Lets `ix map <repo>` scope to its stitched system.
+  async workspaceSystem(workspaceId: string): Promise<{ systemId: string | null }> {
+    try { return await this.get(`/v1/stitch/system/${workspaceId}`); }
+    catch { return { systemId: null }; } // older backend without the endpoint
+  }
+
   async map(opts?: { full?: boolean; workspaceId?: string; systemId?: string }): Promise<any> {
     // /v1/map reads snake_case keys (full, branch_id, workspace_id, system_id) off the raw JSON body.
     const body: Record<string, unknown> = { full: opts?.full ?? false };

--- a/ix-cli/src/client/api.ts
+++ b/ix-cli/src/client/api.ts
@@ -219,6 +219,18 @@ export class IxClient {
     return this.post('/v1/source-hashes', { uris: filePaths, workspaceIds });
   }
 
+  // Path-2 separate-ingest stitcher (Ix#225). Registers this workspace's published
+  // packages (provides) + production-dep external imports (consumes), then the
+  // backend joins them bidirectionally against other workspaces and writes the
+  // cross-repo IMPORTS edges. Returns how many edges were stitched.
+  async stitch(payload: {
+    workspaceId: string;
+    provides: Array<{ name: string; entryNodeId: string; entryUri?: string }>;
+    consumes: Array<{ name: string; consumerNodeId: string }>;
+  }): Promise<{ stitched: number; edges: Array<{ src: string; dst: string; name: string }> }> {
+    return this.post('/v1/stitch', payload);
+  }
+
   async map(opts?: { full?: boolean; workspaceId?: string; systemId?: string }): Promise<any> {
     // /v1/map reads snake_case keys (full, branch_id, workspace_id, system_id) off the raw JSON body.
     const body: Record<string, unknown> = { full: opts?.full ?? false };


### PR DESCRIPTION
CLI half of Path 2 (lockstep with ix-memory-layer#77; **merge together**).

**Problem:** repos ingested separately form zero cross-repo edges, so a system mapped in pieces looks fragmented (co-ingest only connects what's in one batch).

**This makes separate ingest produce the same system grouping as co-ingest:**
- During a solo ingest, collect the repo's published packages (provides: name → entry node) and its production-dep external imports (consumes: name → importing node), and POST `/v1/stitch`. The backend joins them bidirectionally across workspaces, writes the cross-repo edges, and assigns each connected component a deterministic shared `system_id`.
- `ix map`/reads then scope to that system: a new `ensureReadScope` looks up a separately-ingested repo's stitched `system_id` and folds it into the read scope (covers callers/callees/explain/impact/overview/read/depends/contains/imports/locate/history/trace + rank), and `resolveReadSystemId` does the same for the aggregate reads (inventory/search/stats/smells/subsystems).
- New `fileNodeId` export so the CLI references the *same* node ids buildPatch produces.

Production-dep gated (mirrors #244); solo-ingest only (co-ingest already forms these in-batch); best-effort (older backend → workspace scope); registration only on a full ingest so a partial re-map never clobbers.

**Measured (11-repo corpus, separate ingest):** 0 → 6 connected repo-pairs, **byte-identical in both ingest orders**, 3 correct components {chalk,ora,boxen} {express,debug,cookie,morgan} {flask,click} + koa/gin singletons, 0 false. `ix map express` shows the full 29-file system; `ix stats`/`inventory`/`explain` from a stitched member span the system; a singleton stays isolated. ix-cli 507, core-ingestion 189/39-baseline.

Follow-up (separate): symbol-level stitch (finer cross-repo call edges, toward co-ingest's denser graph; enables cross-repo `ix callers`).