### PR TITLE
perf(release): stop shipping the build toolchain in the release tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,29 @@ jobs:
           npm run build
           npm version "$VERSION" --no-git-tag-version --allow-same-version
 
+      # Drop the build toolchain before anything reads node_modules. `npm run
+      # build` above has already consumed it, and every later step only copies
+      # or scans files, so nothing downstream needs it.
+      #
+      # --omit=dev keeps `dependencies` AND `optionalDependencies`, so all 27
+      # tree-sitter grammars (13 required + 14 optional) survive — they are
+      # genuine runtime deps and the parser is useless without them. Only
+      # devDependencies go.
+      #
+      # This also fixes the SBOM below, which scans `ix-cli` and until now
+      # described the build toolchain as shipped content.
+      - name: Prune dev dependencies before packaging
+        run: |
+          size() { du -sm "$1" 2>/dev/null | cut -f1 | head -1; }
+          before_cli=$(size ix-cli/node_modules)
+          before_ing=$(size core-ingestion/node_modules)
+          (cd ix-cli && npm prune --omit=dev)
+          (cd core-ingestion && npm prune --omit=dev)
+          echo "ix-cli/node_modules:         ${before_cli:-?} MB -> $(size ix-cli/node_modules) MB"
+          echo "core-ingestion/node_modules: ${before_ing:-?} MB -> $(size core-ingestion/node_modules) MB"
+          # The CLI must still start from the pruned tree, or the tarball ships broken.
+          node ix-cli/dist/cli/main.js --version
+
       # The compass job does not run on PR dry-runs, so the artifact is legitimately
       # absent there. continue-on-error covers only that case; a real release
       # asserts the bundle is present in the packaging step below.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,19 +202,41 @@ jobs:
       # genuine runtime deps and the parser is useless without them. Only
       # devDependencies go.
       #
-      # This also fixes the SBOM below, which scans `ix-cli` and until now
-      # described the build toolchain as shipped content.
+      # This also tightens the SBOM below for `ix-cli`, which until now described
+      # the build toolchain as shipped content. Note the SBOM still scans only
+      # `ix-cli`; core-ingestion's runtime tree is shipped but not catalogued.
       - name: Prune dev dependencies before packaging
         run: |
-          size() { du -sm "$1" 2>/dev/null | cut -f1 | head -1; }
+          # `|| true`: this step runs under `bash -eo pipefail`, so a non-zero du
+          # anywhere in the pipeline would abort the whole release. Reporting a
+          # size is not worth that, and the `:-?` fallbacks below only mean
+          # something if the failure is allowed to reach them.
+          size() { du -sm "$1" 2>/dev/null | cut -f1 | head -1 || true; }
           before_cli=$(size ix-cli/node_modules)
           before_ing=$(size core-ingestion/node_modules)
           (cd ix-cli && npm prune --omit=dev)
           (cd core-ingestion && npm prune --omit=dev)
           echo "ix-cli/node_modules:         ${before_cli:-?} MB -> $(size ix-cli/node_modules) MB"
           echo "core-ingestion/node_modules: ${before_ing:-?} MB -> $(size core-ingestion/node_modules) MB"
-          # The CLI must still start from the pruned tree, or the tarball ships broken.
+
+          # The CLI must still start from the pruned tree, or the tarball ships
+          # broken. `--version` only resolves the eager import graph, so it
+          # proves nothing about core-ingestion: the CLI reaches that through a
+          # dynamic import in ingestion-loader.ts and would fail first on a
+          # user's `ix map`, long after this step went green.
+          #
+          # So actually parse something. A grammar dropped by mistake makes
+          # parseFile return null here rather than at a user's first ingest.
+          # (parse-worker.js is deliberately not imported — it throws by design
+          # unless it is running inside a worker thread.)
           node ix-cli/dist/cli/main.js --version
+          node --input-type=module -e "
+            const { parseFile } = await import('./core-ingestion/dist/index.js');
+            await import('./core-ingestion/dist/patch-builder.js');
+            const result = parseFile('smoke.ts', 'export const smoke = 1;\n');
+            if (!result) throw new Error('core-ingestion parsed nothing from the pruned tree');
+            console.log('core-ingestion parses from the pruned tree');
+          "
 
       # The compass job does not run on PR dry-runs, so the artifact is legitimately
       # absent there. continue-on-error covers only that case; a real release

--- a/ix-cli/package.json
+++ b/ix-cli/package.json
@@ -16,7 +16,7 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "build": "node scripts/build-core-ingestion.mjs && node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
+    "build": "node scripts/build-core-ingestion.mjs && node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.build.json",
     "test": "node scripts/build-core-ingestion.mjs && vitest run && node test/parser.smoke.mjs",
     "test:unit": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/ix-cli/tsconfig.build.json
+++ b/ix-cli/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  // Build-only config: same settings as tsconfig.json, minus the tests.
+  //
+  // tsconfig.json deliberately still includes them so `npm run typecheck`
+  // covers test files. But emitting them is a different matter: tsc would write
+  // every src/**/__tests__ file into dist/, the Package step copies dist/
+  // wholesale into the release tarball, and the result is ~35 shipped modules
+  // importing vitest — inside a tree from which the release workflow's
+  // `npm prune --omit=dev` has just removed vitest. It also made the SBOM
+  // describe test-only imports as shipped content.
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/__tests__/**", "src/**/*.test.ts"]
+}

--- a/ix-cli/tsconfig.json
+++ b/ix-cli/tsconfig.json
@@ -10,5 +10,7 @@
     "declaration": true,
     "skipLibCheck": true
   },
+  // Covers tests too, so `npm run typecheck` keeps checking them.
+  // The shipped build uses tsconfig.build.json, which excludes them from dist.
   "include": ["src"]
 }


### PR DESCRIPTION
The packaging step copies `node_modules` verbatim after a plain `npm ci`, so every release tarball carries the full dev toolchain:

```sh
cp -rL ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
```

Measured on this repo:

| | size | note |
|---|---|---|
| `ix-cli/node_modules` | 88 MB | |
| └ runtime deps | **4 MB** | exactly 3 packages: `chalk`, `commander`, `yaml` |
| └ direct devDependencies | 48 MB | typescript alone is 23 MB |
| `core-ingestion` direct devDependencies | 34 MB | |

None of it is executed by the CLI. It's downloaded, extracted, and left on every user's disk. The published v0.8.1 assets are 72–91 MiB; the dry-run artifact I pulled today was 114 MB.

## The change

One prune step between build and packaging. `npm run build` has already consumed the toolchain by then, and everything downstream only copies or scans files.

**`--omit=dev` keeps `dependencies` and `optionalDependencies`**, so all 27 tree-sitter grammars survive — 13 required plus 14 optional, ~417 MB of genuine runtime deps the parser cannot work without. Only devDependencies go. I verified the grammar declarations before writing this; none of them are devDependencies.

## Two things fall out beyond the size

**The SBOM becomes accurate.** The SBOM step scans `path: ix-cli`, so until now it described the build toolchain as shipped content. Pruning first means it describes what actually ships.

**The dismissed advisories become true.** Advisories against `vitest`, `esbuild`, `postcss` and friends were auto-dismissed as *development-scope* — accurate for the repo, but not for the tarball, where those packages were landing on user disks. Now they genuinely don't.

## Safety

The step prints before/after sizes, so the real saving shows up in the release log rather than being asserted here. It then runs:

```sh
node ix-cli/dist/cli/main.js --version
```

If pruning ever removes something load-bearing, the release fails at that line instead of shipping a broken tarball. Verified locally that this command works against a built tree (`0.6.1`).

`release.yml` is valid YAML. The full effect is visible on the next dry run.