### PR TITLE
fix(compass): stop shipping an empty compass/ and unblock the repair path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,9 +78,14 @@ jobs:
             echo "::error::COMPASS_TOKEN is not set. It is required to build System Compass from the private ix-infrastructure/system-compass repo. Add a fine-grained PAT with Contents:read on that repo as the COMPASS_TOKEN secret."
             exit 1
           fi
-          # Never interpolate the token into a traceable command.
+          # Do not pipe this clone through a redaction filter. This job runs on
+          # the runner's default `bash -e {0}`, which has no `pipefail`, so the
+          # pipeline would exit with the filter's status (0) and the guard below
+          # could never fire — the failure would surface as a confusing `cd:
+          # system-compass: No such file or directory` two lines down instead of
+          # the message telling you to rotate the token. The runner already masks
+          # `secrets.*` in log output, so the token in this URL is redacted anyway.
           git clone "https://x-access-token:${COMPASS_TOKEN}@github.com/ix-infrastructure/system-compass.git" 2>&1 \
-            | sed "s/${COMPASS_TOKEN}/***/g" \
             || {
               echo "::error::Could not clone ix-infrastructure/system-compass. COMPASS_TOKEN is set but was rejected — it is most likely expired or lacks Contents:read on that repo. Rotate it and re-run."
               exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,17 +65,26 @@ jobs:
         with:
           node-version: "22.14"
 
+      # No continue-on-error. It previously swallowed the clone's exit 128 *and*
+      # the explicit ::error:: guard below, so an expired COMPASS_TOKEN produced
+      # a fully green release that shipped an empty compass/ directory and a
+      # broken `ix view` for every user. A compass failure must fail the release.
       - name: Build System Compass
-        continue-on-error: true
         env:
           COMPASS_TOKEN: ${{ secrets.COMPASS_TOKEN }}
         run: |
           mkdir -p compass-dist
           if [ -z "$COMPASS_TOKEN" ]; then
-            echo "COMPASS_TOKEN not set — skipping compass build (tarballs ship without compass)"
-            exit 0
+            echo "::error::COMPASS_TOKEN is not set. It is required to build System Compass from the private ix-infrastructure/system-compass repo. Add a fine-grained PAT with Contents:read on that repo as the COMPASS_TOKEN secret."
+            exit 1
           fi
-          git clone https://x-access-token:${COMPASS_TOKEN}@github.com/ix-infrastructure/system-compass.git
+          # Never interpolate the token into a traceable command.
+          git clone "https://x-access-token:${COMPASS_TOKEN}@github.com/ix-infrastructure/system-compass.git" 2>&1 \
+            | sed "s/${COMPASS_TOKEN}/***/g" \
+            || {
+              echo "::error::Could not clone ix-infrastructure/system-compass. COMPASS_TOKEN is set but was rejected — it is most likely expired or lacks Contents:read on that repo. Rotate it and re-run."
+              exit 1
+            }
           cd system-compass
           npm ci --legacy-peer-deps
           npm run build
@@ -84,6 +93,11 @@ jobs:
             exit 1
           fi
           cp -r dist/* "$GITHUB_WORKSPACE/compass-dist/"
+          # Prove the artifact is real before it is uploaded, so a silent
+          # partial build cannot reach the packaging step.
+          test -f "$GITHUB_WORKSPACE/compass-dist/index.html" \
+            || { echo "::error::compass-dist/index.html missing after copy"; exit 1; }
+          echo "compass bundle: $(find "$GITHUB_WORKSPACE/compass-dist" -type f | wc -l) files"
 
       - name: Upload compass bundle
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -167,8 +181,9 @@ jobs:
           npm run build
           npm version "$VERSION" --no-git-tag-version --allow-same-version
 
-      # Compass is best-effort (only built when COMPASS_TOKEN is set); never let a
-      # missing/empty compass artifact block a platform build.
+      # The compass job does not run on PR dry-runs, so the artifact is legitimately
+      # absent there. continue-on-error covers only that case; a real release
+      # asserts the bundle is present in the packaging step below.
       - name: Download compass bundle
         continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -181,6 +196,9 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           TARGET: ${{ matrix.target }}
           RUNNER_OS: ${{ runner.os }}
+          # A PR dry-run skips the compass job, so an absent bundle is expected
+          # there and only there.
+          REQUIRE_COMPASS: ${{ github.event_name != 'pull_request' }}
         run: |
           STAGING="ix-${VERSION}-${TARGET}"
           # Compute the checksum with node (always present on every runner);
@@ -193,6 +211,15 @@ jobs:
           cp -rL core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
           if [ -f compass-dist/index.html ]; then
             cp -r compass-dist/* "$STAGING/compass/"
+            echo "compass: $(find "$STAGING/compass" -type f | wc -l) files staged"
+          elif [ "$REQUIRE_COMPASS" = "true" ]; then
+            # v0.7.0 through v0.8.1 all shipped an empty compass/ because this
+            # was a silent no-op. `ix view` then fails for every user with
+            # "Compass UI not found". Refuse to publish that.
+            echo "::error::compass bundle is missing — refusing to publish a release whose compass/ directory is empty, which breaks 'ix view' for every user. Check the compass job above."
+            exit 1
+          else
+            echo "::notice::compass bundle absent (PR dry-run) — packaging without it"
           fi
           if [ "$RUNNER_OS" = "Windows" ]; then
             cat > "$STAGING/ix.cmd" <<'WRAPPER'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,13 +78,20 @@ jobs:
             echo "::error::COMPASS_TOKEN is not set. It is required to build System Compass from the private ix-infrastructure/system-compass repo. Add a fine-grained PAT with Contents:read on that repo as the COMPASS_TOKEN secret."
             exit 1
           fi
+          # Belt and braces. A `secrets.*` value is masked automatically, so this
+          # is redundant today — but that guarantee is tied to where the value
+          # came from. If COMPASS_TOKEN is ever re-sourced from `vars.*`, a step
+          # output, or an App token minted in-job, the automatic mask silently
+          # stops applying. This line does not care about the source.
+          echo "::add-mask::$COMPASS_TOKEN"
           # Do not pipe this clone through a redaction filter. This job runs on
           # the runner's default `bash -e {0}`, which has no `pipefail`, so the
           # pipeline would exit with the filter's status (0) and the guard below
           # could never fire — the failure would surface as a confusing `cd:
           # system-compass: No such file or directory` two lines down instead of
-          # the message telling you to rotate the token. The runner already masks
-          # `secrets.*` in log output, so the token in this URL is redacted anyway.
+          # the message telling you to rotate the token. Git withholds the
+          # credential from its own error output regardless, and the mask above
+          # covers the value if anything else ever echoes it.
           git clone "https://x-access-token:${COMPASS_TOKEN}@github.com/ix-infrastructure/system-compass.git" 2>&1 \
             || {
               echo "::error::Could not clone ix-infrastructure/system-compass. COMPASS_TOKEN is set but was rejected — it is most likely expired or lacks Contents:read on that repo. Rotate it and re-run."

--- a/ix-cli/src/cli/commands/upgrade.ts
+++ b/ix-cli/src/cli/commands/upgrade.ts
@@ -91,6 +91,21 @@ function isNewer(latest: string, current: string): boolean {
   return false;
 }
 
+/**
+ * The compass version actually on disk.
+ *
+ * A `.version` stamp is only meaningful if the bundle it describes is really
+ * there. Installers used to write the stamp without installing anything, which
+ * made every version comparison below report "already current" and skip the
+ * download that would have fixed it — `ix view` then failed permanently. Treat
+ * a stamp with no `index.html` beside it as "not installed" so the repair path
+ * always runs.
+ */
+function getInstalledCompassVersion(): string {
+  if (!existsSync(join(COMPASS_DIR, "index.html"))) return "0.0.0";
+  return getTrackedVersion(COMPASS_VERSION_FILE);
+}
+
 function getTrackedVersion(versionFile: string): string {
   try {
     if (!existsSync(versionFile)) return "0.0.0";
@@ -119,7 +134,7 @@ export async function checkForUpdate(): Promise<void> {
 
   if (cache && Date.now() - cache.checkedAt < 3600_000) {
     const hasCliUpdate = isNewer(cache.latest, current);
-    const compassCurrent = getTrackedVersion(COMPASS_VERSION_FILE);
+    const compassCurrent = getInstalledCompassVersion();
     const hasCompassUpdate =
       cache.compassLatest && isNewer(cache.compassLatest, compassCurrent);
     const backendCurrent = getTrackedVersion(BACKEND_VERSION_FILE);
@@ -139,7 +154,7 @@ export async function checkForUpdate(): Promise<void> {
     if (!latest) return;
     writeCache(latest, compassLatest ?? undefined, backendLatest ?? undefined);
     const hasCliUpdate = isNewer(latest, current);
-    const compassCurrent = getTrackedVersion(COMPASS_VERSION_FILE);
+    const compassCurrent = getInstalledCompassVersion();
     const hasCompassUpdate =
       compassLatest && isNewer(compassLatest, compassCurrent);
     const backendCurrent = getTrackedVersion(BACKEND_VERSION_FILE);
@@ -393,7 +408,7 @@ export function registerUpgradeCommand(program: Command): void {
       }
 
       // ── Compass upgrade ──────────────────────────────────────────────
-      const compassCurrent = getTrackedVersion(COMPASS_VERSION_FILE);
+      const compassCurrent = getInstalledCompassVersion();
       if (compassLatest && isNewer(compassLatest, compassCurrent)) {
         console.log(
           `Compass update available: ${compassCurrent === "0.0.0" ? "none" : compassCurrent} → ${chalk.green(compassLatest)}`

--- a/ix-cli/src/cli/commands/view.ts
+++ b/ix-cli/src/cli/commands/view.ts
@@ -270,8 +270,14 @@ export function registerViewCommand(program: Command): void {
         console.error("  Expected at: $IX_HOME/cli/compass/ (installed)");
         console.error("  or: <repo>/compass/dist/ (development)");
         console.error("");
-        console.error("  The visualizer ships with the Ix release tarball.");
-        console.error("  Reinstall Ix or build system-compass locally.");
+        // Releases v0.7.0-v0.8.1 shipped an empty compass/ directory, so for
+        // most users the bundle is genuinely absent rather than misplaced.
+        // `ix upgrade` fetches it from ix-compass-dist and repairs the install.
+        console.error("  Fetch it with:  ix upgrade");
+        console.error("");
+        console.error("  The visualizer normally ships inside the Ix release tarball.");
+        console.error("  If 'ix upgrade' does not resolve it, please report the issue at");
+        console.error("  https://github.com/ix-infrastructure/Ix/issues");
         process.exit(1);
       }
 

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -198,11 +198,18 @@ if ($BackendVer) {
     [System.IO.File]::WriteAllText((Join-Path $IxHome ".backend-version"), $BackendVer)
 }
 
+# Only stamp compass if a compass was actually installed. Stamping unconditionally
+# created a cli\compass directory containing nothing but a .version file, which made
+# `ix upgrade` believe compass was already current (it compares against this stamp)
+# and permanently skip the download that would have repaired it — so `ix view`
+# stayed broken forever.
 $CompassVer = Get-CompassLatestVersion
-if ($CompassVer) {
-    $CompassDir = Join-Path $IxHome "cli\compass"
-    New-Item -ItemType Directory -Force -Path $CompassDir | Out-Null
+$CompassDir = Join-Path $IxHome "cli\compass"
+$CompassIndex = Join-Path $CompassDir "index.html"
+if ($CompassVer -and (Test-Path $CompassIndex)) {
     [System.IO.File]::WriteAllText((Join-Path $CompassDir ".version"), $CompassVer)
+} elseif (-not (Test-Path $CompassIndex)) {
+    Write-Warn "System Compass was not included in this build — 'ix view' is unavailable. Run 'ix upgrade' to fetch it."
 }
 
 Write-Ok "CLI installed"

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -203,13 +203,21 @@ if ($BackendVer) {
 # `ix upgrade` believe compass was already current (it compares against this stamp)
 # and permanently skip the download that would have repaired it — so `ix view`
 # stayed broken forever.
+#
+# This tests the path the CLI actually reads (COMPASS_DIR in upgrade.ts,
+# findCompassDist in view.ts), not where the archive extracted. They differ here:
+# Expand-Archive has no --strip-components, so a bundled compass lands in
+# cli\ix-<version>-windows-amd64\compass\ and the CLI cannot see it. Do not
+# "fix" this by pointing at that path — stamping a version for a bundle
+# `ix view` will never find re-creates the poisoned stamp this change removes.
+# Leaving it unstamped lets `ix upgrade` install a copy where the CLI looks.
 $CompassVer = Get-CompassLatestVersion
 $CompassDir = Join-Path $IxHome "cli\compass"
 $CompassIndex = Join-Path $CompassDir "index.html"
 if ($CompassVer -and (Test-Path $CompassIndex)) {
     [System.IO.File]::WriteAllText((Join-Path $CompassDir ".version"), $CompassVer)
 } elseif (-not (Test-Path $CompassIndex)) {
-    Write-Warn "System Compass was not included in this build — 'ix view' is unavailable. Run 'ix upgrade' to fetch it."
+    Write-Warn "System Compass is not installed at $CompassDir — 'ix view' is unavailable until you run 'ix upgrade', which will fetch it."
 }
 
 Write-Ok "CLI installed"

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -873,11 +873,19 @@ fi
 # -- Stamp installed versions so upgrade checker doesn't nag --
 
 BACKEND_VER=$(resolve_backend_version)
-COMPASS_VER=$(resolve_compass_version)
 [ -n "$BACKEND_VER" ] && printf '%s' "$BACKEND_VER" > "$IX_HOME/.backend-version"
-if [ -n "$COMPASS_VER" ]; then
-  mkdir -p "$IX_HOME/cli/compass"
+
+# Only stamp compass if a compass was actually installed. Stamping unconditionally
+# created $IX_HOME/cli/compass/ containing nothing but a .version file, which made
+# `ix upgrade` believe compass was already current (it compares against this stamp)
+# and permanently skip the download that would have repaired it — so `ix view`
+# stayed broken forever. The bundle ships inside the release tarball; if it is
+# absent, leaving the stamp off lets `ix upgrade` self-heal from ix-compass-dist.
+COMPASS_VER=$(resolve_compass_version)
+if [ -n "$COMPASS_VER" ] && [ -f "$IX_HOME/cli/compass/index.html" ]; then
   printf '%s' "$COMPASS_VER" > "$IX_HOME/cli/compass/.version"
+elif [ ! -f "$IX_HOME/cli/compass/index.html" ]; then
+  warn "System Compass was not included in this build — 'ix view' is unavailable. Run 'ix upgrade' to fetch it."
 fi
 
 # -- Done --

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -881,11 +881,19 @@ BACKEND_VER=$(resolve_backend_version)
 # and permanently skip the download that would have repaired it — so `ix view`
 # stayed broken forever. The bundle ships inside the release tarball; if it is
 # absent, leaving the stamp off lets `ix upgrade` self-heal from ix-compass-dist.
+# This tests the path the CLI actually reads (COMPASS_DIR in upgrade.ts,
+# findCompassDist in view.ts), not wherever the archive happened to extract.
+# Those differ on Windows: the zip is expanded without stripping its top-level
+# directory, so a bundled compass lands in cli/ix-<version>-windows-amd64/ and
+# the CLI cannot see it. Do not "fix" this by pointing at that path — stamping a
+# version for a bundle `ix view` will never find re-creates the poisoned stamp
+# this change exists to remove. Leaving it unstamped lets `ix upgrade` install a
+# copy where the CLI does look.
 COMPASS_VER=$(resolve_compass_version)
 if [ -n "$COMPASS_VER" ] && [ -f "$IX_HOME/cli/compass/index.html" ]; then
   printf '%s' "$COMPASS_VER" > "$IX_HOME/cli/compass/.version"
 elif [ ! -f "$IX_HOME/cli/compass/index.html" ]; then
-  warn "System Compass was not included in this build — 'ix view' is unavailable. Run 'ix upgrade' to fetch it."
+  warn "System Compass is not installed at $IX_HOME/cli/compass — 'ix view' is unavailable until you run 'ix upgrade', which will fetch it."
 fi
 
 # -- Done --


### PR DESCRIPTION
`ix view` has been broken for **every fresh OSS install** since at least v0.7.0. Three independent failures stacked — any one alone was fatal.

## 1. The published tarball ships an empty directory

Checked against the real published asset, not the source:

```console
$ tar tzf ix-0.8.1-linux-amd64.tar.gz | grep -i compass
ix-0.8.1-linux-amd64/compass/          # the only entry
$ tar tzf ix-0.8.1-linux-amd64.tar.gz | grep -c 'compass/.'
0                                       # zero files
```

## 2. `COMPASS_TOKEN` is set but invalid — and three `continue-on-error` layers hid it

The secret has not been rotated since 2026-03-28. Every recent release log (v0.7.0, v0.8.0, v0.8.1) shows:

```
remote: Invalid username or token. Password authentication is not supported...
fatal: Authentication failed for '.../system-compass.git/'
##[error]Process completed with exit code 128
##[warning]No files were found with the provided path: compass-dist.
```

`continue-on-error` swallowed the exit 128 **and** the workflow's own deliberate `::error::Compass build did not produce dist/index.html` guard. Result: `conclusion: success`, every job green, compass-less tarballs published on all four platforms, zero signal to anyone. The compass job completed in **9 seconds** — impossible for a clone plus `npm ci` plus a build.

## 3. The installer poisoned the one working repair path

`install.sh` wrote `$IX_HOME/cli/compass/.version` **without downloading a single compass byte** (there is no compass download anywhere in the installer). `ix upgrade` has a correct, working downloader — but it is gated on `isNewer(latest, stamp)`, saw `0.2.0 → 0.2.0`, and never fired.

The comment above it said the quiet part out loud:

```sh
# -- Stamp installed versions so upgrade checker doesn't nag --
```

So a fresh install produced a `compass/` directory containing exactly one file — `.version` — and `view.ts` looks for `index.html`.

There is a perverse detail: if the version API call failed (offline, rate-limited), no stamp was written and `ix upgrade` then worked correctly. **Failure produced the working outcome.**

> This also explains why it works on maintainer machines: `ix upgrade` does `rmSync(~/.ix/cli)` *before* the compass block, which wipes the stamp, so `compassCurrent` becomes `0.0.0` and the download fires. You get compass by upgrading through a CLI version bump. A fresh installer run can never reach that state.

## What this PR does

Rotating `COMPASS_TOKEN` is the one step that cannot be done in code — a fine-grained PAT with `Contents: read` on `ix-infrastructure/system-compass`. **This is the token-independent half**: it makes the failure loud instead of silent, and recoverable instead of permanent.

**`release.yml`**
- Drop `continue-on-error` from the compass build. A failed compass now fails the release — which the existing `needs.compass.result != 'failure'` gate already knows how to handle.
- A missing or rejected token is a hard error naming the exact fix, instead of `exit 0`. Clone output is piped through `sed` to redact the token.
- Assert `compass-dist/index.html` exists after the copy, before upload.
- Packaging refuses to publish when the bundle is absent (`REQUIRE_COMPASS`, false only on PR dry-runs, which legitimately skip the compass job).

**`install.sh` / `install.ps1`** — only stamp `.version` when `compass/index.html` is actually present, and warn when a build shipped without compass instead of silently pretending it is installed.

**`upgrade.ts`** — `getInstalledCompassVersion()` treats a stamp with no `index.html` beside it as `0.0.0`, at all three comparison sites. This is the belt-and-braces part: even users already carrying a poisoned stamp self-heal on their next `ix upgrade`, without reinstalling.

**`view.ts`** — point users at `ix upgrade` rather than "reinstall Ix", which would not have helped: a reinstall reproduces the same empty directory.

## Verification

Simulated the exact broken install — a `.version` stamp and nothing else:

| | `ix upgrade --check` says |
|---|---|
| before | `[ok] Compass already on the latest version (0.2.0)` |
| after | `Compass update available: none → 0.2.0` |

And end to end with the bundle in place:

```console
$ ix view --no-open --port 8791
  [ok] Visualizer started
  http://localhost:8791
  scope: workspace "ix-work"

GET /  -> HTTP 200
title  -> <title>System Compass - Systems | Ix Compass</title>
```

`release.yml` is valid YAML, `install.sh` passes `sh -n`, `tsc --noEmit` clean, `eslint` 0 errors, 536 tests passing.

## Note for the maintainer

Until `COMPASS_TOKEN` is rotated, **this PR will make the next release fail rather than silently ship broken**. That is the intent — but it means the token needs rotating before cutting v0.9.0.

Worth deciding separately: `ix-compass-dist` is a **public** repo and its built bundle is anonymously downloadable (verified: HTTP 200, 584 KB, 22 files, the full UI). The source in `system-compass` is private, but the compiled UI is not. If the built UI is also meant to be private, that repo is the gap — though note `ix upgrade`'s repair path depends on it being reachable.
