### PR TITLE
build: pin script deps (npm ci) + fix flaky workspace_id migration

### DIFF
--- a/ix-cli/src/cli/config.ts
+++ b/ix-cli/src/cli/config.ts
@@ -46,6 +46,13 @@ export function loadConfig(): IxConfig {
   try {
     const raw = readFileSync(configPath, "utf-8");
     const parsed = parse(raw) as Partial<IxConfig>;
+    // Normalize workspace_id to a string. saveConfig quotes an all-digit path-hash
+    // id, but a hand-edited or legacy unquoted value parses from YAML as a number,
+    // which then silently breaks string id comparisons (e.g. migration detection
+    // would re-key a workspace that is already on the correct id).
+    if (Array.isArray(parsed.workspaces)) {
+      parsed.workspaces = parsed.workspaces.map((w) => ({ ...w, workspace_id: String(w.workspace_id) }));
+    }
     return { ...defaultConfig, ...parsed };
   } catch {
     return defaultConfig;
@@ -123,7 +130,7 @@ export async function createClient(): Promise<IxClient> {
 
 export function loadWorkspaces(): WorkspaceConfig[] {
   const config = loadConfig();
-  return config.workspaces ?? [];
+  return config.workspaces ?? []; // workspace_id already normalized to string in loadConfig
 }
 
 export function findWorkspaceForCwd(cwd: string): WorkspaceConfig | undefined {

--- a/scripts/build-cli.sh
+++ b/scripts/build-cli.sh
@@ -47,7 +47,7 @@ case "${1:---build}" in
 
     echo "Installing dependencies..."
     cd "$CLI_DIR"
-    npm install --silent
+    npm ci --silent  # install exactly from the committed lockfile (pinned/reproducible)
     echo "[ok] Dependencies installed"
 
     echo "Building CLI..."
@@ -79,7 +79,7 @@ case "${1:---build}" in
     if [ ! -d "$CLI_DIR/node_modules" ]; then
       echo "Installing dependencies..."
       cd "$CLI_DIR"
-      npm install --silent
+      npm ci --silent  # install exactly from the committed lockfile (pinned/reproducible)
       echo "[ok] Dependencies installed"
     else
       echo "[ok] Dependencies already installed"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -36,7 +36,7 @@ fi
 # Verify CLI builds
 echo "Verifying CLI build..."
 cd "$IX_DIR/ix-cli"
-npm install --silent
+npm ci --silent  # install exactly from the committed lockfile (pinned/reproducible)
 npm run build
 echo "[ok] CLI builds successfully"
 


### PR DESCRIPTION
Two fixes:

**1. Scorecard `Pinned-Dependencies` (3 alerts):** switch `npm install` → `npm ci` in `scripts/build-cli.sh` (×2) and `scripts/release.sh`, so installs come exactly from the committed lockfile (pinned, reproducible).

**2. Flaky `bootstrap-migration` test → root-caused to a real bug:** an all-digit path-hash `workspace_id` written unquoted (hand-edited or legacy config) parses from YAML as a *number*, so `getOrCreateWorkspace`'s `existing.workspace_id !== pathId` compared number-vs-string and spuriously "re-migrated" a workspace already on the correct id. Fixed by normalizing `workspace_id` to a string in `loadConfig` (single parse point). This was the source of the intermittent CI failures (flaked on whether the temp path hashed to all digits).

Verified: `tsc` clean, `eslint` 0 errors, bootstrap-migration deterministic across 12 repeated runs, full suite 514 passing.