### PR TITLE
fix(cli): drop the goals Pro stub, removed from @ix/pro

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Underlying structural commands — useful for debugging or fine-grained inspecti
 | Goal | Command | Example |
 |---|---|---|
 | Create a goal | `ix goal create` | `ix goal create "Support GitHub" --format json` |
-| List goals | `ix goals` | `ix goals --status active --format json` |
+| List goals | `ix goal list` | `ix goal list --status active --format json` |
 | Create a plan | `ix plan create` | `ix plan create "Fix auth" --goal <id> --responds-to <bugId> --format json` |
 | Add a task | `ix plan task` | `ix plan task "Step 1" --plan <id> --depends-on <taskId> --resolves <bugId> --workflow-staged '{"discover":["ix overview X"],"implement":["ix map"],"validate":["ix smells"]}' --format json` |
 | Plan status | `ix plan status` | `ix plan status <id> --format json` |

--- a/ix-cli/src/cli/register/oss.ts
+++ b/ix-cli/src/cli/register/oss.ts
@@ -42,7 +42,6 @@ const PRO_COMMANDS: { name: string; desc: string }[] = [
   { name: "decide", desc: "Record a design decision" },
   { name: "decisions", desc: "List recorded design decisions" },
   { name: "goal", desc: "Manage project goals" },
-  { name: "goals", desc: "List all goals" },
   { name: "patches", desc: "List recent patches" },
   { name: "plan", desc: "Manage plans and plan tasks" },
   { name: "task", desc: "Manage tasks" },


### PR DESCRIPTION
## Summary

Follow-up to [Ix-pro#103](https://github.com/ix-infrastructure/Ix-pro/pull/103), which removed `ix goals` as a duplicate of `ix goal list`.

`PRO_COMMANDS` in `ix-cli/src/cli/register/oss.ts` still listed it. Since `registerProStubs()` registers a hidden stub for every entry Pro didn't claim, OSS-only installs were printing:

> The 'goals' command requires Ix Pro.
> Install @ix/pro to enable premium features.

...for a command that installing Pro no longer provides. This is the cross-repo half of that cleanup.

## Scope

- `oss.ts` — drop the `goals` entry. `goal` stays; Pro still registers it.
- `CLAUDE.md` — the "List goals" row pointed at `ix goals`. Agents read this table, so it would have kept recommending a deleted command. Now `ix goal list`, same flags.

**Blast radius is OSS-only.** `registerProStubs` is called only in the `else` branch of the Pro-load probe in `main.ts:57`, so anyone with `@ix/pro` installed never saw the stub and sees no change.

**`ix help goals` still works and is kept on purpose.** The forwarder at `workflows.ts:83` redirects the topic to `goal`'s help, which documents `goal list` — the right landing spot for anyone with the old command in muscle memory. It's now load-bearing: with the stub gone, the generic topic lookup below it no longer resolves `goals`.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 39 files / 534 tests pass, 1 file + 2 tests skipped (pre-existing), parser smoke passes
- [x] Direct `registerProStubs` check on a bare program: stubs are now `briefing bug bugs decide decisions goal patches plan plans task tasks truth workflow` — `goals` absent, `goal` present
- [x] `git diff --check` silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)