### PR TITLE
fix(config): write ~/.ix/config.yaml as 0600 (holds credentials)

### DIFF
--- a/ix-cli/src/cli/__tests__/config-file-mode.test.ts
+++ b/ix-cli/src/cli/__tests__/config-file-mode.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as nodePath from "node:path";
+
+import { saveConfig } from "../config.js";
+
+// Isolate ~/.ix by pointing HOME/USERPROFILE at a temp dir per test.
+let home: string;
+let savedHome: string | undefined;
+let savedProfile: string | undefined;
+
+beforeEach(() => {
+  home = fs.mkdtempSync(nodePath.join(os.tmpdir(), "ix-cfgmode-"));
+  savedHome = process.env.HOME;
+  savedProfile = process.env.USERPROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  fs.mkdirSync(nodePath.join(home, ".ix"), { recursive: true });
+});
+
+afterEach(() => {
+  process.env.HOME = savedHome;
+  process.env.USERPROFILE = savedProfile;
+  try { fs.rmSync(home, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+const cfgPath = () => nodePath.join(home, ".ix", "config.yaml");
+
+describe("saveConfig file mode (credentials live in this file)", () => {
+  it("creates the config 0600", () => {
+    saveConfig({ endpoint: "http://localhost:8090", format: "text" });
+    expect(fs.statSync(cfgPath()).mode & 0o777).toBe(0o600);
+  });
+
+  it("tightens a pre-existing group/world-readable config to 0600", () => {
+    fs.writeFileSync(cfgPath(), "endpoint: http://localhost:8090\nformat: text\n", { mode: 0o644 });
+    fs.chmodSync(cfgPath(), 0o644); // force 0644 regardless of umask
+    saveConfig({ endpoint: "http://localhost:8090", format: "text" });
+    // No group/world bits remain.
+    expect(fs.statSync(cfgPath()).mode & 0o077).toBe(0);
+  });
+});

--- a/ix-cli/src/cli/config.ts
+++ b/ix-cli/src/cli/config.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, rmSync, chmodSync } from "node:fs";
 import { join, resolve as resolvePath } from "node:path";
 import { homedir } from "node:os";
 import { createHash } from "node:crypto";
@@ -88,7 +88,16 @@ export function saveConfig(config: IxConfig): void {
     if (!OSS_OWNED_KEYS.has(k as keyof IxConfig)) preserved[k] = v;
   }
   const merged: Record<string, unknown> = { ...preserved, ...(config as unknown as Record<string, unknown>) };
-  writeFileSync(configPath, stringify(merged));
+  // 0600 — the config holds credentials (Pro's instances carry a tunnel JWT and
+  // a long-lived IdP refresh token). `mode` on writeFileSync only applies when
+  // CREATING the file, so chmodSync enforces it on an already-existing file too
+  // (a pre-existing config written before this fix may be group/world-readable).
+  writeFileSync(configPath, stringify(merged), { mode: 0o600 });
+  try {
+    chmodSync(configPath, 0o600);
+  } catch {
+    // chmod can fail on exotic filesystems; the create-mode above is the primary guard.
+  }
 }
 
 export function getEndpoint(): string {


### PR DESCRIPTION
`saveConfig` never set a file mode, so on **first creation** `~/.ix/config.yaml` was written world/group-readable (umask default `0664`). The file holds credentials — Pro's `instances` carry the tunnel JWT **and** a 12h IdP refresh token. Now writes with `mode: 0o600` and `chmodSync` to enforce it on pre-existing looser files too.

Found by a pre-merge security review of the cloud-auth work (the Pro token-lifecycle branch *asserted* 0600 but nothing enforced it). Small, isolated, OSS-side.