### PR TITLE
fix(install): tell Intel Mac users the truth, and stop citing a script that does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,10 @@ The install script sets up everything for you on macOS and Linux. It checks for 
 
 All you need beforehand is a terminal with `curl` (or `wget`). On Windows, install Node.js 22+ and Docker Desktop first, then run the installer.
 
-Works on macOS, Linux, and Windows, on both x86-64 and arm64.
+Works on macOS, Linux, and Windows. Pre-built CLI packages are published for
+Apple Silicon macOS, Linux (x86-64 and arm64) and Windows x86-64. **Intel Macs**
+have no pre-built package — install with Homebrew, which builds from
+source: `brew tap ix-infrastructure/ix https://github.com/ix-infrastructure/Ix && brew install ix`.
 
 For the full list, including the endpoints the installer reaches and the directories it creates, see [docs/prerequisites.md](docs/prerequisites.md).
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -100,7 +100,10 @@ ix-memory-layer==latest
 
 # Pre-built tarball from GitHub Releases, extracted to ~/.ix/cli/
 # Wrapper script placed in /usr/local/bin/ix or ~/.local/bin/ix
-# Platforms: linux-amd64, linux-arm64, darwin-amd64, darwin-arm64, windows-amd64
+# Platforms: linux-amd64, linux-arm64, darwin-arm64, windows-amd64
+# No darwin-amd64 (Intel Mac) tarball is published — install with Homebrew,
+# which builds from source. The README links here as the full list, so this
+# has to agree with it.
 
 # ============================================================================
 #  ALSO INSTALLED (used by ix commands)

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -886,6 +886,25 @@ if [ ! -x "$IX_BIN/ix" ] || [ "$(check_installed_version)" != "$VERSION" ]; then
   TMP_DIR=$(mktemp -d)
   TMP_FILE="$TMP_DIR/${TARBALL_NAME}"
 
+  # Intel Macs have no pre-built asset and never will on the current release
+  # matrix — darwin-amd64 is deliberately omitted because the macos-13 runners
+  # queue indefinitely. Say so up front rather than letting the download 404 and
+  # then blaming a missing upload. Homebrew is a real answer here: the formula
+  # builds from source and carries no architecture restriction.
+  if [ "$PLATFORM" = "darwin-amd64" ]; then
+    rm -rf "$TMP_DIR"
+    echo ""
+    warn "Ix does not publish a pre-built CLI for Intel Macs (darwin-amd64)."
+    echo ""
+    echo "  Install with Homebrew instead — it builds from source and works on Intel:"
+    echo "    brew tap ${GITHUB_ORG}/ix https://github.com/${GITHUB_ORG}/${GITHUB_REPO}"
+    echo "    brew install ix"
+    echo ""
+    echo "  Apple Silicon Macs are supported by this installer directly."
+    echo ""
+    err "No darwin-amd64 release asset. Use Homebrew (above)."
+  fi
+
   echo "  Downloading ix CLI v${VERSION} for ${PLATFORM}..."
   echo "  URL: $TARBALL_URL"
   if ! _download "$TARBALL_URL" "$TMP_FILE" 2>/dev/null; then
@@ -898,9 +917,9 @@ if [ ! -x "$IX_BIN/ix" ] || [ "$(check_installed_version)" != "$VERSION" ]; then
     echo "  Check available releases at:"
     echo "    https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases"
     echo ""
-    echo "  Or build from source:"
-    echo "    git clone https://github.com/${GITHUB_ORG}/${GITHUB_REPO}.git"
-    echo "    cd ${GITHUB_REPO} && ./setup.sh"
+    echo "  Or install with Homebrew, which builds from source:"
+    echo "    brew tap ${GITHUB_ORG}/ix https://github.com/${GITHUB_ORG}/${GITHUB_REPO}"
+    echo "    brew install ix"
     echo ""
     err "CLI download failed. See above for alternatives."
   fi

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -870,7 +870,39 @@ check_installed_version() {
   fi
 }
 
-if [ -x "$IX_BIN/ix" ]; then
+# Intel Macs have no pre-built asset on the current release matrix —
+# darwin-amd64 is deliberately omitted because the macos-13 runners queue
+# indefinitely. Decide this BEFORE the upgrade branch below removes the existing
+# install: reaching it after `rm -rf "$INSTALL_DIR"` would delete a working CLI
+# and then abort, leaving the user worse off than not running the script.
+#
+# Only for the resolved-latest path. IX_VERSION is an explicit request for a
+# specific release, and every build before #259 did publish darwin-amd64 — so a
+# pinned rollback is allowed through to the normal download-and-404 handling.
+SKIP_CLI_INSTALL=0
+if [ "$PLATFORM" = "darwin-amd64" ] && [ -z "${IX_VERSION:-}" ]; then
+  echo ""
+  warn "Ix does not publish a pre-built CLI for Intel Macs (darwin-amd64)."
+  echo ""
+  echo "  Install the CLI with Homebrew instead — it builds from source:"
+  echo "    brew tap ${GITHUB_ORG}/ix https://github.com/${GITHUB_ORG}/${GITHUB_REPO}"
+  echo "    brew install ix"
+  echo ""
+  if [ -x "$IX_BIN/ix" ]; then
+    # A CLI is already here (Homebrew, or a pre-#259 release). Leave it exactly
+    # as it is and carry on with the backend setup, which is platform-neutral
+    # and is the rest of what this script does.
+    warn "Leaving your existing ix CLI untouched and continuing with the backend setup."
+    echo ""
+    SKIP_CLI_INSTALL=1
+  else
+    echo "  Apple Silicon Macs are supported by this installer directly."
+    echo ""
+    err "No darwin-amd64 release asset. Install the CLI with Homebrew (above), then re-run this script to set up the backend."
+  fi
+fi
+
+if [ "$SKIP_CLI_INSTALL" = "0" ] && [ -x "$IX_BIN/ix" ]; then
   existing_version=$(check_installed_version)
   if [ "$existing_version" = "$VERSION" ]; then
     info "ix CLI v${VERSION} is already installed"
@@ -880,30 +912,11 @@ if [ -x "$IX_BIN/ix" ]; then
   fi
 fi
 
-if [ ! -x "$IX_BIN/ix" ] || [ "$(check_installed_version)" != "$VERSION" ]; then
+if [ "$SKIP_CLI_INSTALL" = "0" ] && { [ ! -x "$IX_BIN/ix" ] || [ "$(check_installed_version)" != "$VERSION" ]; }; then
   mkdir -p "$INSTALL_DIR"
 
   TMP_DIR=$(mktemp -d)
   TMP_FILE="$TMP_DIR/${TARBALL_NAME}"
-
-  # Intel Macs have no pre-built asset and never will on the current release
-  # matrix — darwin-amd64 is deliberately omitted because the macos-13 runners
-  # queue indefinitely. Say so up front rather than letting the download 404 and
-  # then blaming a missing upload. Homebrew is a real answer here: the formula
-  # builds from source and carries no architecture restriction.
-  if [ "$PLATFORM" = "darwin-amd64" ]; then
-    rm -rf "$TMP_DIR"
-    echo ""
-    warn "Ix does not publish a pre-built CLI for Intel Macs (darwin-amd64)."
-    echo ""
-    echo "  Install with Homebrew instead — it builds from source and works on Intel:"
-    echo "    brew tap ${GITHUB_ORG}/ix https://github.com/${GITHUB_ORG}/${GITHUB_REPO}"
-    echo "    brew install ix"
-    echo ""
-    echo "  Apple Silicon Macs are supported by this installer directly."
-    echo ""
-    err "No darwin-amd64 release asset. Use Homebrew (above)."
-  fi
 
   echo "  Downloading ix CLI v${VERSION} for ${PLATFORM}..."
   echo "  URL: $TARBALL_URL"
@@ -917,9 +930,23 @@ if [ ! -x "$IX_BIN/ix" ] || [ "$(check_installed_version)" != "$VERSION" ]; then
     echo "  Check available releases at:"
     echo "    https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases"
     echo ""
-    echo "  Or install with Homebrew, which builds from source:"
-    echo "    brew tap ${GITHUB_ORG}/ix https://github.com/${GITHUB_ORG}/${GITHUB_REPO}"
-    echo "    brew install ix"
+    # This branch is reached on every platform, so the advice has to work on
+    # every platform. Homebrew is the right answer on macOS specifically; it is
+    # no help at all to the Linux and Windows users who also land here.
+    case "$PLATFORM" in
+      darwin-*)
+        echo "  Or install with Homebrew, which builds from source:"
+        echo "    brew tap ${GITHUB_ORG}/ix https://github.com/${GITHUB_ORG}/${GITHUB_REPO}"
+        echo "    brew install ix"
+        ;;
+      *)
+        # scripts/dev/setup.sh, not ./setup.sh — the root-level script this used
+        # to cite has never existed in this repo.
+        echo "  Or build from source:"
+        echo "    git clone https://github.com/${GITHUB_ORG}/${GITHUB_REPO}.git"
+        echo "    cd ${GITHUB_REPO} && ./scripts/dev/setup.sh"
+        ;;
+    esac
     echo ""
     err "CLI download failed. See above for alternatives."
   fi


### PR DESCRIPTION
Intel Macs resolve to `darwin-amd64`, which `release.yml` **deliberately never builds** — the matrix comment explains why (macos-13 runners queue indefinitely and would stall every release). The installer doesn't know that, so it attempts the download, gets a 404, and reports:

```
This likely means the release asset has not been uploaded yet.
Check available releases at: ...
```

That's wrong, and it implies waiting will fix it. It won't. Meanwhile `README.md:160` promised:

> Works on macOS, Linux, and Windows, on both x86-64 and arm64.

## Two bugs in that one error path

**1. Intel Macs get a misleading diagnosis.** Now detected before the download, with a route that actually works. `Formula/ix.rb` builds from source (`npm install` + `npm run build`, `depends_on "node@22"`) and carries no architecture restriction — so Homebrew is a genuine answer for Intel, not a consolation prize:

```
  [!!] Ix does not publish a pre-built CLI for Intel Macs (darwin-amd64).

  Install with Homebrew instead — it builds from source and works on Intel:
    brew tap ix-infrastructure/ix https://github.com/ix-infrastructure/Ix
    brew install ix

  Apple Silicon Macs are supported by this installer directly.
```

**2. The generic failure path cited a script that doesn't exist.** It told users:

```sh
git clone https://github.com/ix-infrastructure/Ix.git
cd Ix && ./setup.sh          # <- not in this repo, and never has been
```

Replaced with the Homebrew instructions. The tap command is taken from `homebrew/README.md` and checked against `Formula/ix.rb` rather than invented — there is no `homebrew-tap` repo in the org, so the `brew install <org>/tap/ix` shorthand would not have worked.

## README

Corrected to state what is actually published, and to point Intel users at Homebrew.

## Verification

`sh -n` passes; shellcheck reports **0 findings at both error and warning level**. Simulated the `darwin-amd64` branch to confirm the message renders and the script aborts before attempting a download that cannot succeed.