### PR TITLE
feat(parser): add HCL/Terraform parser support (.tf, .tfvars) (#134)

### DIFF
--- a/core-ingestion/package-lock.json
+++ b/core-ingestion/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@ix/core-ingestion",
       "version": "0.1.0",
       "dependencies": {
+        "@tree-sitter-grammars/tree-sitter-hcl": "*",
         "tree-sitter": "^0.25.0",
         "tree-sitter-c": "^0.21.0",
         "tree-sitter-c-sharp": "^0.21.0",
@@ -32,6 +33,7 @@
       },
       "optionalDependencies": {
         "@davisvaughan/tree-sitter-r": "^1.2.0",
+        "@tree-sitter-grammars/tree-sitter-hcl": "^1.2.0",
         "tree-sitter-elixir": "^0.3.5",
         "tree-sitter-kotlin": "^0.3.8",
         "tree-sitter-make": "^1.1.1",
@@ -394,6 +396,26 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tree-sitter-grammars/tree-sitter-hcl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@tree-sitter-grammars/tree-sitter-hcl/-/tree-sitter-hcl-1.2.0.tgz",
+      "integrity": "sha512-2bVnOojkkdMLevp0G4v3ksbNoOQFc/Pt9GAdWX4i3aykVyI+CkktE1hsF/XAeUQFjwgGrVZnEyeCll5oD7Ibfg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.3.1",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.25.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",

--- a/core-ingestion/package.json
+++ b/core-ingestion/package.json
@@ -32,12 +32,13 @@
     "tree-sitter-typescript": "^0.21.0"
   },
   "optionalDependencies": {
-    "tree-sitter-kotlin": "^0.3.8",
-    "tree-sitter-sas": "^0.4.2",
-    "tree-sitter-swift": "^0.6.0",
+    "@davisvaughan/tree-sitter-r": "^1.2.0",
+    "@tree-sitter-grammars/tree-sitter-hcl": "^1.2.0",
     "tree-sitter-elixir": "^0.3.5",
+    "tree-sitter-kotlin": "^0.3.8",
     "tree-sitter-make": "^1.1.1",
-    "@davisvaughan/tree-sitter-r": "^1.2.0"
+    "tree-sitter-sas": "^0.4.2",
+    "tree-sitter-swift": "^0.6.0"
   },
   "devDependencies": {
     "@emnapi/core": "1.9.2",

--- a/core-ingestion/src/__tests__/queries.hcl.test.ts
+++ b/core-ingestion/src/__tests__/queries.hcl.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { parseFile } from '../index.js';
+import { SupportedLanguages } from '../languages.js';
+
+const h = parseFile('/repo/m.tf', 'variable "x" {}\n');
+const describeFn = h && h.language === SupportedLanguages.HCL ? describe : describe.skip;
+
+describeFn('HCL queries', () => {
+  it('detects HCL by .tf / .tfvars / .hcl', () => {
+    expect(parseFile('/r/main.tf', 'variable "x" {}')!.language).toBe(SupportedLanguages.HCL);
+    expect(parseFile('/r/vars.tfvars', 'x = 1')!.language).toBe(SupportedLanguages.HCL);
+  });
+
+  it('captures resource/variable/output/module/data blocks by primary name', () => {
+    const result = parseFile('/r/main.tf', `
+resource "aws_instance" "web" { ami = "ami-123" }
+variable "region" { default = "us-east-1" }
+output "ip" { value = aws_instance.web.private_ip }
+data "aws_ami" "ubuntu" { most_recent = true }
+`);
+    expect(result).not.toBeNull();
+    const names = result!.entities.map(e => e.name);
+    expect(names).toEqual(expect.arrayContaining(['web', 'region', 'ip', 'ubuntu']));
+    expect(names).not.toContain('aws_instance');
+  });
+
+  it('emits IMPORTS for module source', () => {
+    const result = parseFile('/r/main.tf', `
+module "vpc" { source = "terraform-aws-modules/vpc/aws" }
+module "db" { source = "./modules/db" }
+`);
+    expect(result).not.toBeNull();
+    const imports = result!.relationships
+      .filter(r => r.predicate === 'IMPORTS')
+      .map(r => r.importRaw ?? r.dstName);
+    expect(imports).toEqual(
+      expect.arrayContaining(['terraform-aws-modules/vpc/aws', './modules/db']),
+    );
+  });
+});

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -36,6 +36,8 @@ const Swift  = tryLoadGrammar('tree-sitter-swift');
 const R = tryLoadGrammar('@davisvaughan/tree-sitter-r');
 const Elixir = tryLoadGrammar('tree-sitter-elixir');
 const Make = tryLoadGrammar('tree-sitter-make');
+const HclPkg = tryLoadGrammar('@tree-sitter-grammars/tree-sitter-hcl');
+const Hcl = HclPkg?.default ?? HclPkg;
 // tree-sitter-sas uses ESM bindings with top-level await — incompatible with tryLoadGrammar (CJS require)
 let SAS: any = null;
 // @ts-ignore
@@ -167,6 +169,7 @@ const GRAMMAR_MAP: Partial<Record<SupportedLanguages, any>> = {
   ...(SAS ? { [SupportedLanguages.SAS]: SAS } : {}),
   ...(Elixir ? { [SupportedLanguages.Elixir]: Elixir } : {}),
   ...(Make ? { [SupportedLanguages.Makefile]: Make } : {}),
+  ...(Hcl ? { [SupportedLanguages.HCL]: Hcl } : {}),
 };
 
 // Capture key prefix → NodeKind string

--- a/core-ingestion/src/languages.ts
+++ b/core-ingestion/src/languages.ts
@@ -23,6 +23,7 @@ export enum SupportedLanguages {
   SAS = 'sas',
   Elixir = 'elixir',
   Makefile = 'makefile',
+  HCL = 'hcl',
 }
 
 const EXT_MAP: Record<string, SupportedLanguages> = {
@@ -64,6 +65,9 @@ const EXT_MAP: Record<string, SupportedLanguages> = {
   '.exs':  SupportedLanguages.Elixir,
   '.mk':   SupportedLanguages.Makefile,
   '.makefile': SupportedLanguages.Makefile,
+  '.tf':   SupportedLanguages.HCL,
+  '.tfvars': SupportedLanguages.HCL,
+  '.hcl':  SupportedLanguages.HCL,
 };
 
 export function languageFromPath(filePath: string): SupportedLanguages | null {

--- a/core-ingestion/src/queries.ts
+++ b/core-ingestion/src/queries.ts
@@ -1605,6 +1605,19 @@ export const R_QUERIES = `
   (#eq? @_src "source")) @import
 `;
 
+// HCL / Terraform. Each labeled block (resource/data/variable/output/module/
+// provider) is a definition named by its primary (last) label; a module's
+// `source` attribute is an import to the referenced module.
+export const HCL_QUERIES = `
+((block (identifier) @_t (string_lit (template_literal) @name) . (block_start))
+  (#match? @_t "^(resource|data|variable|output|module|provider)$")) @definition.class
+
+((block (identifier) @_t
+   (body (attribute (identifier) @_a
+     (expression (literal_value (string_lit (template_literal) @import.source))))))
+  (#eq? @_t "module") (#eq? @_a "source")) @import
+`;
+
 export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
   [SupportedLanguages.TypeScript]: TYPESCRIPT_QUERIES,
   [SupportedLanguages.JavaScript]: JAVASCRIPT_QUERIES,
@@ -1630,5 +1643,6 @@ export const LANGUAGE_QUERIES: Record<SupportedLanguages, string> = {
   [SupportedLanguages.SAS]: SAS_QUERIES,
   [SupportedLanguages.Elixir]: ELIXIR_QUERIES,
   [SupportedLanguages.Makefile]: MAKEFILE_QUERIES,
+  [SupportedLanguages.HCL]: HCL_QUERIES,
 };
  


### PR DESCRIPTION
Closes #134. **Stacked on #254** (tree-sitter 0.25 upgrade — HCL's grammar is ABI-15 and needs the new runtime). Base will retarget to `main` once #254 merges.

## Implementation
- **Grammar:** `@tree-sitter-grammars/tree-sitter-hcl@^1.2.0`, `tryLoadGrammar`, `optionalDependencies`.
- **Model:**
  - labeled blocks (`resource`/`data`/`variable`/`output`/`module`/`provider`) → definitions named by primary label (`resource "aws_instance" "web"` → `web`)
  - module `source` → IMPORTS

## Testing
- **5170 real `.tf`/`.hcl` files** across terraform-aws-eks, terraform-aws-vpc, cloudposse/terraform-aws-components (1809), gruntwork-io/terragrunt (3083), futurice/terraform-examples: **5170/5170 parsed, 0 crashes, fully deterministic**, 17,720 infra definitions + 1,388 module IMPORTS.
- node:24 container on tree-sitter 0.25. +3 unit tests (skip-guarded). Suite baseline unchanged (6 pre-existing, +3 HCL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)