### PR TITLE
fix(install): Docker auto-install silently did nothing on Linux

### DIFF
--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -509,7 +509,11 @@ install_docker() {
           err "Could not download the Docker Compose plugin.
   Install it manually: https://docs.docker.com/compose/install/linux/"
         fi
-        sudo install -m 0755 "$compose_bin" /usr/local/lib/docker/cli-plugins/docker-compose
+        if ! sudo install -m 0755 "$compose_bin" /usr/local/lib/docker/cli-plugins/docker-compose; then
+          rm -f "$compose_bin"
+          err "Could not install the Docker Compose plugin.
+  Install it manually: https://docs.docker.com/compose/install/linux/"
+        fi
         rm -f "$compose_bin"
       fi
       ;;
@@ -739,7 +743,7 @@ else
 
     # Pull images first so we catch rate limits / auth errors clearly
     echo "  Pulling Docker images (this may take a few minutes on first run)..."
-    PULL_LOG=$(mktemp /tmp/ix-pull-XXXXXX.log)
+    PULL_LOG=$(mktemp /tmp/ix-pull-XXXXXX) || err "Could not create a temporary file for the image pull log."
     dc -f "$COMPOSE_DIR/docker-compose.yml" pull < /dev/null >"$PULL_LOG" 2>&1 &
     PULL_PID=$!
     while kill -0 "$PULL_PID" 2>/dev/null; do
@@ -774,7 +778,7 @@ else
 
     # Start services
     printf "  Starting backend services..."
-    START_LOG=$(mktemp /tmp/ix-start-XXXXXX.log)
+    START_LOG=$(mktemp /tmp/ix-start-XXXXXX) || err "Could not create a temporary file for the startup log."
     if ! dc -f "$COMPOSE_DIR/docker-compose.yml" up -d < /dev/null >"$START_LOG" 2>&1; then
       echo ""
       echo "  Failed to start backend. Error output:"

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -459,7 +459,25 @@ install_docker() {
       ;;
     Linux)
       echo "  Installing Docker Engine via get.docker.com..."
-      _fetch https://get.docker.com | sh < /dev/null
+      # Download to a file instead of piping into `sh`. This installer is
+      # normally run as `curl ... | sh`, so commands get `< /dev/null` to stop
+      # them consuming the piped installer off stdin. On a *pipe into* `sh`
+      # that redirect wins over the pipe: sh read the install script from
+      # /dev/null, did nothing, and exited 0 — so Docker was never installed
+      # and the failure was silent. (The Homebrew call above is safe: it uses
+      # command substitution, not a pipe.)
+      get_docker=$(mktemp /tmp/get-docker-XXXXXX.sh)
+      if ! _download https://get.docker.com "$get_docker"; then
+        rm -f "$get_docker"
+        err "Could not download the Docker install script from get.docker.com.
+  Install Docker manually: https://docs.docker.com/engine/install/"
+      fi
+      if ! sh "$get_docker" < /dev/null; then
+        rm -f "$get_docker"
+        err "Docker Engine install failed.
+  Install Docker manually: https://docs.docker.com/engine/install/"
+      fi
+      rm -f "$get_docker"
       if ! id -nG "$USER" 2>/dev/null | grep -qw docker; then
         echo "  Adding $USER to the docker group..."
         sudo usermod -aG docker "$USER" < /dev/null 2>/dev/null || true

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -466,7 +466,13 @@ install_docker() {
       # /dev/null, did nothing, and exited 0 — so Docker was never installed
       # and the failure was silent. (The Homebrew call above is safe: it uses
       # command substitution, not a pipe.)
-      get_docker=$(mktemp /tmp/get-docker-XXXXXX.sh)
+      # No `.sh` suffix on the template: BusyBox mktemp (Alpine) passes the
+      # template straight to mkstemp() and rejects anything not ending in
+      # XXXXXX. `sh FILE` does not care about the extension. Handle a mktemp
+      # failure explicitly too — under `set -e` it would otherwise abort with
+      # just "mktemp: Invalid argument" and no hint at which step died.
+      get_docker=$(mktemp /tmp/get-docker-XXXXXX) || err "Could not create a temporary file for the Docker install script.
+  Install Docker manually: https://docs.docker.com/engine/install/"
       if ! _download https://get.docker.com "$get_docker"; then
         rm -f "$get_docker"
         err "Could not download the Docker install script from get.docker.com.
@@ -492,8 +498,19 @@ install_docker() {
         if [ "$(uname -m)" = "aarch64" ]; then compose_arch="aarch64"; fi
         compose_url="https://github.com/docker/compose/releases/latest/download/docker-compose-linux-${compose_arch}"
         sudo mkdir -p /usr/local/lib/docker/cli-plugins
-        sudo _download "$compose_url" /usr/local/lib/docker/cli-plugins/docker-compose
-        sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+        # `_download` is a shell function, so it cannot be run through sudo:
+        # sudo execs a program and functions do not survive the exec, so this
+        # died with "sudo: _download: command not found". Fetch as the current
+        # user, then place the binary with sudo.
+        compose_bin=$(mktemp /tmp/docker-compose-XXXXXX) || err "Could not create a temporary file for the Docker Compose plugin.
+  Install it manually: https://docs.docker.com/compose/install/linux/"
+        if ! _download "$compose_url" "$compose_bin"; then
+          rm -f "$compose_bin"
+          err "Could not download the Docker Compose plugin.
+  Install it manually: https://docs.docker.com/compose/install/linux/"
+        fi
+        sudo install -m 0755 "$compose_bin" /usr/local/lib/docker/cli-plugins/docker-compose
+        rm -f "$compose_bin"
       fi
       ;;
     MINGW*|MSYS*|CYGWIN*)

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -497,7 +497,10 @@ install_docker() {
         compose_arch="x86_64"
         if [ "$(uname -m)" = "aarch64" ]; then compose_arch="aarch64"; fi
         compose_url="https://github.com/docker/compose/releases/latest/download/docker-compose-linux-${compose_arch}"
-        sudo mkdir -p /usr/local/lib/docker/cli-plugins
+        if ! sudo mkdir -p /usr/local/lib/docker/cli-plugins; then
+          err "Could not create /usr/local/lib/docker/cli-plugins.
+  Install Docker Compose manually: https://docs.docker.com/compose/install/linux/"
+        fi
         # `_download` is a shell function, so it cannot be run through sudo:
         # sudo execs a program and functions do not survive the exec, so this
         # died with "sudo: _download: command not found". Fetch as the current
@@ -778,7 +781,8 @@ else
 
     # Start services
     printf "  Starting backend services..."
-    START_LOG=$(mktemp /tmp/ix-start-XXXXXX) || err "Could not create a temporary file for the startup log."
+    # The printf above left the cursor mid-line, so break it before erroring.
+    START_LOG=$(mktemp /tmp/ix-start-XXXXXX) || { echo ""; err "Could not create a temporary file for the startup log."; }
     if ! dc -f "$COMPOSE_DIR/docker-compose.yml" up -d < /dev/null >"$START_LOG" 2>&1; then
       echo ""
       echo "  Failed to start backend. Error output:"


### PR DESCRIPTION
Found while working #328. Unrelated to that bug, so it's split out here.

## The bug

`scripts/install/install.sh:462`

```sh
_fetch https://get.docker.com | sh < /dev/null
```

The `< /dev/null` redirect binds to `sh` and **overrides the pipe**. `sh` reads its script from `/dev/null`, does nothing, and exits `0`.

So on any Linux machine without Docker, the installer printed `Installing Docker Engine via get.docker.com...`, installed nothing, reported success, and then failed further down at the compose step — with nothing indicating Docker had never been installed.

Demonstrated:

```console
$ printf 'echo "DOCKER INSTALL RAN"\n' | sh < /dev/null
$ echo $?
0        # no output, and success
```

## Why the redirect is there

It's deliberate everywhere else in this script. The installer is normally run as `curl -fsSL https://ix-infra.com/install.sh | sh`, so the installer's own source is on stdin; every command gets `< /dev/null` to stop it consuming the rest of the script. That's correct — it's only wrong when the command being protected is *itself* on the receiving end of a pipe.

The Homebrew call at line 193 does the same job safely, because it uses command substitution rather than a pipe:

```sh
/bin/bash -c "$(_fetch https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" < /dev/null
```

This line was the only place the two patterns collided.

## The fix

Download to a temp file, then run it with stdin still pointed at `/dev/null`. The pipe is no longer load-bearing, so the redirect and the script no longer contend for stdin.

A failed download or a failed install now aborts with an actionable message pointing at the manual install docs, rather than being swallowed. Previously **both** were silent. The temp file is removed on every path.

## Verification

| path | result |
|---|---|
| happy path | script executes, reaches post-install, no temp left |
| download fails | aborts with actionable error, no temp left |
| install script exits 7 | aborts with actionable error, no temp left |

Each failure case stops before the post-install step, confirming the abort works.

- `sh -n scripts/install/install.sh` passes
- shellcheck error-level findings: **1 → 0** (this was SC2259, the file's only one)

## Note

This changes behavior: a genuine Docker install failure now stops the installer instead of continuing silently. That's the intent — the current silence is what makes this bug hard to spot from the user side — but it is a behavior change worth a look during review.