### PR TITLE
feat(parser): add HTML parser support (.html, .htm) (#129)

### DIFF
--- a/core-ingestion/package-lock.json
+++ b/core-ingestion/package-lock.json
@@ -13,6 +13,7 @@
         "tree-sitter-c-sharp": "^0.21.0",
         "tree-sitter-cpp": "^0.22.0",
         "tree-sitter-go": "^0.21.0",
+        "tree-sitter-html": "*",
         "tree-sitter-java": "^0.23.5",
         "tree-sitter-javascript": "^0.21.0",
         "tree-sitter-php": "^0.23.12",
@@ -33,6 +34,7 @@
       "optionalDependencies": {
         "@davisvaughan/tree-sitter-r": "^1.2.0",
         "tree-sitter-elixir": "^0.3.5",
+        "tree-sitter-html": "^0.23.2",
         "tree-sitter-kotlin": "^0.3.8",
         "tree-sitter-make": "^1.1.1",
         "tree-sitter-sas": "^0.4.2",
@@ -1303,6 +1305,26 @@
       },
       "peerDependenciesMeta": {
         "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-html": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-html/-/tree-sitter-html-0.23.2.tgz",
+      "integrity": "sha512-TN+l+7cCeLx9db/1RhRSqMAZO/266Oh2BHb8J8hMSSFLuzYvFTYP/UnD3S0mny5awzw05KzFNgu2vnwzN9wVJg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
           "optional": true
         }
       }

--- a/core-ingestion/package.json
+++ b/core-ingestion/package.json
@@ -32,12 +32,13 @@
     "tree-sitter-typescript": "^0.21.0"
   },
   "optionalDependencies": {
-    "tree-sitter-kotlin": "^0.3.8",
-    "tree-sitter-sas": "^0.4.2",
-    "tree-sitter-swift": "^0.6.0",
+    "@davisvaughan/tree-sitter-r": "^1.2.0",
     "tree-sitter-elixir": "^0.3.5",
+    "tree-sitter-html": "^0.23.2",
+    "tree-sitter-kotlin": "^0.3.8",
     "tree-sitter-make": "^1.1.1",
-    "@davisvaughan/tree-sitter-r": "^1.2.0"
+    "tree-sitter-sas": "^0.4.2",
+    "tree-sitter-swift": "^0.6.0"
   },
   "devDependencies": {
     "@emnapi/core": "1.9.2",

--- a/core-ingestion/src/__tests__/queries.html.test.ts
+++ b/core-ingestion/src/__tests__/queries.html.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { parseFile } from '../index.js';
+import { SupportedLanguages } from '../languages.js';
+
+const h = parseFile('/repo/i.html', '<html></html>\n');
+const describeFn = h && h.language === SupportedLanguages.HTML ? describe : describe.skip;
+
+describeFn('HTML queries', () => {
+  it('detects language as HTML', () => {
+    expect(parseFile('/repo/index.html', '<!DOCTYPE html><html></html>')!.language)
+      .toBe(SupportedLanguages.HTML);
+  });
+
+  it('emits IMPORTS for script src, link href and anchor/img resources', () => {
+    const result = parseFile('/repo/index.html', `
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="stylesheet" href="styles/main.css">
+  <script src="js/app.js"></script>
+</head>
+<body>
+  <a href="about.html">About</a>
+  <img src="logo.png">
+</body>
+</html>
+`);
+    expect(result).not.toBeNull();
+    const imports = result!.relationships
+      .filter(r => r.predicate === 'IMPORTS')
+      .map(r => r.importRaw);
+    expect(imports).toEqual(
+      expect.arrayContaining(['styles/main.css', 'js/app.js', 'about.html', 'logo.png']),
+    );
+  });
+
+  it('captures custom elements (web components) as definitions', () => {
+    const result = parseFile('/repo/app.html', `
+<body>
+  <app-root></app-root>
+  <my-button label="go"></my-button>
+  <div class="plain"></div>
+</body>
+`);
+    expect(result).not.toBeNull();
+    const names = result!.entities.map(e => e.name);
+    expect(names).toEqual(expect.arrayContaining(['app-root', 'my-button']));
+    expect(names).not.toContain('div');
+  });
+});

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -36,6 +36,7 @@ const Swift  = tryLoadGrammar('tree-sitter-swift');
 const R = tryLoadGrammar('@davisvaughan/tree-sitter-r');
 const Elixir = tryLoadGrammar('tree-sitter-elixir');
 const Make = tryLoadGrammar('tree-sitter-make');
+const Html = tryLoadGrammar('tree-sitter-html');
 // tree-sitter-sas uses ESM bindings with top-level await — incompatible with tryLoadGrammar (CJS require)
 let SAS: any = null;
 // @ts-ignore
@@ -167,6 +168,7 @@ const GRAMMAR_MAP: Partial<Record<SupportedLanguages, any>> = {
   ...(SAS ? { [SupportedLanguages.SAS]: SAS } : {}),
   ...(Elixir ? { [SupportedLanguages.Elixir]: Elixir } : {}),
   ...(Make ? { [SupportedLanguages.Makefile]: Make } : {}),
+  ...(Html ? { [SupportedLanguages.HTML]: Html } : {}),
 };
 
 // Capture key prefix → NodeKind string

--- a/core-ingestion/src/languages.ts
+++ b/core-ingestion/src/languages.ts
@@ -23,6 +23,7 @@ export enum SupportedLanguages {
   SAS = 'sas',
   Elixir = 'elixir',
   Makefile = 'makefile',
+  HTML = 'html',
 }
 
 const EXT_MAP: Record<string, SupportedLanguages> = {
@@ -64,6 +65,9 @@ const EXT_MAP: Record<string, SupportedLanguages> = {
   '.exs':  SupportedLanguages.Elixir,
   '.mk':   SupportedLanguages.Makefile,
   '.makefile': SupportedLanguages.Makefile,
+  '.html': SupportedLanguages.HTML,
+  '.htm':  SupportedLanguages.HTML,
+  '.xhtml': SupportedLanguages.HTML,
 };
 
 export function languageFromPath(filePath: string): SupportedLanguages | null {

--- a/core-ingestion/src/queries.ts
+++ b/core-ingestion/src/queries.ts
@@ -1605,6 +1605,24 @@ export const R_QUERIES = `
   (#eq? @_src "source")) @import
 `;
 
+// HTML. Resource dependencies as imports (<script src>, <link href>, and
+// <a/img/iframe/source/use href|src>), and custom elements (hyphenated tag names
+// = web components) as definitions.
+export const HTML_QUERIES = `
+((script_element
+  (start_tag
+    (attribute (attribute_name) @_a (quoted_attribute_value (attribute_value) @import.source))))
+  (#eq? @_a "src")) @import
+
+((element
+  (start_tag (tag_name) @_t
+    (attribute (attribute_name) @_a (quoted_attribute_value (attribute_value) @import.source))))
+  (#match? @_t "^(link|a|img|iframe|source|use)$")
+  (#match? @_a "^(href|src)$")) @import
+
+((element (start_tag (tag_name) @name) (#match? @name "-")) @definition.class)
+`;
+
 export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
   [SupportedLanguages.TypeScript]: TYPESCRIPT_QUERIES,
   [SupportedLanguages.JavaScript]: JAVASCRIPT_QUERIES,
@@ -1630,5 +1648,6 @@ export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
   [SupportedLanguages.SAS]: SAS_QUERIES,
   [SupportedLanguages.Elixir]: ELIXIR_QUERIES,
   [SupportedLanguages.Makefile]: MAKEFILE_QUERIES,
+  [SupportedLanguages.HTML]: HTML_QUERIES,
 };
  


### PR DESCRIPTION
Closes #129.

## Implementation
- **Grammar:** `tree-sitter-html@^0.23.2` (ABI-compatible with `tree-sitter@0.21`), `tryLoadGrammar`, `optionalDependencies`.
- **Model:** for a code graph, HTML's useful signal is its resource dependencies:
  - IMPORTS: `<script src>`, `<link href>`, `<a|img|iframe|source|use href|src>`
  - definitions: custom elements (hyphenated tag names = web components)

## Testing
- **631 real `.html` files** across html5-boilerplate, bootstrap, mdn/learning-area (549), spectre: **631/631 parsed, 0 crashes, fully deterministic**, 5,930 resource IMPORTS. Custom elements captured when present (rare in these corpora).
- node:24 container matching CI. +3 unit tests (skip-guarded). Suite baseline unchanged (6 pre-existing, +3 HTML).

🤖 Generated with [Claude Code](https://claude.com/claude-code)