### PR TITLE
docs(readme): add Kartr alpha signup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,33 @@
 
 <br/>
 
----
+## Sign up for Kartr
 
-<br/>
+We built Kartr on top of this technology.
+
+An agentic platform where AI agents with persistent memory work alongside you, at your job and in your day to day life.
+
+Kartr aggregates your knowledge from every source you already use:
+
+- your code and systems
+- your docs and files
+- your email and calendar
+- your meetings and notes
+- your team chat
+
+One memory, built from all of it, that your agents can reason over.
+
+Agents that remember.
+Agents that carry context across sources and sessions.
+Agents that get more useful the longer you use them.
+
+Kartr is in alpha. We're onboarding early users now.
+
+<p align="center">
+  <a href="https://docs.google.com/forms/d/e/1FAIpQLSdh5IXVGW9mNBUtyBAsP_uysS38GgilpTNMbKRAVQf1FZ1eBg/viewform?usp=pp_url&amp;entry.2087374943=ix_github" target="_blank" rel="noopener noreferrer">
+    <img src="https://img.shields.io/badge/Sign%20up%20for%20the%20Kartr%20alpha-%E2%86%92-8A2BE2?style=for-the-badge" />
+  </a>
+</p>
 
 ## Problem
 Running out of tokens while developing?


### PR DESCRIPTION
Adds a Kartr alpha signup CTA to the README, above the `## Problem` section, to convert the current inbound traffic.

## What's in it

- New `## Sign up for Kartr` section positioned in the top matter, directly after the star line
- Copy frames Kartr as an agentic platform with persistent memory, and is specific about aggregation: code, docs, email, calendar, meetings, team chat
- Centered shields.io button linking to the alpha form with `entry.2087374943=ix_github` so signups from the repo are attributable
- Removes the README's single `---`, which otherwise bracketed the new section in a way no other section has

## Notes

- `target="_blank"` is on the anchor but **GitHub strips it** — the form will open in the same tab on github.com. The attribute only takes effect in renderers that don't sanitize.
- Rendered and reviewed locally through GitHub's own `/markdown` API, so the preview matched the real repo page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)