### PR TITLE
fix: remove raw NUL bytes that made the two largest sources unsearchable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,21 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # A raw NUL byte makes a file "binary" to grep/ripgrep, which then skips it
+      # silently — including `ix text`, which shells out to rg. Two of the
+      # largest sources in this repo carried them and were invisible to search.
+      # Needs no toolchain, so it runs first and fails in seconds.
+      - name: No raw NUL bytes in tracked sources
+        run: |
+          status=0
+          for f in $(git ls-files '*.ts' '*.tsx' '*.js' '*.mjs' '*.cjs'); do
+            n=$(tr -dc '\000' < "$f" | wc -c)
+            if [ "$n" -gt 0 ]; then
+              echo "::error file=$f::$n raw NUL byte(s) — use the \\x00 escape instead; a raw NUL makes this file binary to grep/ripgrep, which silently skips it"
+              status=1
+            fi
+          done
+          exit $status
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,28 @@ jobs:
       # largest sources in this repo carried them and were invisible to search.
       # Needs no toolchain, so it runs first and fails in seconds.
       - name: No raw NUL bytes in tracked sources
+        # `shell: bash` for -o pipefail: without it the `tr | wc` pipeline below
+        # reports wc's exit status, so a failed read would score as "0 NULs".
+        shell: bash
         run: |
           status=0
-          for f in $(git ls-files '*.ts' '*.tsx' '*.js' '*.mjs' '*.cjs'); do
+          checked=0
+          # -z / read -d '': a path containing a space would otherwise word-split,
+          # the redirect would fail, and `wc -c` would still print 0 — passing the
+          # file as clean. A guard against silent skipping must not skip silently.
+          while IFS= read -r -d '' f; do
+            checked=$((checked + 1))
             n=$(tr -dc '\000' < "$f" | wc -c)
             if [ "$n" -gt 0 ]; then
               echo "::error file=$f::$n raw NUL byte(s) — use the \\x00 escape instead; a raw NUL makes this file binary to grep/ripgrep, which silently skips it"
               status=1
             fi
-          done
+          done < <(git ls-files -z '*.ts' '*.tsx' '*.mts' '*.cts' '*.js' '*.jsx' '*.mjs' '*.cjs')
+          if [ "$checked" -eq 0 ]; then
+            echo "::error::NUL-byte guard matched no files — the pathspecs or working directory are wrong, so this check is protecting nothing"
+            exit 1
+          fi
+          echo "checked $checked tracked sources"
           exit $status
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -508,7 +508,7 @@ function extractJsExportPublicNames(rootNode: any): ExportPublicName[] {
           const local = localN.text;
           const pub = pubN && pubN.text ? pubN.text : local;
           if (pub !== local) {
-            const k = `${local} ${pub}`;
+            const k = `${local}\x00${pub}`;
             if (!seen.has(k)) { seen.add(k); out.push({ local, public: pub }); }
           }
         }
@@ -518,7 +518,7 @@ function extractJsExportPublicNames(rootNode: any): ExportPublicName[] {
         const nameNode = (decl.childForFieldName && decl.childForFieldName('name')) || decl.namedChild(0);
         const nm = nameNode?.text;
         if (nm) {
-          const k = `${nm} default`;
+          const k = `${nm}\x00default`;
           if (!seen.has(k)) { seen.add(k); out.push({ local: nm, public: 'default' }); }
         }
       }
@@ -1193,7 +1193,7 @@ function parseLatexFile(filePath: string, source: string): FileParseResult {
       const envName = (args[0] ?? '').trim();
       if (envName) {
         const cont = container();
-        const key = `${cont} ${envName}`;
+        const key = `${cont}\x00${envName}`;
         if (!seenEnv.has(key)) {
           seenEnv.add(key);
           entities.push({ name: envName, kind: 'environment', lineStart: line, lineEnd: line, language, container: cont === fileName ? undefined : cont });

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -541,7 +541,7 @@ export async function ingestFiles(
         const pkg = specToPkg(typeof rel.importRaw === 'string' ? rel.importRaw : rel.dstName);
         if (!pkg || !stitchProdDeps.has(pkg)) continue;
         const consumerNodeId = fileNodeId(workspaceId, p.filePath);
-        const k = `${pkg} ${consumerNodeId}`;
+        const k = `${pkg}\u0000${consumerNodeId}`;
         if (stitchConsumeSeen.has(k)) continue;
         stitchConsumeSeen.add(k);
         stitchConsumes.push({ name: pkg, consumerNodeId });
@@ -1299,7 +1299,7 @@ export async function ingestFiles(
           const def = stitchDefs.get(a.local);
           if (!def) continue;
           const nodeId = symbolNodeId(workspaceId, def.filePath, def.qk);
-          const ek = `${a.pub} ${nodeId}`;
+          const ek = `${a.pub}\u0000${nodeId}`;
           if (stitchExportAliasSeen.has(ek)) continue;
           stitchExportAliasSeen.add(ek);
           stitchExports.push({ name: a.pub, nodeId });
@@ -1327,7 +1327,7 @@ export async function ingestFiles(
             if (stitchDefs.has(c.symbol)) continue;
           }
           const callerNodeId = symbolNodeId(workspaceId, callerDef.filePath, callerDef.qk);
-          const sk = `${symbol} ${pkg ?? ''} ${callerNodeId}`;
+          const sk = `${symbol}\u0000${pkg ?? ''}\u0000${callerNodeId}`;
           if (symbolConsumeSeen.has(sk)) continue;
           symbolConsumeSeen.add(sk);
           symbolConsumes.push({ symbol, callerNodeId, pkg });


### PR DESCRIPTION
## The bug

Two files carried literal NUL bytes, used as separators in composite `Set` keys inside template literals:

```ts
const k = `${pkg}<NUL>${consumerNodeId}`;     // ingest.ts:544
```

| file | raw NULs | lines | `file` reports |
|---|---|---|---|
| `core-ingestion/src/index.ts` | 3 | 3,665 | `data` |
| `ix-cli/src/cli/commands/ingest.ts` | 4 | 1,558 | `data` |

A single NUL makes a file binary as far as grep, `git grep` and ripgrep are concerned — and they then skip it **silently**. No match, no warning, exit 0.

These are the two largest files in the repo. A contributor grepping for a symbol defined in either one gets nothing back and reasonably concludes it doesn't exist. It also degrades the product itself: `ix text` shells out to ripgrep (`text.ts:37`), so **ix could not search its own source**.

This is not theoretical — it repeatedly produced empty results during a codebase audit before the cause was found.

## The fix

Replaced each raw byte with the escape **already used elsewhere in the same file**, so each file stays internally consistent:

- `ingest.ts` → the unicode escape, matching its own line 1470 (`const sep = ""`)
- `index.ts` → the hex escape, matching its own lines 812 and 820

## This is a no-op at runtime

Verified rather than assumed — the escaped forms and a raw NUL produce the same string:

```
uni escape === raw NUL : true
hex escape === raw NUL : true
separator charCode     : 0 0
identical lengths      : true
```

Only the on-disk encoding of the literal changes.

## Verification

| check | before | after |
|---|---|---|
| `file` on both | `data` | `JavaScript source, Unicode text, UTF-8` |
| `grep -c stitchConsumeSeen ingest.ts` | 0 (skipped silently) | **3** |
| `grep -c seenEnv index.ts` | 0 (skipped silently) | **3** |
| raw NULs in any tracked `.ts` | 7 | **0** |
| `tsc --noEmit` (both packages) | clean | clean |
| ix-cli suite | 536 passing | 536 passing |
| core-ingestion suite | 6 failed / 271 passed | 6 failed / 271 passed |

The core-ingestion failures are **pre-existing on `main`** and unrelated to this change — I ran the suite on `main` and on this branch and diffed the failing test list, which is byte-identical. (They're the `memory-layer/` fixture tests and two query tests; separate issue, and that suite isn't run by CI at all today.)

## Regression guard

Added a check to the fast `static` gate. It needs no toolchain, so it runs before install and fails in seconds with a per-file GitHub annotation:

```
::error file=<path>::N raw NUL byte(s) — use the \x00 escape instead; a raw NUL
makes this file binary to grep/ripgrep, which silently skips it
```

Confirmed both directions: passes on the fixed tree, and fails when a NUL is deliberately reintroduced.
