### PR TITLE
feat(search): add --semantic vector-similarity flag

### DIFF
--- a/ix-cli/src/cli/commands/search.ts
+++ b/ix-cli/src/cli/commands/search.ts
@@ -114,6 +114,7 @@ export function registerSearchCommand(program: Command): void {
     .option("--format <fmt>", "Output format (text|json|llm)", "text")
     .option("--include-tests", "Include test and fixture entities in results")
     .option("--tests-only", "Show only test and fixture entities")
+    .option("--semantic", "Use vector-similarity (embedding) search instead of keyword matching")
     .addHelpText("after", `\nRanking priority:
   1. Exact name + exact kind match
   2. Exact name + structural kind (class, function, etc.)
@@ -130,7 +131,7 @@ Examples:
   ix search expand --path memory-layer
   ix search "" --kind file --limit 50 --format json`)
     .action(async (term: string, opts: {
-      limit: string; kind?: string; language?: string; path?: string; asOf?: string; format: string; includeTests?: boolean; testsOnly?: boolean
+      limit: string; kind?: string; language?: string; path?: string; asOf?: string; format: string; includeTests?: boolean; testsOnly?: boolean; semantic?: boolean
     }) => {
       const client = new IxClient(getEndpoint());
       const limit = parseInt(opts.limit, 10);
@@ -145,14 +146,25 @@ Examples:
       // Auto-detect a multi-repo system; when present, scope by system_id (which
       // spans all member repos) instead of the single-repo workspace_id.
       const systemId = await resolveReadSystemId(client);
-      const rawNodes = await client.search(term, {
-        limit: fetchLimit,
-        kind: opts.kind,
-        language: opts.language,
-        asOfRev: opts.asOf ? parseInt(opts.asOf, 10) : undefined,
-        workspaceId: systemId ? undefined : resolveWorkspaceId(),
-        systemId,
-      });
+      const workspaceId = systemId ? undefined : resolveWorkspaceId();
+      // Semantic search hits a different backend endpoint that embeds the term and
+      // returns nodes already ordered by vector similarity. It ignores --language
+      // and --as-of (the endpoint accepts neither); scoping is shared.
+      const rawNodes = opts.semantic
+        ? await client.semanticSearch(term, {
+            limit: fetchLimit,
+            kind: opts.kind,
+            workspaceId,
+            systemId,
+          })
+        : await client.search(term, {
+            limit: fetchLimit,
+            kind: opts.kind,
+            language: opts.language,
+            asOfRev: opts.asOf ? parseInt(opts.asOf, 10) : undefined,
+            workspaceId,
+            systemId,
+          });
       const nodes = effectivePathFilter
         ? rawNodes.filter((node: any) => {
             const sourceUri = normalizePath(node.provenance?.sourceUri ?? node.provenance?.source_uri ?? "");
@@ -160,13 +172,16 @@ Examples:
           })
         : rawNodes;
 
-      // Re-rank client-side using shared scoring + backend weight
+      // Re-rank client-side using shared scoring + backend weight. The rank object
+      // is still computed for display (tier/score), but for semantic search we keep
+      // the backend's vector-similarity order and skip the keyword-based re-sort,
+      // which would otherwise demote semantically-relevant results lacking the term.
       const scored = nodes.map(n => ({
         node: n,
         rank: rankScore(n, term, opts.kind, effectivePathFilter),
       }));
 
-      scored.sort(searchSort);
+      if (!opts.semantic) scored.sort(searchSort);
 
       const { filtered: roleFiltered, hiddenTestCount } = applyRoleFilter(
         scored.map(s => s.node),

--- a/ix-cli/src/client/api.ts
+++ b/ix-cli/src/client/api.ts
@@ -67,6 +67,24 @@ export class IxClient {
     });
   }
 
+  // Vector-similarity search. The backend (POST /v1/search/semantic) embeds the
+  // term and returns nodes already ordered by similarity, so callers must NOT
+  // re-rank. Requires the extraction service to be configured (cloud); otherwise
+  // the backend returns 503. The request field is `term` (not `query`), and this
+  // endpoint does not accept a `language` filter — only term/limit/kind/scoping.
+  async semanticSearch(
+    term: string,
+    opts?: { limit?: number; kind?: string; workspaceId?: string; systemId?: string }
+  ): Promise<GraphNode[]> {
+    return this.post("/v1/search/semantic", {
+      term,
+      limit: opts?.limit,
+      kind: opts?.kind,
+      workspaceId: opts?.workspaceId,
+      systemId: opts?.systemId,
+    });
+  }
+
   async listByKind(
     kind: string,
     opts?: { limit?: number; workspaceId?: string; scope?: string; systemId?: string }


### PR DESCRIPTION
## Summary
Adds `ix search --semantic` for embedding-based (vector-similarity) search, routed to the backend's `POST /v1/search/semantic` endpoint.

## What changed since the original branch
The original `feat/semantic-search` branch was **69 commits behind main** and bundled an already-merged Makefile parser (shipped separately as #211). That stale commit was the source of the PR's ~1900 deletions (including removal of the `parseFile.test.ts.snap`) and the duplicate `tree-sitter-make`/`.npmrc` adds. It has been rebuilt as the feature in isolation, on top of current main.

Three correctness bugs in the original feature were also fixed (verified against the backend source in `ix-memory-layer/.../SearchRoutes.scala`):

- **Endpoint path**: now `/v1/search/semantic`. The original posted to `/v1/semantic-search`, which does not exist (404).
- **Request field**: now sends `term`. The original sent `query`, so the required `term` field was absent and the backend failed to decode the request. Also dropped `language`, which this endpoint does not accept.
- **Result ordering**: the backend returns nodes already ordered by vector similarity. The keyword re-sort is now skipped for `--semantic`, so semantically relevant results that lack the literal term are no longer demoted. Path/role filters and trimming still apply.
- Reuses main's workspace/system read-scoping.
- Dropped the unused `createClient()` helper (dead code).

## Type
- [X] Feature

## Validation
- `tsc --noEmit`: clean
- `vitest run`: full ix-cli suite passes (507 unrelated tests green)

## Notes
Semantic search requires the extraction/embedding service to be configured (cloud); without it the backend returns 503. Original feature by Noah Klein.