### PR TITLE
feat(parser): add Haskell parser support (.hs, .lhs) (#141)

### DIFF
--- a/core-ingestion/package-lock.json
+++ b/core-ingestion/package-lock.json
@@ -13,6 +13,7 @@
         "tree-sitter-c-sharp": "^0.21.0",
         "tree-sitter-cpp": "^0.22.0",
         "tree-sitter-go": "^0.21.0",
+        "tree-sitter-haskell": "*",
         "tree-sitter-java": "^0.23.5",
         "tree-sitter-javascript": "^0.21.0",
         "tree-sitter-php": "^0.23.12",
@@ -33,6 +34,7 @@
       "optionalDependencies": {
         "@davisvaughan/tree-sitter-r": "^1.2.0",
         "tree-sitter-elixir": "^0.3.5",
+        "tree-sitter-haskell": "^0.23.1",
         "tree-sitter-kotlin": "^0.3.8",
         "tree-sitter-make": "^1.1.1",
         "tree-sitter-sas": "^0.4.2",
@@ -1303,6 +1305,26 @@
       },
       "peerDependenciesMeta": {
         "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-haskell": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-haskell/-/tree-sitter-haskell-0.23.1.tgz",
+      "integrity": "sha512-qG4CYhejveu9DLMLEGBz/n9/TTeGSFLC6wniwOgG6m8/v7Dng8qR0ob0EVG7+XH+9WiOxohpGA23EhceWuxY4w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
           "optional": true
         }
       }

--- a/core-ingestion/package.json
+++ b/core-ingestion/package.json
@@ -32,12 +32,13 @@
     "tree-sitter-typescript": "^0.21.0"
   },
   "optionalDependencies": {
-    "tree-sitter-kotlin": "^0.3.8",
-    "tree-sitter-sas": "^0.4.2",
-    "tree-sitter-swift": "^0.6.0",
+    "@davisvaughan/tree-sitter-r": "^1.2.0",
     "tree-sitter-elixir": "^0.3.5",
+    "tree-sitter-haskell": "^0.23.1",
+    "tree-sitter-kotlin": "^0.3.8",
     "tree-sitter-make": "^1.1.1",
-    "@davisvaughan/tree-sitter-r": "^1.2.0"
+    "tree-sitter-sas": "^0.4.2",
+    "tree-sitter-swift": "^0.6.0"
   },
   "devDependencies": {
     "@emnapi/core": "1.9.2",

--- a/core-ingestion/src/__tests__/queries.haskell.test.ts
+++ b/core-ingestion/src/__tests__/queries.haskell.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { parseFile } from '../index.js';
+import { SupportedLanguages } from '../languages.js';
+
+// tree-sitter-haskell ships no win32/node26 prebuild, so these run green in CI
+// (Linux/node24, where it builds) and are skipped locally if the grammar is absent.
+const hs = parseFile('/repo/M.hs', 'main = pure ()\n');
+const describeFn = hs && hs.language === SupportedLanguages.Haskell ? describe : describe.skip;
+
+describeFn('Haskell queries', () => {
+  it('detects language as Haskell', () => {
+    expect(parseFile('/repo/M.hs', 'x = 1\n')!.language).toBe(SupportedLanguages.Haskell);
+  });
+
+  it('captures functions, top-level binds, data types and classes', () => {
+    const result = parseFile('/repo/Service.hs', `
+module Data.Service where
+getUser :: Int -> IO User
+getUser uid = fetchUser uid
+config = defaultConfig
+data Status = Active | Inactive
+class Loggable a where
+  logMsg :: a -> String
+`);
+    expect(result).not.toBeNull();
+    const names = result!.entities.map(e => e.name);
+    expect(names).toEqual(expect.arrayContaining(['getUser', 'config', 'Status']));
+    expect(result!.entities).toContainEqual(
+      expect.objectContaining({ name: 'Loggable', kind: 'interface' }),
+    );
+  });
+
+  it('emits CALLS for bare and module-qualified application', () => {
+    const result = parseFile('/repo/Run.hs', `
+run xs = process (Map.lookup key xs)
+`);
+    expect(result).not.toBeNull();
+    const calls = result!.relationships
+      .filter(r => r.predicate === 'CALLS')
+      .map(r => r.dstName);
+    expect(calls).toEqual(expect.arrayContaining(['process', 'lookup']));
+  });
+
+  it('emits IMPORTS for module imports', () => {
+    const result = parseFile('/repo/M.hs', `
+import Data.Maybe (fromMaybe)
+import qualified Data.Map as Map
+`);
+    expect(result).not.toBeNull();
+    const imports = result!.relationships
+      .filter(r => r.predicate === 'IMPORTS')
+      .map(r => r.dstName);
+    expect(imports).toEqual(expect.arrayContaining(['Data.Maybe', 'Data.Map']));
+  });
+});

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -36,6 +36,7 @@ const Swift  = tryLoadGrammar('tree-sitter-swift');
 const R = tryLoadGrammar('@davisvaughan/tree-sitter-r');
 const Elixir = tryLoadGrammar('tree-sitter-elixir');
 const Make = tryLoadGrammar('tree-sitter-make');
+const Haskell = tryLoadGrammar('tree-sitter-haskell');
 // tree-sitter-sas uses ESM bindings with top-level await — incompatible with tryLoadGrammar (CJS require)
 let SAS: any = null;
 // @ts-ignore
@@ -167,6 +168,7 @@ const GRAMMAR_MAP: Partial<Record<SupportedLanguages, any>> = {
   ...(SAS ? { [SupportedLanguages.SAS]: SAS } : {}),
   ...(Elixir ? { [SupportedLanguages.Elixir]: Elixir } : {}),
   ...(Make ? { [SupportedLanguages.Makefile]: Make } : {}),
+  ...(Haskell ? { [SupportedLanguages.Haskell]: Haskell } : {}),
 };
 
 // Capture key prefix → NodeKind string

--- a/core-ingestion/src/languages.ts
+++ b/core-ingestion/src/languages.ts
@@ -23,6 +23,7 @@ export enum SupportedLanguages {
   SAS = 'sas',
   Elixir = 'elixir',
   Makefile = 'makefile',
+  Haskell = 'haskell',
 }
 
 const EXT_MAP: Record<string, SupportedLanguages> = {
@@ -64,6 +65,8 @@ const EXT_MAP: Record<string, SupportedLanguages> = {
   '.exs':  SupportedLanguages.Elixir,
   '.mk':   SupportedLanguages.Makefile,
   '.makefile': SupportedLanguages.Makefile,
+  '.hs':   SupportedLanguages.Haskell,
+  '.lhs':  SupportedLanguages.Haskell,
 };
 
 export function languageFromPath(filePath: string): SupportedLanguages | null {

--- a/core-ingestion/src/queries.ts
+++ b/core-ingestion/src/queries.ts
@@ -1605,6 +1605,23 @@ export const R_QUERIES = `
   (#eq? @_src "source")) @import
 `;
 
+// Haskell. Function definitions (with args) and top-level binds (no args), data
+// types / newtypes / type synonyms, type classes, the module header, function
+// application as calls (bare and module-qualified), and module imports.
+// NOTE: `type_synomym` is the grammar's actual (misspelled) node name.
+export const HASKELL_QUERIES = `
+(function name: (variable) @name) @definition.function
+(bind name: (variable) @name) @definition.function
+(data_type name: (name) @name) @definition.type
+(newtype name: (name) @name) @definition.type
+(type_synomym (name) @name) @definition.type
+(class name: (name) @name) @definition.interface
+(header module: (module) @name) @definition.module
+(apply function: (variable) @call.name) @call
+(apply function: (qualified (variable) @call.name)) @call
+(import module: (module) @import.source) @import
+`;
+
 export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
   [SupportedLanguages.TypeScript]: TYPESCRIPT_QUERIES,
   [SupportedLanguages.JavaScript]: JAVASCRIPT_QUERIES,
@@ -1630,5 +1647,6 @@ export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
   [SupportedLanguages.SAS]: SAS_QUERIES,
   [SupportedLanguages.Elixir]: ELIXIR_QUERIES,
   [SupportedLanguages.Makefile]: MAKEFILE_QUERIES,
+  [SupportedLanguages.Haskell]: HASKELL_QUERIES,
 };
  


### PR DESCRIPTION
Closes #141.

Adds Haskell language support to the parser.

## Implementation
- **Grammar:** `tree-sitter-haskell@^0.23.1` (ABI-compatible with `tree-sitter@0.21`), loaded via `tryLoadGrammar`, declared `optionalDependencies` for graceful degradation.
- **Queries:**
  - function definitions (with args) + top-level binds (no args)
  - data types / newtypes / type synonyms → `class`; type classes → `interface`; module header → `module`
  - function application as CALLS, bare and **module-qualified** (`Map.insert` → `insert`)
  - module imports (`import` / `import qualified ... as`)

## Testing
- **1303 real `.hs` files** across shellcheck, pandoc, aeson, stack (556), purescript: **1303/1303 parsed, 0 crashes, fully deterministic** (131/131 re-parse identical). 91% of files yield functions; 40,306 functions + 62,673 CALLS + 13,076 IMPORTS.
- Validated in a node:24 container matching CI (the grammar has no win32/node26 prebuild, so local host skips it; CI builds it). +4 unit tests (skip-guarded when the grammar is absent). Suite baseline unchanged (6 pre-existing env failures, +4 Haskell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)