### PR TITLE
fix(deps): unblock knip 6.27+ (platform-dispatch binaries) and hold TS major in core-ingestion

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,10 +32,10 @@ updates:
       interval: weekly
     open-pull-requests-limit: 5
     ignore:
-      # Toolchain majors need a deliberate, tested migration, not an auto-bump:
-      # TypeScript 7 is the native Go port; typescript-eslint throws at module
-      # load on it and Next.js 16.2 can't detect it, so the org holds TS 7
-      # everywhere. Minor/patch still flow.
+      # Toolchain majors need a deliberate, tested migration, not an auto-bump.
+      # core-ingestion is already on TypeScript 7 (#311). A TS 8 major would be a
+      # deliberate migration validated by the tsc build plus the vitest suite over
+      # the tree-sitter grammars, not an auto-bump. Minor/patch still flow.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,13 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      # Toolchain majors need a deliberate, tested migration, not an auto-bump:
+      # TypeScript 7 is the native Go port; typescript-eslint throws at module
+      # load on it and Next.js 16.2 can't detect it, so the org holds TS 7
+      # everywhere. Minor/patch still flow.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       dev-dependencies:
         dependency-type: development

--- a/ix-cli/knip.json
+++ b/ix-cli/knip.json
@@ -3,5 +3,5 @@
   "entry": ["src/cli/main.ts", "src/index.ts", "test/parser.smoke.mjs"],
   "project": ["src/**/*.ts"],
   "ignore": ["test/fixtures/**", "test/parser.stress.mjs"],
-  "ignoreBinaries": ["ix", "cygpath", "tar"]
+  "ignoreBinaries": ["ix", "cygpath", "tar", "start", "xdg-open"]
 }


### PR DESCRIPTION
Unblocks dependabot PR #312 (dev-dependencies group in `/ix-cli`), whose **Lint & Typecheck** job is red.

## Root cause

knip **6.27.0** added shell-command binary detection. `openBrowser()` in `ix-cli/src/cli/commands/view.ts` (lines ~169-181) dispatches per platform:

```ts
if (plat === "darwin")      execSync(`open ${url}`, ...);
else if (plat === "win32")  execSync(`start ${url}`, ...);
else                        execSync(`xdg-open ${url}`, ...);
```

knip now parses those `execSync` strings and reports `start` and `xdg-open` as **Unlisted binaries (2)**, exiting 1. These are OS-provided commands, not project dependencies, so this is a false positive about intentional platform dispatch. knip 6.24.0 (main's current pin) exits 0 on the identical tree, so the failure is isolated to the knip bump alone.

## Fix

1. `ix-cli/knip.json`: `ignoreBinaries` extended from `["ix", "cygpath", "tar"]` to `["ix", "cygpath", "tar", "start", "xdg-open"]` — same treatment already given to `cygpath`/`tar`.
2. `.github/dependabot.yml`: added the same `typescript` `version-update:semver-major` ignore that `/ix-cli` already carries to the `/core-ingestion` entry. TypeScript 7 is the native Go port; typescript-eslint throws at module load on it and Next.js 16.2 cannot detect it, so the org stance is to hold TS 7 everywhere. core-ingestion compiles fine under TS 7 today but should not drift ahead of the rest of the org.

## Red/green evidence

All runs are `npm run knip` in `ix-cli/` on this tree.

**(a) RED — knip 6.27.0, without the knip.json change:**
```
6.27.0
> @ix/cli@0.6.1 knip
> knip

Unlisted binaries (2)
start     src/cli/commands/view.ts
xdg-open  src/cli/commands/view.ts
...
KNIP_EXIT=1
```

Same failure on **6.29.0**, the version #312 actually proposes:
```
6.29.0
Unlisted binaries (2)
start     src/cli/commands/view.ts
xdg-open  src/cli/commands/view.ts
KNIP_EXIT=1
```

**(b) GREEN — with the change:**
```
=== GREEN 6.29.0 ===
Configuration hints (6)
...
KNIP_EXIT=0
=== GREEN 6.27.0 ===
Configuration hints (6)
...
KNIP_EXIT=0
```

**(c) Landing this ahead of #312 cannot red main** — knip **6.24.0** (main's current lockfile version, restored via `npm ci`) still exits 0 with the change applied. It emits two extra non-fatal configuration *hints* (`start`/`xdg-open` "Remove from ignoreBinaries"), which do not affect the exit code:
```
knip version: 6.24.0
Configuration hints (8)
tar       knip.json  Remove from ignoreBinaries
start     knip.json  Remove from ignoreBinaries
xdg-open  knip.json  Remove from ignoreBinaries
...
KNIP_EXIT=0
```
(`tar` already produced the same hint on main before this PR, so the pattern is pre-existing and tolerated.)

**(d) Rest of the Lint & Typecheck job is undisturbed:**
```
> eslint src
✖ 39 problems (0 errors, 39 warnings)
LINT_EXIT=0

> tsc --noEmit
TSC_EXIT=0
```

## Next step for #312

Once this lands on main, rebase/recreate #312 (comment `@dependabot rebase`) — do not force-push its branch — and its Lint & Typecheck job should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
