### PR TITLE
feat(path2): symbol-level cross-repo stitch + renamed/default import alias resolution (Ix#225)

### DIFF
--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -2427,6 +2427,22 @@ export function resolveEdges(
     globalCandidateTotal: 0, resolvedImport: 0, resolvedTransitive: 0,
     resolvedGlobal: 0, resolvedQualifier: 0, skippedSameFile: 0, skippedAmbiguous: 0,
   };
+  // Renamed-import call resolution (Z): a call to a renamed local binding (`import
+  // { format as fmt }; fmt()`) should resolve as the provider's public symbol
+  // (`format`), so in-repo AND co-ingest resolution link it to the real definition.
+  // Map per file: local binding name -> imported public symbol, EXCLUDING default
+  // imports (imported == "default" is not a by-name symbol in the provider; those are
+  // handled in the cross-repo stitch path) and no-op named imports (local == imported).
+  const callBindings = new Map<string, Map<string, string>>();
+  for (const r of results) {
+    if (!r.importBindings) continue;
+    for (const b of r.importBindings) {
+      if (b.imported === 'default' || b.local === b.imported) continue;
+      let m = callBindings.get(r.filePath);
+      if (!m) { m = new Map(); callBindings.set(r.filePath, m); }
+      if (!m.has(b.local)) m.set(b.local, b.imported);
+    }
+  }
   // Cross-repo dependency graph: repo R depends on repo D when any file in R
   // imports a module published by D. Built from the raw IMPORTS relationships.
   const repoOf = opts?.repoOf;
@@ -3049,7 +3065,11 @@ export function resolveEdges(
         // fall through to Tier 1b → Tier 2 → Tier 3 below
       }
 
-      const dstName = rel.dstName;
+      const origDstName = rel.dstName;
+      // Z: resolve a renamed-import call by the provider's public symbol, but keep the
+      // ORIGINAL local name on the emitted edge (buildPatchWithResolution maps the edge
+      // back to the source call by name). No-op unless this is a renamed-import call.
+      const dstName = (rel.predicate === 'CALLS' ? callBindings.get(srcFilePath)?.get(rel.dstName) : undefined) ?? rel.dstName;
       const srcName = rel.srcName;
 
       // Tier 1b: qualifier-assisted (confidence 0.9 / 0.7)
@@ -3087,7 +3107,7 @@ export function resolveEdges(
               const dstQualifiedKey = bestQKey(fileQKeys, qfp, memberPart, preferredQKey);
               if (dstQualifiedKey !== null) {
                 // dstName must match rel.dstName so buildPatchWithResolution can look it up
-                resolved.push({ srcFilePath, srcName, dstFilePath: qfp, dstName, dstQualifiedKey, predicate: rel.predicate, confidence: 0.9 });
+                resolved.push({ srcFilePath, srcName, dstFilePath: qfp, dstName: origDstName, dstQualifiedKey, predicate: rel.predicate, confidence: 0.9 });
               }
             }
             continue;
@@ -3112,7 +3132,7 @@ export function resolveEdges(
             if (fileHasSymbol.get(qfp)?.has(memberPart)) {
               const dstQualifiedKey = bestQKey(fileQKeys, qfp, memberPart, `${qualifierPart}.${memberPart}`);
               if (dstQualifiedKey !== null) {
-                resolved.push({ srcFilePath, srcName, dstFilePath: qfp, dstName, dstQualifiedKey, predicate: rel.predicate, confidence: 0.7 });
+                resolved.push({ srcFilePath, srcName, dstFilePath: qfp, dstName: origDstName, dstQualifiedKey, predicate: rel.predicate, confidence: 0.7 });
               }
             }
           }
@@ -3134,7 +3154,7 @@ export function resolveEdges(
         const fp = narrowedImportMatches[0];
         const dstQualifiedKey = bestQKey(fileQKeys, fp, dstName);
         if (dstQualifiedKey === null) continue; // ambiguous — do not emit bad nodeId
-        resolved.push({ srcFilePath, srcName, dstFilePath: fp, dstName, dstQualifiedKey, predicate: rel.predicate, confidence: 0.9 });
+        resolved.push({ srcFilePath, srcName, dstFilePath: fp, dstName: origDstName, dstQualifiedKey, predicate: rel.predicate, confidence: 0.9 });
         continue;
       }
       // Commodity gate: beyond the precise import-scoped tier above, the remaining
@@ -3161,7 +3181,7 @@ export function resolveEdges(
         const fp = narrowedTransitiveMatches[0];
         const dstQualifiedKey = bestQKey(fileQKeys, fp, dstName);
         if (dstQualifiedKey === null) continue;
-        resolved.push({ srcFilePath, srcName, dstFilePath: fp, dstName, dstQualifiedKey, predicate: rel.predicate, confidence: 0.8 });
+        resolved.push({ srcFilePath, srcName, dstFilePath: fp, dstName: origDstName, dstQualifiedKey, predicate: rel.predicate, confidence: 0.8 });
         continue;
       }
       // Tier 3: global fallback (confidence 0.5) — uses inverted symbol index
@@ -3191,7 +3211,7 @@ export function resolveEdges(
         const fp = resolvedMatches[0];
         const dstQualifiedKey = bestQKey(fileQKeys, fp, dstName);
         if (dstQualifiedKey === null) continue; // ambiguous — do not emit bad nodeId
-        resolved.push({ srcFilePath, srcName, dstFilePath: fp, dstName, dstQualifiedKey, predicate: rel.predicate, confidence: 0.5 });
+        resolved.push({ srcFilePath, srcName, dstFilePath: fp, dstName: origDstName, dstQualifiedKey, predicate: rel.predicate, confidence: 0.5 });
         stats.resolvedGlobal++;
         continue;
       }

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -106,6 +106,30 @@ export interface ParsedRelationship {
   importRaw?: string;
 }
 
+/**
+ * A single named/default import binding in a JS/TS file: the in-file local name
+ * mapped to the PUBLIC symbol it refers to in the source package. `imported` is
+ * the public export name ("default" for a default import). Lets a consumer's
+ * call to the LOCAL name (e.g. `fmt()` from `import { format as fmt }`) be
+ * resolved back to the provider's public symbol for cross-repo stitching.
+ */
+export interface ImportBinding {
+  pkg: string;       // raw import specifier, e.g. "libcore", "@scope/pkg", "./local"
+  local: string;     // in-file binding name (the call site uses this)
+  imported: string;  // public symbol in the source package ("default" for default import)
+}
+
+/**
+ * A provider-side public export whose public name differs from the local entity
+ * name: `export default function debug` → { local: "debug", public: "default" };
+ * `export { impl as format }` → { local: "impl", public: "format" }. Lets the
+ * provider advertise the symbol by the name consumers actually import.
+ */
+export interface ExportPublicName {
+  local: string;   // local entity name in the provider file
+  public: string;  // name consumers import it by ("default" for default export)
+}
+
 export interface FileParseResult {
   filePath: string;
   language: SupportedLanguages;
@@ -113,6 +137,10 @@ export interface FileParseResult {
   chunks: ParsedChunk[];
   relationships: ParsedRelationship[];
   importAliases?: Record<string, string>;
+  /** JS/TS named/default import bindings (local → public symbol). */
+  importBindings?: ImportBinding[];
+  /** JS/TS provider-side aliased/default public export names. */
+  exportPublicNames?: ExportPublicName[];
   fileRole: RoleClassification;
 }
 
@@ -375,6 +403,100 @@ function unwrapImportSpecifier(rawValue: string): string {
     .replace(/\\\\/g, '/')
     .replace(/^["'`<]/, '')
     .replace(/[>"'`]$/, '');
+}
+
+/**
+ * Walk a JS/TS `import_statement` node and return its named/default bindings.
+ * Namespace imports (`* as ns`) are intentionally skipped: a call like `ns.foo()`
+ * already resolves to "foo" through the member_expression call query, so it needs
+ * no rewrite. Purely additive — does not alter any emitted relationship.
+ */
+function extractJsImportBindings(stmtNode: any, rawSpec: string): ImportBinding[] {
+  const out: ImportBinding[] = [];
+  if (!stmtNode || stmtNode.type !== 'import_statement') return out;
+  let clause: any = null;
+  for (let i = 0; i < stmtNode.namedChildCount; i++) {
+    const c = stmtNode.namedChild(i);
+    if (c.type === 'import_clause') { clause = c; break; }
+  }
+  if (!clause) return out;
+  for (let i = 0; i < clause.namedChildCount; i++) {
+    const child = clause.namedChild(i);
+    if (child.type === 'identifier') {
+      // `import dbg from "pkg"` — default import.
+      if (child.text) out.push({ pkg: rawSpec, local: child.text, imported: 'default' });
+    } else if (child.type === 'named_imports') {
+      for (let j = 0; j < child.namedChildCount; j++) {
+        const spec = child.namedChild(j);
+        if (spec.type !== 'import_specifier') continue;
+        const nameNode = spec.namedChild(0);
+        const aliasNode = spec.namedChildCount > 1 ? spec.namedChild(1) : null;
+        if (!nameNode || !nameNode.text) continue;
+        const imported = nameNode.text;
+        const local = aliasNode && aliasNode.text ? aliasNode.text : imported;
+        out.push({ pkg: rawSpec, local, imported });
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Walk a JS/TS tree for provider-side public export names that differ from the
+ * local entity name: `export { impl as format }` (no source) → {impl, format};
+ * `export default function debug` → {debug, "default"}. Lets a provider advertise
+ * a symbol by the name a consumer imports it as. Purely additive.
+ */
+function extractJsExportPublicNames(rootNode: any): ExportPublicName[] {
+  const out: ExportPublicName[] = [];
+  const seen = new Set<string>();
+  const visit = (node: any): void => {
+    if (node.type === 'export_statement') {
+      let hasSource = false;
+      let isDefault = false;
+      for (let i = 0; i < node.childCount; i++) {
+        const c = node.child(i);
+        if (c.type === 'default') isDefault = true;
+        if (c.type === 'string') hasSource = true;
+      }
+      let clause: any = null;
+      let decl: any = null;
+      for (let i = 0; i < node.namedChildCount; i++) {
+        const c = node.namedChild(i);
+        if (c.type === 'export_clause') clause = c;
+        else if (c.type === 'function_declaration' || c.type === 'class_declaration'
+          || c.type === 'lexical_declaration' || c.type === 'generator_function_declaration') decl = c;
+      }
+      // Local re-export `export { a as b }` (NOT `... from './x'`): a is public as b.
+      if (clause && !hasSource) {
+        for (let j = 0; j < clause.namedChildCount; j++) {
+          const spec = clause.namedChild(j);
+          if (spec.type !== 'export_specifier') continue;
+          const localN = spec.namedChild(0);
+          const pubN = spec.namedChildCount > 1 ? spec.namedChild(1) : null;
+          if (!localN || !localN.text) continue;
+          const local = localN.text;
+          const pub = pubN && pubN.text ? pubN.text : local;
+          if (pub !== local) {
+            const k = `${local} ${pub}`;
+            if (!seen.has(k)) { seen.add(k); out.push({ local, public: pub }); }
+          }
+        }
+      }
+      // `export default function debug(){}` / `export default class X {}` → public "default".
+      if (isDefault && decl) {
+        const nameNode = (decl.childForFieldName && decl.childForFieldName('name')) || decl.namedChild(0);
+        const nm = nameNode?.text;
+        if (nm) {
+          const k = `${nm} default`;
+          if (!seen.has(k)) { seen.add(k); out.push({ local: nm, public: 'default' }); }
+        }
+      }
+    }
+    for (let i = 0; i < node.namedChildCount; i++) visit(node.namedChild(i));
+  };
+  visit(rootNode);
+  return out;
 }
 
 function fileEntityName(filePath: string): string {
@@ -1399,6 +1521,10 @@ export function parseFile(filePath: string, source: string): FileParseResult | n
     const declaredTypeMap = new Map<string, Map<string, string>>();
     // Import aliases keyed by the in-file alias name (Go explicit aliases, etc.).
     const importAliases: Record<string, string> = {};
+    // JS/TS named/default import bindings (local → public symbol) for cross-repo
+    // alias resolution. Additive: never alters emitted relationships.
+    const isJsTs = language === SupportedLanguages.JavaScript || language === SupportedLanguages.TypeScript;
+    const importBindings: ImportBinding[] = [];
 
     // Detect the Go package name once (one package_clause per file). Used to
     // package-prefix Go entity qualifiedNames + bare-call dstNames so
@@ -1668,6 +1794,15 @@ export function parseFile(filePath: string, source: string): FileParseResult | n
       // Import captures (JS/TS/Python path-based)
       const importSource = match.captures.find((c: any) => c.name === 'import.source');
       if (importSource) {
+        // JS/TS: pull per-specifier bindings off the whole import_statement node
+        // (@import). Additive — leaves the IMPORTS/CALLS relationships untouched.
+        if (isJsTs) {
+          const stmtNode = match.captures.find((c: any) => c.name === 'import')?.node;
+          if (stmtNode) {
+            const rawSpec = unwrapImportSpecifier(importSource.node.text);
+            for (const b of extractJsImportBindings(stmtNode, rawSpec)) importBindings.push(b);
+          }
+        }
         // Grouped alias `alias MyApp.{User, Repo}`: each member alias is captured bare
         // ("User"); the prefix alias ("MyApp") comes through @import.prefix so we can
         // rebuild the full module name "MyApp.User", matching the single-alias form.
@@ -1935,6 +2070,8 @@ export function parseFile(filePath: string, source: string): FileParseResult | n
       for (let j = dropIdx.length - 1; j >= 0; j--) entities.splice(dropIdx[j], 1);
     }
 
+    const exportPublicNames = isJsTs ? extractJsExportPublicNames(tree.rootNode) : [];
+
     return {
       filePath,
       language,
@@ -1942,6 +2079,8 @@ export function parseFile(filePath: string, source: string): FileParseResult | n
       chunks,
       relationships,
       importAliases: Object.keys(importAliases).length > 0 ? importAliases : undefined,
+      importBindings: importBindings.length > 0 ? importBindings : undefined,
+      exportPublicNames: exportPublicNames.length > 0 ? exportPublicNames : undefined,
       fileRole: classifyFileRole(filePath, source),
     };
   } catch (e) {

--- a/core-ingestion/src/patch-builder.ts
+++ b/core-ingestion/src/patch-builder.ts
@@ -63,6 +63,16 @@ export function fileNodeId(workspaceId: string, filePath: string): string {
   return makeIds(workspaceId).nodeId(filePath, nodePath.basename(filePath));
 }
 
+/**
+ * The node id of a symbol (function/class/...) in a SOLO ingest, by its qualified
+ * key (`name`, or `container.name` for a member). Lets the Path-2 symbol-level
+ * stitcher reference a provider's exported symbol and a consumer's calling symbol
+ * by the SAME id buildPatch produces — so cross-repo CALL edges land on real nodes.
+ */
+export function symbolNodeId(workspaceId: string, filePath: string, qualifiedKey: string): string {
+  return makeIds(workspaceId).nodeId(filePath, qualifiedKey);
+}
+
 // ---------------------------------------------------------------------------
 // Source type from file extension
 // ---------------------------------------------------------------------------

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -520,6 +520,10 @@ export async function ingestFiles(
       for (const e of (p.entities ?? [])) {
         const qk = e.container ? `${e.container}.${e.name}` : e.name;
         stitchDefs.set(e.name, { qk, filePath: p.filePath });
+        // A call FROM inside a class/namespace method has a QUALIFIED srcName
+        // (e.g. "Ora.constructor"); also key the def by its qualified key so the
+        // caller node resolves (else cross-repo calls from methods are dropped).
+        if (qk !== e.name) stitchDefs.set(qk, { qk, filePath: p.filePath });
         if (!e.container && (e.kind === 'function' || e.kind === 'class') && !stitchExportNames.has(e.name)) {
           stitchExportNames.add(e.name);
           stitchExports.push({ name: e.name, nodeId: symbolNodeId(workspaceId, p.filePath, qk) });

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -404,7 +404,7 @@ export async function ingestFiles(
   const mapMode = opts.mapMode === true;
   const trueStart = performance.now();
 
-  const [{ parseFile, resolveEdges, isGrammarSupported }, { buildPatchWithResolution, fileNodeId }, { languageFromPath }] = await loadIngestionModules();
+  const [{ parseFile, resolveEdges, isGrammarSupported }, { buildPatchWithResolution, fileNodeId, symbolNodeId }, { languageFromPath }] = await loadIngestionModules();
   const moduleLoadMs = Math.round(performance.now() - trueStart);
 
 
@@ -493,15 +493,35 @@ export async function ingestFiles(
   const stitchConsumes: Array<{ name: string; consumerNodeId: string }> = [];
   const stitchConsumeSeen = new Set<string>();
   const stitchFiles: string[] = [];
+  // Symbol-level stitch (Ix#225): a provider's exported top-level symbols + a
+  // consumer's calls (collected raw; resolved post-ingest once the full repo symbol
+  // set is known, so "external" = a call to a symbol not defined anywhere in this repo).
+  const stitchDefs = new Map<string, { qk: string; filePath: string }>(); // name -> def (caller-key + local set)
+  const stitchExportNames = new Set<string>();
+  const stitchExports: Array<{ name: string; nodeId: string }> = [];
+  const stitchCalls: Array<{ symbol: string; caller: string; callerFilePath: string }> = [];
+  // Builtin instance-method names that are never a real cross-repo call target.
+  const STITCH_COMMODITY = new Set(['map', 'forEach', 'reduce', 'reduceRight', 'flatMap', 'flat', 'push', 'pop', 'shift', 'unshift', 'splice', 'slice', 'concat', 'get', 'set', 'has', 'keys', 'values', 'entries', 'then', 'catch', 'finally', 'resolve', 'race', 'allSettled', 'bind', 'call', 'apply', 'stringify', 'toString', 'valueOf', 'hasOwnProperty']);
   const specToPkg = (spec: string | undefined): string | null => {
     if (!spec || spec.startsWith('.') || spec.startsWith('/')) return null;
     if (spec.startsWith('@')) { const parts = spec.split('/'); return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : null; }
     return spec.split('/')[0] || null;
   };
-  const collectStitch = (parsedFiles: Array<{ filePath: string; relationships?: Array<{ predicate: string; dstName?: string; importRaw?: string }> }>): void => {
+  const collectStitch = (parsedFiles: Array<{ filePath: string; entities?: Array<{ name: string; kind: string; container?: string }>; relationships?: Array<{ predicate: string; srcName?: string; dstName?: string; importRaw?: string }> }>): void => {
     for (const p of parsedFiles) {
       stitchFiles.push(p.filePath);
+      for (const e of (p.entities ?? [])) {
+        const qk = e.container ? `${e.container}.${e.name}` : e.name;
+        stitchDefs.set(e.name, { qk, filePath: p.filePath });
+        if (!e.container && (e.kind === 'function' || e.kind === 'class') && !stitchExportNames.has(e.name)) {
+          stitchExportNames.add(e.name);
+          stitchExports.push({ name: e.name, nodeId: symbolNodeId(workspaceId, p.filePath, qk) });
+        }
+      }
       for (const rel of (p.relationships ?? [])) {
+        if (rel.predicate === 'CALLS' && typeof rel.dstName === 'string' && typeof rel.srcName === 'string' && !STITCH_COMMODITY.has(rel.dstName)) {
+          stitchCalls.push({ symbol: rel.dstName, caller: rel.srcName, callerFilePath: p.filePath });
+        }
         if (rel.predicate !== 'IMPORTS') continue;
         const pkg = specToPkg(typeof rel.importRaw === 'string' ? rel.importRaw : rel.dstName);
         if (!pkg || !stitchProdDeps.has(pkg)) continue;
@@ -1249,9 +1269,24 @@ export async function ingestFiles(
         const provides = entry
           ? readPackageNames(workspaceRoot).map(name => ({ name, entryNodeId: fileNodeId(workspaceId, entry), entryUri: entry }))
           : [];
-        if (provides.length > 0 || stitchConsumes.length > 0) {
-          const res = await client.stitch({ workspaceId, provides, consumes: stitchConsumes });
-          if (debug) process.stderr.write(`  [stitch] provides=${provides.length} consumes=${stitchConsumes.length} -> ${res.stitched} cross-repo edges\n`);
+        // Symbol-level consumes: a call to a symbol NOT defined anywhere in this
+        // repo (external) whose caller IS a known local symbol (so the edge src is a
+        // real node). The backend matches these to providers' exports by name.
+        const symbolConsumes: Array<{ symbol: string; callerNodeId: string }> = [];
+        const symbolConsumeSeen = new Set<string>();
+        for (const c of stitchCalls) {
+          if (stitchDefs.has(c.symbol)) continue;
+          const callerDef = stitchDefs.get(c.caller);
+          if (!callerDef) continue;
+          const callerNodeId = symbolNodeId(workspaceId, callerDef.filePath, callerDef.qk);
+          const sk = `${c.symbol} ${callerNodeId}`;
+          if (symbolConsumeSeen.has(sk)) continue;
+          symbolConsumeSeen.add(sk);
+          symbolConsumes.push({ symbol: c.symbol, callerNodeId });
+        }
+        if (provides.length > 0 || stitchConsumes.length > 0 || stitchExports.length > 0 || symbolConsumes.length > 0) {
+          const res = await client.stitch({ workspaceId, provides, consumes: stitchConsumes, exports: stitchExports, symbolConsumes });
+          if (debug) process.stderr.write(`  [stitch] provides=${provides.length} consumes=${stitchConsumes.length} exports=${stitchExports.length} symConsumes=${symbolConsumes.length} -> ${res.stitched} edges\n`);
         }
       } catch (err) {
         if (debug) process.stderr.write(`  [stitch skipped] ${err}\n`);

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -500,6 +500,13 @@ export async function ingestFiles(
   const stitchExportNames = new Set<string>();
   const stitchExports: Array<{ name: string; nodeId: string }> = [];
   const stitchCalls: Array<{ symbol: string; caller: string; callerFilePath: string }> = [];
+  // Per-file JS/TS import bindings (localName -> {pkg, public symbol}) so a call to
+  // a renamed/default-imported local name resolves to the provider's public symbol.
+  const stitchBindings = new Map<string, Map<string, { pkg: string; imported: string }>>();
+  // Provider-side public export aliases (default exports, `export { x as y }`):
+  // {filePath, local entity name, public name} -> add an export entry by public name.
+  const stitchExportAliases: Array<{ filePath: string; local: string; pub: string }> = [];
+  const stitchExportAliasSeen = new Set<string>();
   // Builtin instance-method names that are never a real cross-repo call target.
   const STITCH_COMMODITY = new Set(['map', 'forEach', 'reduce', 'reduceRight', 'flatMap', 'flat', 'push', 'pop', 'shift', 'unshift', 'splice', 'slice', 'concat', 'get', 'set', 'has', 'keys', 'values', 'entries', 'then', 'catch', 'finally', 'resolve', 'race', 'allSettled', 'bind', 'call', 'apply', 'stringify', 'toString', 'valueOf', 'hasOwnProperty']);
   const specToPkg = (spec: string | undefined): string | null => {
@@ -507,7 +514,7 @@ export async function ingestFiles(
     if (spec.startsWith('@')) { const parts = spec.split('/'); return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : null; }
     return spec.split('/')[0] || null;
   };
-  const collectStitch = (parsedFiles: Array<{ filePath: string; entities?: Array<{ name: string; kind: string; container?: string }>; relationships?: Array<{ predicate: string; srcName?: string; dstName?: string; importRaw?: string }> }>): void => {
+  const collectStitch = (parsedFiles: Array<{ filePath: string; entities?: Array<{ name: string; kind: string; container?: string }>; relationships?: Array<{ predicate: string; srcName?: string; dstName?: string; importRaw?: string }>; importBindings?: Array<{ pkg: string; local: string; imported: string }>; exportPublicNames?: Array<{ local: string; public: string }> }>): void => {
     for (const p of parsedFiles) {
       stitchFiles.push(p.filePath);
       for (const e of (p.entities ?? [])) {
@@ -517,6 +524,15 @@ export async function ingestFiles(
           stitchExportNames.add(e.name);
           stitchExports.push({ name: e.name, nodeId: symbolNodeId(workspaceId, p.filePath, qk) });
         }
+      }
+      // JS/TS alias metadata (additive; absent for other languages).
+      for (const b of (p.importBindings ?? [])) {
+        let m = stitchBindings.get(p.filePath);
+        if (!m) { m = new Map(); stitchBindings.set(p.filePath, m); }
+        if (!m.has(b.local)) m.set(b.local, { pkg: b.pkg, imported: b.imported });
+      }
+      for (const x of (p.exportPublicNames ?? [])) {
+        stitchExportAliases.push({ filePath: p.filePath, local: x.local, pub: x.public });
       }
       for (const rel of (p.relationships ?? [])) {
         if (rel.predicate === 'CALLS' && typeof rel.dstName === 'string' && typeof rel.srcName === 'string' && !STITCH_COMMODITY.has(rel.dstName)) {
@@ -1269,20 +1285,45 @@ export async function ingestFiles(
         const provides = entry
           ? readPackageNames(workspaceRoot).map(name => ({ name, entryNodeId: fileNodeId(workspaceId, entry), entryUri: entry }))
           : [];
-        // Symbol-level consumes: a call to a symbol NOT defined anywhere in this
-        // repo (external) whose caller IS a known local symbol (so the edge src is a
-        // real node). The backend matches these to providers' exports by name.
-        const symbolConsumes: Array<{ symbol: string; callerNodeId: string }> = [];
+        // Provider public export aliases: advertise default/`as`-exported symbols by
+        // the name consumers import them as (`export { impl as format }` -> "format";
+        // `export default function debug` -> "default"), pointing at the same node.
+        for (const a of stitchExportAliases) {
+          const def = stitchDefs.get(a.local);
+          if (!def) continue;
+          const nodeId = symbolNodeId(workspaceId, def.filePath, def.qk);
+          const ek = `${a.pub} ${nodeId}`;
+          if (stitchExportAliasSeen.has(ek)) continue;
+          stitchExportAliasSeen.add(ek);
+          stitchExports.push({ name: a.pub, nodeId });
+        }
+        // Symbol-level consumes: a call whose callee resolves to an EXTERNAL package
+        // symbol. A renamed/default import binds a local name (fmt, dbg) to a public
+        // symbol (format, "default") in a package — resolve through the binding and
+        // carry the package so the backend can scope the match precisely. Without a
+        // binding (namespace member call, or a plain call) keep the old rule: skip
+        // calls to symbols defined locally (intra-repo, resolved by normal ingest).
+        const symbolConsumes: Array<{ symbol: string; callerNodeId: string; pkg?: string }> = [];
         const symbolConsumeSeen = new Set<string>();
         for (const c of stitchCalls) {
-          if (stitchDefs.has(c.symbol)) continue;
           const callerDef = stitchDefs.get(c.caller);
           if (!callerDef) continue;
+          const binding = stitchBindings.get(c.callerFilePath)?.get(c.symbol);
+          let symbol = c.symbol;
+          let pkg: string | undefined;
+          if (binding) {
+            const bpkg = specToPkg(binding.pkg);
+            if (!bpkg || !stitchProdDeps.has(bpkg)) continue; // only stitch prod-dep packages
+            symbol = binding.imported;
+            pkg = bpkg;
+          } else {
+            if (stitchDefs.has(c.symbol)) continue;
+          }
           const callerNodeId = symbolNodeId(workspaceId, callerDef.filePath, callerDef.qk);
-          const sk = `${c.symbol} ${callerNodeId}`;
+          const sk = `${symbol} ${pkg ?? ''} ${callerNodeId}`;
           if (symbolConsumeSeen.has(sk)) continue;
           symbolConsumeSeen.add(sk);
-          symbolConsumes.push({ symbol: c.symbol, callerNodeId });
+          symbolConsumes.push({ symbol, callerNodeId, pkg });
         }
         if (provides.length > 0 || stitchConsumes.length > 0 || stitchExports.length > 0 || symbolConsumes.length > 0) {
           const res = await client.stitch({ workspaceId, provides, consumes: stitchConsumes, exports: stitchExports, symbolConsumes });

--- a/ix-cli/src/cli/commands/ingestion-loader.ts
+++ b/ix-cli/src/cli/commands/ingestion-loader.ts
@@ -12,6 +12,7 @@ type PatchBuilderModule = {
   buildPatch: (parsed: any, hash: string, workspaceId: string, previousSourceHash?: string) => any;
   buildPatchWithResolution: (parsed: any, hash: string, workspaceId: string, resolvedEdges: any[], previousSourceHash?: string) => any;
   fileNodeId: (workspaceId: string, filePath: string) => string;
+  symbolNodeId: (workspaceId: string, filePath: string, qualifiedKey: string) => string;
 };
 
 type LanguagesModule = {

--- a/ix-cli/src/client/api.ts
+++ b/ix-cli/src/client/api.ts
@@ -227,7 +227,9 @@ export class IxClient {
     workspaceId: string;
     provides: Array<{ name: string; entryNodeId: string; entryUri?: string }>;
     consumes: Array<{ name: string; consumerNodeId: string }>;
-  }): Promise<{ stitched: number; edges: Array<{ src: string; dst: string; name: string }> }> {
+    exports?: Array<{ name: string; nodeId: string }>;
+    symbolConsumes?: Array<{ symbol: string; callerNodeId: string }>;
+  }): Promise<{ stitched: number; systemId?: string | null; edges: Array<{ src: string; dst: string; name: string }> }> {
     return this.post('/v1/stitch', payload);
   }
 

--- a/ix-cli/src/client/api.ts
+++ b/ix-cli/src/client/api.ts
@@ -228,7 +228,7 @@ export class IxClient {
     provides: Array<{ name: string; entryNodeId: string; entryUri?: string }>;
     consumes: Array<{ name: string; consumerNodeId: string }>;
     exports?: Array<{ name: string; nodeId: string }>;
-    symbolConsumes?: Array<{ symbol: string; callerNodeId: string }>;
+    symbolConsumes?: Array<{ symbol: string; callerNodeId: string; pkg?: string }>;
   }): Promise<{ stitched: number; systemId?: string | null; edges: Array<{ src: string; dst: string; name: string }> }> {
     return this.post('/v1/stitch', payload);
   }


### PR DESCRIPTION
CLI/parser half of Path-2 symbol-level stitching. Pairs with the backend PR (ix-memory-layer#84). Lets separately-ingested repos recover co-ingest's finer cross-repo coupling, so `ix callers`/`callees` work across repos — and additionally fixes in-repo + co-ingest resolution of renamed-import calls.

## What this adds
1. **Symbol-level collection** (`ix-cli` ingest): on a solo ingest, gather a provider's exported top-level symbols and a consumer's external calls, POST them to the stitcher.

2. **Renamed/default import alias resolution (cross-repo stitch)**: the parser emits a CALL for `import { format as fmt }; fmt()` and `import dbg from "pkg"; dbg()`, but keyed by the *local* name, so cross-repo callers never formed. Now resolved:
   - **Parser** (additive, JS/TS, no tree-sitter query change): surface per-file import bindings (`local → public symbol`; `"default"` for default imports) and provider public export names (`export { x as y }`, `export default`). Byte-identical parser output with/without the change.
   - **CLI**: map a call's local name to the provider's public symbol + package; advertise provider default/aliased exports by public name. Carries the package on `symbolConsumes` so the backend scopes the match precisely (default-import disambiguation across deps).

3. **Renamed-import resolution in `resolveEdges`** (in-repo + co-ingest): `import { format as fmt }; fmt()` previously resolved to nothing within a repo. The lookup now uses the provider's public symbol while the emitted edge keeps the original local name (so the patch builder maps it back). Default imports excluded here (handled in the stitch path). No-op for every non-renamed call.

## Tests
- ix-cli 507/507 + parser smoke green. core-ingestion suite byte-identical to baseline (39 pre-existing node26 native-grammar failures unchanged) with all three changes.
- Live-verified on a 6-repo corpus: renamed (`fmt→format`, `val→validate`), default (`dbg→deflib default`, `alt→altlib default`, correctly disambiguated), and namespace (`core.format()`) all surface in callers/callees; deterministic and order-independent (forward vs reverse ingest byte-identical). In-repo renamed resolution verified fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)