### PR TITLE
fix(core-ingestion): sync package-lock with the 9 new grammars (unbreak CI)

### DIFF
--- a/core-ingestion/package-lock.json
+++ b/core-ingestion/package-lock.json
@@ -32,10 +32,15 @@
       },
       "optionalDependencies": {
         "@davisvaughan/tree-sitter-r": "^1.2.0",
+        "@tree-sitter-grammars/tree-sitter-hcl": "^1.2.0",
         "@tree-sitter-grammars/tree-sitter-lua": "^0.2.0",
+        "@tree-sitter-grammars/tree-sitter-xml": "^0.7.0",
+        "@tree-sitter-grammars/tree-sitter-zig": "^1.1.2",
         "tree-sitter-bash": "^0.21.0",
+        "tree-sitter-css": "^0.25.0",
         "tree-sitter-elixir": "^0.3.5",
         "tree-sitter-haskell": "^0.23.1",
+        "tree-sitter-html": "^0.23.2",
         "tree-sitter-kotlin": "^0.3.8",
         "tree-sitter-make": "^1.1.1",
         "tree-sitter-sas": "^0.4.2",
@@ -398,6 +403,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tree-sitter-grammars/tree-sitter-hcl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@tree-sitter-grammars/tree-sitter-hcl/-/tree-sitter-hcl-1.2.0.tgz",
+      "integrity": "sha512-2bVnOojkkdMLevp0G4v3ksbNoOQFc/Pt9GAdWX4i3aykVyI+CkktE1hsF/XAeUQFjwgGrVZnEyeCll5oD7Ibfg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.3.1",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.25.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tree-sitter-grammars/tree-sitter-lua": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@tree-sitter-grammars/tree-sitter-lua/-/tree-sitter-lua-0.2.0.tgz",
@@ -414,6 +439,50 @@
       },
       "peerDependenciesMeta": {
         "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tree-sitter-grammars/tree-sitter-xml": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@tree-sitter-grammars/tree-sitter-xml/-/tree-sitter-xml-0.7.0.tgz",
+      "integrity": "sha512-AZHPPHEffNECqe1j6SGtgrQryPymKxniIbwI/9FQHvfhHe2Ug/aec51sJr2JWhE8do1Keaul5Yw2U2AiiPEm8Q==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ObserverOfTime"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tree-sitter-grammars/tree-sitter-zig": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tree-sitter-grammars/tree-sitter-zig/-/tree-sitter-zig-1.1.2.tgz",
+      "integrity": "sha512-J0L31HZ2isy3F5zb2g5QWQOv2r/pbruQNL9ADhuQv2pn5BQOzxt80WcEJaYXBeuJ8GHxVT42slpCna8k1c8LOw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
           "optional": true
         }
       }
@@ -1320,6 +1389,29 @@
         }
       }
     },
+    "node_modules/tree-sitter-css": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-css/-/tree-sitter-css-0.25.0.tgz",
+      "integrity": "sha512-FRc9R8ePrwJiUhZsuZ/wcFQ3K8Z+9yCgDrrUjuYswGWlN89UvcB9vslTUGZElQWGwhS8sUw3/r2n4lpb2sxT4Q==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.5.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/tree-sitter"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.25.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tree-sitter-elixir": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/tree-sitter-elixir/-/tree-sitter-elixir-0.3.5.tgz",
@@ -1365,6 +1457,26 @@
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/tree-sitter-haskell/-/tree-sitter-haskell-0.23.1.tgz",
       "integrity": "sha512-qG4CYhejveu9DLMLEGBz/n9/TTeGSFLC6wniwOgG6m8/v7Dng8qR0ob0EVG7+XH+9WiOxohpGA23EhceWuxY4w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-html": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-html/-/tree-sitter-html-0.23.2.tgz",
+      "integrity": "sha512-TN+l+7cCeLx9db/1RhRSqMAZO/266Oh2BHb8J8hMSSFLuzYvFTYP/UnD3S0mny5awzw05KzFNgu2vnwzN9wVJg==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Problem

`main` CI is red. The parser-support merges (#248–#258) declared 5 grammars in `core-ingestion/package.json` `optionalDependencies` whose **resolved tree entries never made it into `package-lock.json`**:

- `tree-sitter-css@0.25.0`
- `tree-sitter-html@0.23.2`
- `@tree-sitter-grammars/tree-sitter-hcl@1.2.0`
- `@tree-sitter-grammars/tree-sitter-xml@0.7.0`
- `@tree-sitter-grammars/tree-sitter-zig@1.1.2`

`npm ci` requires `package.json` and the lock to be in exact sync, so it failed immediately (`EUSAGE … can only install packages when your package.json and package-lock.json are in sync`). The CI "Install core-ingestion deps" step (`npm ci --silent`) errored ~2s in, before any compile. (Root cause: during the merge conflict resolutions the lock was reconciled against a populated `node_modules`, which left these 5 entries unrecorded. `lua`, `bash`, `haskell` landed correctly.)

## Fix

Regenerated `core-ingestion/package-lock.json` from a clean `npm install`. Purely additive (+112 lines); all 9 grammar entries now resolve.

## Verified

In a `node:24` container matching CI: emptied `node_modules`, ran `npm ci` → **exit 0, 89 packages**. Full suite: 250 passed / 6 failed (the pre-existing baseline: Scala/Rust grammar-version-sensitive tests + snapshot/integration tests needing fixtures absent in the sandbox — unchanged by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)