### PR TITLE
fix(deps): stop the prerequisites doc being parsed as a pip manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ All you need beforehand is a terminal with `curl` (or `wget`). On Windows, insta
 
 Works on macOS, Linux, and Windows, on both x86-64 and arm64.
 
+For the full list, including the endpoints the installer reaches and the directories it creates, see [docs/prerequisites.md](docs/prerequisites.md).
+
 ## Supported Languages
 
 Ix parses and extracts symbols, calls, and imports across 26 languages, and recognizes several more config and data formats.

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -1,19 +1,34 @@
-# Ix — System Prerequisites
+# System Prerequisites
+
+Everything the Ix installer checks for and installs, and the endpoints and
+directories it touches. Reference documentation — not a dependency manifest.
+
+> **Do not move this back to `requirements.txt`, and do not give it a `.txt` or
+> `.in` extension.**
+>
+> Every entry below is a *system* package — curl, git, node, docker, ripgrep —
+> and none is a PyPI dependency of this repo. While this file lived at
+> `requirements.txt`, GitHub's dependency graph parsed it as pip and recorded
+> nine phantom PyPI packages against the repo; seven of those (`arangodb`,
+> `docker`, `docker-compose`, `homebrew`, `node`, `npm`, `ripgrep`) are real
+> PyPI names owned by unrelated projects, so the SBOM asserted dependencies
+> that do not exist. The graph job then failed outright on
+> `ix-memory-layer==latest`, which pip cannot parse.
+>
+> The extension matters as much as the name: Dependabot's pip fetcher
+> enumerates `.txt` and `.in` files in the repo root *and one directory deep*,
+> then decides by filename or by whether every line parses as a requirement.
+> Keeping this as Markdown puts it outside that scan entirely, rather than
+> relying on one line staying unparseable.
+
+```
+# Ix — System Requirements
 #
 # Everything listed here is checked and installed by the install script:
 #   curl -fsSL https://ix-infra.com/install.sh | sh
 #
 # Fully automated on macOS and Linux.
 # Windows requires manual Docker Desktop install, then re-run.
-#
-# NOTE: this is documentation, not a pip manifest, and it is deliberately not
-# named requirements.txt. Everything below is a *system* package — curl, git,
-# node, docker, ripgrep — none of them PyPI ones. While this file was named
-# requirements.txt, GitHub's dependency graph parsed it as pip and recorded
-# nine phantom PyPI dependencies, several of which (docker, docker-compose,
-# npm) are real PyPI names belonging to unrelated projects. The graph update
-# then failed outright on "ix-memory-layer==latest", which pip cannot parse.
-# Please don't rename it back.
 #
 # ============================================================================
 #  STEP 0: System prerequisites (auto-installed if missing)
@@ -123,3 +138,4 @@ ripgrep>=13
 #
 # Wrapper: /usr/local/bin/ix (if writable) or ~/.local/bin/ix (fallback)
 # Ports: 8090 (Memory Layer), 8529 (ArangoDB) — localhost only
+```

--- a/docs/prerequisites.txt
+++ b/docs/prerequisites.txt
@@ -1,10 +1,19 @@
-# Ix — System Requirements
+# Ix — System Prerequisites
 #
 # Everything listed here is checked and installed by the install script:
 #   curl -fsSL https://ix-infra.com/install.sh | sh
 #
 # Fully automated on macOS and Linux.
 # Windows requires manual Docker Desktop install, then re-run.
+#
+# NOTE: this is documentation, not a pip manifest, and it is deliberately not
+# named requirements.txt. Everything below is a *system* package — curl, git,
+# node, docker, ripgrep — none of them PyPI ones. While this file was named
+# requirements.txt, GitHub's dependency graph parsed it as pip and recorded
+# nine phantom PyPI dependencies, several of which (docker, docker-compose,
+# npm) are real PyPI names belonging to unrelated projects. The graph update
+# then failed outright on "ix-memory-layer==latest", which pip cannot parse.
+# Please don't rename it back.
 #
 # ============================================================================
 #  STEP 0: System prerequisites (auto-installed if missing)


### PR DESCRIPTION
Fixes the `Dependency Graph` failure currently red on `main`, and removes nine phantom dependencies from the repo's SBOM.

## What's wrong

`requirements.txt` was never a pip manifest. It documents *system* packages — curl, git, node, docker, ripgrep — in a requirements-like style. GitHub's dependency graph parsed it as pip regardless, which caused two separate problems.

**Wrong supply-chain metadata.** The graph currently records nine PyPI packages for this repo:

```console
$ gh api repos/ix-infrastructure/Ix/dependency-graph/sbom \
    --jq '[.sbom.packages[] | select(.externalRefs[]?.referenceLocator | test("pkg:pypi")) | .name] | unique'
["arangodb","curl","docker","docker-compose","git","homebrew","node","npm","ripgrep"]
```

Seven of those nine — `arangodb`, `docker`, `docker-compose`, `homebrew`, `node`, `npm`, `ripgrep` — are **real PyPI names owned by unrelated projects** (only `curl` and `git` 404). So the SBOM asserts a dependency on, for instance, the Docker SDK for Python. Nothing has materialized from it yet: there are zero pip Dependabot alerts, and `dependabot.yml` has no pip ecosystem entry, so version-update PRs can't fire. But security-update PRs and `dependency-review-action` both read the graph, so it is wrong data sitting in the supply-chain surface.

**The graph update fails.** `ix-memory-layer==latest` is not parseable by pip:

```
dependency_file_not_evaluatable
InstallationError("Invalid requirement: 'ix-memory-layer==latest': Expected semicolon
(after name with no version specifier) or end")
```

That line has been there since #146 in April 2026 (`5728519c`). It only went red now because #326 touched the file, and touching it is what triggers the job — `Dependency Graph` has exactly one run in its history. Pre-existing, not a regression from #326.

## The fix

Converted to `docs/prerequisites.md`, and linked from README's `## Requirements` section.

**The extension is what matters, not the name.** My first attempt renamed to `docs/prerequisites.txt` on the assumption that dropping the word "requirements" was enough. Review showed that is wrong: Dependabot's pip fetcher (`python/lib/dependabot/python/shared_file_fetcher.rb`) enumerates `.txt` and `.in` files in the repo root **and one directory deep**, so `docs/prerequisites.txt` was still inside the scan radius. It escaped only on a content technicality — `requirements_file?` falls back to requiring *every* line to parse as a requirement, and exactly one line (`ix-memory-layer==latest`) fails. Anyone later "fixing" that line to something parseable would have silently re-detected the file as a pip manifest under `docs/`, reinstating the phantom dependencies.

Markdown sits outside that scan entirely, so the fix no longer depends on one line staying broken. The repo now contains no `.txt` or `.in` file at all.

The spec is fenced **verbatim** — byte-for-byte identical to the original, verified by `diff` — because its `#`-prefixed lines would otherwise render as Markdown headings. The rationale moves above the fence as prose and now records the extension rule, not just "don't rename it back".

## Why this is safe

Nothing referenced the old path. `git grep -i requirement` across all tracked files returns exactly three hits: this file, `README.md:149` (`## Requirements`, hand-written prose, which linked nothing before this PR), and `ix-cli/src/cli/system.ts:17` — an unrelated comment about filenames that appear in ordinary subdirectories, explaining why `REPO_MANIFESTS` excludes them.

No script reads it. Packaging is unaffected: `release.yml` stages explicit paths (`cp -rL ix-cli/dist ix-cli/node_modules ix-cli/package.json ...`), never a root glob, so the file was never in the tarball. The Homebrew source tarball is GitHub's tag archive, which contains all tracked files — the file just moves inside it, and `Formula/ix.rb` never references it. No `package.json` has a `files:` array; there is no `.npmignore`.

No other file in the repo is misparsed the same way — no `Pipfile`, `setup.py`, `pyproject.toml`, or `environment.yml` exists.

## Expected after merge

The `Graph Update: pip in /.` job stops being created, and the nine phantom PyPI entries drop out of the graph on the next default-branch parse. Post-merge check: re-run the SBOM command above and confirm the pypi list is empty.

