### PR TITLE
fix(ci): Windows tree-sitter native compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,6 @@ jobs:
 
       - name: Install & build
         working-directory: ix-cli
-        env:
-          IX_FORCE_INSTALL: "1" # DIAGNOSTIC: force fresh tree-sitter compile to surface MSVC error
         run: |
           npm ci --silent
           npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,12 @@ jobs:
         include:
           - { os: ubuntu-latest, node: "22", coverage: true }
           - { os: ubuntu-latest, node: "24" }
-          - { os: windows-latest, node: "22" }
+          # Pinned to windows-2022: windows-latest now ships Visual Studio 18,
+          # which the node-gyp bundled with node 22's npm cannot detect
+          # ("unknown version") so the native tree-sitter compile fails. VS2022
+          # is the toolchain node-gyp supports. Revisit when node-gyp ships
+          # VS18 support (then windows-latest can return).
+          - { os: windows-2022, node: "22" }
           - { os: macos-14, node: "22" }
           - { os: macos-14, node: "24" }
     defaults:
@@ -92,7 +97,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: core-ingestion/node_modules
-          key: core-ingestion-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('core-ingestion/package-lock.json') }}
+          # v2: invalidate caches potentially poisoned by the failed VS18 runs
+          # (runner.os is "Windows" for both windows-latest and windows-2022).
+          key: core-ingestion-v2-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('core-ingestion/package-lock.json') }}
 
       - name: Configure native build flags (node 24)
         if: matrix.node == '24'
@@ -158,7 +165,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: core-ingestion/node_modules
-          key: core-ingestion-${{ runner.os }}-node22-${{ hashFiles('core-ingestion/package-lock.json') }}
+          key: core-ingestion-v2-${{ runner.os }}-node22-${{ hashFiles('core-ingestion/package-lock.json') }}
 
       - name: Build CLI
         working-directory: ix-cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
 
       - name: Install & build
         working-directory: ix-cli
+        env:
+          IX_FORCE_INSTALL: "1" # DIAGNOSTIC: force fresh tree-sitter compile to surface MSVC error
         run: |
           npm ci --silent
           npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,10 @@ jobs:
           - target: darwin-arm64
             runner: macos-14
           - target: windows-amd64
-            runner: windows-latest
+            # Pinned to windows-2022: windows-latest ships Visual Studio 18,
+            # which node 22's bundled node-gyp cannot detect, breaking the
+            # native tree-sitter compile. VS2022 is the supported toolchain.
+            runner: windows-2022
     defaults:
       run:
         shell: bash

--- a/ix-cli/scripts/build-core-ingestion.mjs
+++ b/ix-cli/scripts/build-core-ingestion.mjs
@@ -11,7 +11,7 @@ const nodeModules = resolve(coreIngestionDir, 'node_modules');
 // skips the native tree-sitter recompile, which is the slowest and most
 // failure-prone step. Set IX_FORCE_INSTALL=1 to force a clean `npm ci`.
 if (process.env.IX_FORCE_INSTALL === '1' || !existsSync(nodeModules)) {
-  execSync(`${npmCmd} ci --silent`, {
+  execSync(`${npmCmd} ci --foreground-scripts`, {
     cwd: coreIngestionDir,
     shell: true,
     stdio: 'inherit',

--- a/ix-cli/scripts/build-core-ingestion.mjs
+++ b/ix-cli/scripts/build-core-ingestion.mjs
@@ -11,7 +11,7 @@ const nodeModules = resolve(coreIngestionDir, 'node_modules');
 // skips the native tree-sitter recompile, which is the slowest and most
 // failure-prone step. Set IX_FORCE_INSTALL=1 to force a clean `npm ci`.
 if (process.env.IX_FORCE_INSTALL === '1' || !existsSync(nodeModules)) {
-  execSync(`${npmCmd} ci --foreground-scripts`, {
+  execSync(`${npmCmd} ci --silent`, {
     cwd: coreIngestionDir,
     shell: true,
     stdio: 'inherit',


### PR DESCRIPTION
Investigating + fixing the Windows-only `npm ci` failure on PRs that bust the `core-ingestion/node_modules` cache (e.g. dependabot bumps #292/#293).

Root cause: the tree-sitter native compile is broken on the `windows-latest` runner; a `node_modules` cache normally hides it, so it only surfaces on a cache miss. `--silent` masks the actual MSVC error.

First commit is **diagnostic** (un-silences the compile + forces a fresh install) to capture the runner error. The real fix + re-silencing follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)