### PR TITLE
fix(test): quote workspace_id so the migration fixture stops flaking

### DIFF
--- a/ix-cli/src/cli/__tests__/bootstrap-migration.test.ts
+++ b/ix-cli/src/cli/__tests__/bootstrap-migration.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as nodePath from "node:path";
+import { parse } from "yaml";
 
 import { ensureWorkspaceIdState } from "../bootstrap.js";
 import { workspaceIdForPath } from "../system.js";
@@ -27,10 +28,26 @@ afterEach(() => {
 });
 
 function writeConfig(workspaces: object[]) {
+  // workspace_id MUST be quoted. It is 8 hex chars, so ~1.6% of ids are
+  // numeric-looking to YAML — "709e7420" parses as Infinity, "01311916" as
+  // 1311916 — and loadConfig's String() normalization cannot recover the
+  // original text once the parser has coerced it. An unquoted fixture then
+  // fires a spurious migration and fails "does NOT migrate" at that rate.
+  // saveConfig (yaml.stringify) quotes these for real, so quoting here is
+  // also what makes the fixture faithful to a config the CLI actually wrote.
   const body = "endpoint: http://localhost:8090\n" +
     "workspaces:\n" +
     workspaces.map((w: any) =>
-      `  - workspace_id: ${w.workspace_id}\n    workspace_name: ${w.workspace_name}\n    root_path: ${w.root_path}\n    default: ${w.default ?? false}\n`).join("");
+      `  - workspace_id: "${w.workspace_id}"\n    workspace_name: ${w.workspace_name}\n    root_path: ${w.root_path}\n    default: ${w.default ?? false}\n`).join("");
+
+  // Enforce it rather than trusting the template: an unquoted id reintroduces
+  // a 1-in-60 heisenbug, and this turns that into a deterministic failure.
+  const parsed = parse(body) as { workspaces?: { workspace_id: unknown }[] };
+  (parsed.workspaces ?? []).forEach((w, i) => {
+    expect(typeof w.workspace_id, "workspace_id must survive YAML as a string").toBe("string");
+    expect(w.workspace_id).toBe((workspaces[i] as any).workspace_id);
+  });
+
   fs.writeFileSync(nodePath.join(home, ".ix", "config.yaml"), body);
 }
 

--- a/ix-cli/src/cli/__tests__/bootstrap-migration.test.ts
+++ b/ix-cli/src/cli/__tests__/bootstrap-migration.test.ts
@@ -29,11 +29,12 @@ afterEach(() => {
 
 function writeConfig(workspaces: object[]) {
   // workspace_id MUST be quoted. It is 8 hex chars, so ~3.7% of ids are
-  // numeric-looking to YAML. loadConfig's String() normalization recovers the
-  // plain-integer ones, but not the other ~1.6% — "709e7420" parses as
-  // Infinity, "01311916" as 1311916 — because the original text is gone once
-  // the parser has coerced the value. An unquoted fixture then fires a
-  // spurious migration and fails "does NOT migrate" at that 1.6%.
+  // numeric-looking to YAML. loadConfig's String() normalization round-trips
+  // an integer that reprints identically ("12345678"), but not the other
+  // ~1.6% — "709e7420" parses as Infinity, and "01311916" comes back 1311916
+  // with the leading zero gone — because the original text is lost once the
+  // parser has coerced the value. An unquoted fixture then fires a spurious
+  // migration and fails "does NOT migrate" at that 1.6%.
   // saveConfig (yaml.stringify) quotes these for real, so quoting here is
   // also what makes the fixture faithful to a config the CLI actually wrote.
   const body = "endpoint: http://localhost:8090\n" +

--- a/ix-cli/src/cli/__tests__/bootstrap-migration.test.ts
+++ b/ix-cli/src/cli/__tests__/bootstrap-migration.test.ts
@@ -40,12 +40,23 @@ function writeConfig(workspaces: object[]) {
     workspaces.map((w: any) =>
       `  - workspace_id: "${w.workspace_id}"\n    workspace_name: ${w.workspace_name}\n    root_path: ${w.root_path}\n    default: ${w.default ?? false}\n`).join("");
 
-  // Enforce it rather than trusting the template: an unquoted id reintroduces
-  // a 1-in-60 heisenbug, and this turns that into a deterministic failure.
-  const parsed = parse(body) as { workspaces?: { workspace_id: unknown }[] };
+  // Enforce it rather than trusting the template. Two checks, deliberately:
+  //
+  // The text check fires 100% of the time, because it does not depend on which
+  // id this run's temp path happened to produce. Checking only the parsed value
+  // would reproduce the bug's own trigger condition and so fire at the same
+  // ~1.6% -- self-diagnosing when it happens, but still a heisenbug.
+  workspaces.forEach((w: any) => {
+    expect(body, "workspace_id must be quoted in the fixture").toContain(`workspace_id: "${w.workspace_id}"`);
+  });
+
+  // And the parse check, which catches the wider class: any field whose value
+  // YAML would reinterpret (a workspace_name of `true`, `007` or `null`).
+  const parsed = parse(body) as { workspaces?: { workspace_id: unknown; workspace_name: unknown }[] };
   (parsed.workspaces ?? []).forEach((w, i) => {
     expect(typeof w.workspace_id, "workspace_id must survive YAML as a string").toBe("string");
     expect(w.workspace_id).toBe((workspaces[i] as any).workspace_id);
+    expect(String(w.workspace_name)).toBe(String((workspaces[i] as any).workspace_name));
   });
 
   fs.writeFileSync(nodePath.join(home, ".ix", "config.yaml"), body);

--- a/ix-cli/src/cli/__tests__/bootstrap-migration.test.ts
+++ b/ix-cli/src/cli/__tests__/bootstrap-migration.test.ts
@@ -28,11 +28,12 @@ afterEach(() => {
 });
 
 function writeConfig(workspaces: object[]) {
-  // workspace_id MUST be quoted. It is 8 hex chars, so ~1.6% of ids are
-  // numeric-looking to YAML — "709e7420" parses as Infinity, "01311916" as
-  // 1311916 — and loadConfig's String() normalization cannot recover the
-  // original text once the parser has coerced it. An unquoted fixture then
-  // fires a spurious migration and fails "does NOT migrate" at that rate.
+  // workspace_id MUST be quoted. It is 8 hex chars, so ~3.7% of ids are
+  // numeric-looking to YAML. loadConfig's String() normalization recovers the
+  // plain-integer ones, but not the other ~1.6% — "709e7420" parses as
+  // Infinity, "01311916" as 1311916 — because the original text is gone once
+  // the parser has coerced the value. An unquoted fixture then fires a
+  // spurious migration and fails "does NOT migrate" at that 1.6%.
   // saveConfig (yaml.stringify) quotes these for real, so quoting here is
   // also what makes the fixture faithful to a config the CLI actually wrote.
   const body = "endpoint: http://localhost:8090\n" +
@@ -44,19 +45,23 @@ function writeConfig(workspaces: object[]) {
   //
   // The text check fires 100% of the time, because it does not depend on which
   // id this run's temp path happened to produce. Checking only the parsed value
-  // would reproduce the bug's own trigger condition and so fire at the same
-  // ~1.6% -- self-diagnosing when it happens, but still a heisenbug.
+  // would fire solely on ids YAML coerces -- self-diagnosing when it happens,
+  // but still a heisenbug, and silent on the run that reintroduces the quoting
+  // mistake.
   workspaces.forEach((w: any) => {
     expect(body, "workspace_id must be quoted in the fixture").toContain(`workspace_id: "${w.workspace_id}"`);
   });
 
   // And the parse check, which catches the wider class: any field whose value
   // YAML would reinterpret (a workspace_name of `true`, `007` or `null`).
+  // Compared strictly, NOT via String() on both sides -- that would cancel out
+  // exactly the boolean and null coercions, the ones with real consequences,
+  // since loadConfig normalizes workspace_id but never workspace_name.
   const parsed = parse(body) as { workspaces?: { workspace_id: unknown; workspace_name: unknown }[] };
   (parsed.workspaces ?? []).forEach((w, i) => {
     expect(typeof w.workspace_id, "workspace_id must survive YAML as a string").toBe("string");
     expect(w.workspace_id).toBe((workspaces[i] as any).workspace_id);
-    expect(String(w.workspace_name)).toBe(String((workspaces[i] as any).workspace_name));
+    expect(w.workspace_name, "workspace_name must survive YAML unchanged").toBe((workspaces[i] as any).workspace_name);
   });
 
   fs.writeFileSync(nodePath.join(home, ".ix", "config.yaml"), body);


### PR DESCRIPTION
`main` is currently red on CI. The failing test is `bootstrap-migration.test.ts > workspace_id migration (Ix#225 gap 2) > does NOT migrate (or churn) a workspace already on the path-based id`, which has failed on `8f2c509` and `1ab2e08`, and earlier on #326's `macos-14 · node 24` job.

## Cause — the fixture, not the product

`workspace_id` is 8 hex characters (`sha256(...).slice(0, 8)`), and the test's `writeConfig` emitted it **unquoted**, so YAML got to interpret it. About **3.7%** of ids are numeric-looking to a YAML parser; `loadConfig`'s `String()` round-trips the ones that reprint identically, leaving **~1.6%** that do not:

| id | parses as | `String()` of it |
|---|---|---|
| `709e7420` | `Infinity` | `"Infinity"` |
| `01311916` | `1311916` | `"1311916"` |
| `00560e71` | `5.6e+73` | `"5.6e+73"` |

`loadConfig` normalizes with `String(w.workspace_id)`, which covers an id that reprints identically, such as `12345678` — that was #286's fix — but **it cannot recover the original text once the parser has coerced the value**. Note `01311916` above is all-digit and still not covered: the leading zero is what's lost. The id then mismatches `pathId` at `bootstrap.ts:59`, a spurious migration fires, and `migrated` comes back `true`.

That produces exactly the observed signature — line 77 passes (the id was just re-keyed to the correct value), line 78 fails:

```
AssertionError: expected true to be false
 ❯ src/cli/__tests__/bootstrap-migration.test.ts:78:28
   77|     expect(state.workspaceId).toBe(pathId);
   78|     expect(state.migrated).toBe(false);
```

Rate of the *unrecoverable* class, measured over 200k sampled temp paths: **1.635%** — 2799 scientific-notation, 471 leading-zero. (Analytically 1.630%: `7 × (1/16) × (10/16)⁷`.) Consistent with how often this has been appearing.

## The product needs no change

`saveConfig` goes through `yaml.stringify`, which quotes every numeric-looking id. Confirmed by round-tripping the bad cases:

```
15386e48   -> - workspace_id: "15386e48"   -> "15386e48"
709e7420   -> - workspace_id: "709e7420"   -> "709e7420"
01311916   -> - workspace_id: "01311916"   -> "01311916"
abcd1234   -> - workspace_id: abcd1234     -> "abcd1234"
```

So a config the CLI actually wrote never hits this. Quoting in the fixture is what makes it faithful to one. (A hand-edited unquoted id would trigger one spurious re-key and then self-correct, since the migration writes it back quoted.)

## Verification

Pinned a temp dir whose id is `15386e48` (scientific-notation class) to make the heisenbug deterministic:

- **before:** `Tests 1 failed | 2 passed` — same assertion, same line
- **after:** `Tests 3 passed`

Also green: the file under normal random temp paths, the full `ix-cli` suite (534 passed, 2 skipped, 40 files), `tsc --noEmit`, and `eslint src` (0 errors, 39 warnings — unchanged from `main`).

## Guard against a third round

`writeConfig` now asserts the id is quoted. This is the second attempt at this bug — #286 patched the *reader* (`readWorkspaceId`, which still carries a comment about the same YAML quirk) but not the writer.

The guard checks the **emitted text**, not the parsed value. That distinction matters: a parsed-value check only fires on ids YAML actually coerces (~3.7%), so it would stay a heisenbug and be silent on the very run that reintroduced the mistake. Verified — re-unquoting the id against a parsed-value guard failed 1 of 3 tests and only on unlucky runs, whereas the text check fails **8 of 8 runs**:

```
AssertionError: workspace_id must be quoted in the fixture:
expected 'endpoint: http://localhost:8090\nwork…' to contain 'workspace_id: "rand0001"'
```

A parse check is kept alongside it, covering a wider class the text check cannot see — including `workspace_name`, where a future caller passing `true`, `007`, `null` or a bare `12` would hit the same coercion. That comparison is **strict**, not `String()` on both sides: measured against `yaml@2.9.0`, a loose compare cancels exactly the boolean, null and numeric cases, and those are the consequential ones — `loadConfig` normalizes `workspace_id` but never `workspace_name`, so a boolean name would break the `workspace_name === cfg.workspace` lookups in `config.ts`.

`root_path` is deliberately left unquoted and unchecked: a Windows path double-quoted in YAML is an invalid escape sequence (`\Users`), so quoting it would break the Windows job outright, while unquoted it round-trips on both platforms.



