### PR TITLE
docs(readme): say what Ix actually is, and where to look when it breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ backend not being up yet:
 ```bash
 ix status          # is the backend reachable?
 ix docker start    # start the backend (ArangoDB + memory layer)
-ix doctor          # check the whole install and report what is wrong
+ix doctor          # check system health — server, database, graph integrity
 ```
 
 If a command reports `Ix backend not reachable`, run `ix docker start` and try again.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,28 @@
 
 <br/>
 
+## What Ix is
+
+**Ix is a command-line tool that turns a codebase into a queryable map.**
+
+It parses your repository with [tree-sitter](https://tree-sitter.github.io/) across 26
+languages and builds a graph of the symbols, calls and imports it finds, stored in a
+local backend (ArangoDB, run for you via Docker). You and your AI assistant then ask
+bounded, structural questions instead of grepping and guessing:
+
+```bash
+ix map .                      # build the graph for this repo
+ix explain IngestionService   # what is this, and what does it touch?
+ix impact verify_token        # what breaks if I change this?
+ix trace user_login_flow      # how does this actually flow?
+```
+
+The graph lives on your machine, and it persists — so context survives between
+sessions, and your assistant can navigate a real map of your system instead of
+re-deriving it from whatever fits in a prompt.
+
+<br/>
+
 ## Sign up for Kartr
 
 We built Kartr on top of this technology.
@@ -160,6 +182,20 @@ All you need beforehand is a terminal with `curl` (or `wget`). On Windows, insta
 Works on macOS, Linux, and Windows, on both x86-64 and arm64.
 
 For the full list, including the endpoints the installer reaches and the directories it creates, see [docs/prerequisites.md](docs/prerequisites.md).
+
+## Troubleshooting
+
+Ix talks to a backend that runs locally in Docker, so most first-run problems are the
+backend not being up yet:
+
+```bash
+ix status          # is the backend reachable?
+ix docker start    # start the backend (ArangoDB + memory layer)
+ix doctor          # check the whole install and report what is wrong
+```
+
+If a command reports `Ix backend not reachable`, run `ix docker start` and try again.
+Set `IX_DEBUG=1` to get full stack traces on any error.
 
 ## Supported Languages
 


### PR DESCRIPTION
A visitor landing on this README saw a tagline, a badge wall, then a 27-line Kartr signup before anything explained the project.

Measured on `main` before this PR:

| word | occurrences |
|---|---|
| "CLI" | **0** |
| "command-line" | **0** |
| "ArangoDB" | **0** |
| "tree-sitter" | **0** |
| "graph" | 1 |

Someone arriving from a link had no way to learn Ix is a command-line tool backed by a local graph database until they reached the install snippet and inferred it. With traffic arriving at 464 stars, that's the most expensive gap in the repo.

## What this adds

**"What Ix is"**, above the fold — what it is in one bold line, how the graph is built and where it lives, and four real commands showing the shape of using it:

```bash
ix map .                      # build the graph for this repo
ix explain IngestionService   # what is this, and what does it touch?
ix impact verify_token        # what breaks if I change this?
ix trace user_login_flow      # how does this actually flow?
```

**Troubleshooting.** The most common first-run failure is the Docker backend not being up, and the README offered nothing to try. The CLI's own error for that case now names `ix docker start` (merged in #333), so the README should agree:

```bash
ix status          # is the backend reachable?
ix docker start    # start the backend
ix doctor          # check the whole install
```

**The Kartr section is untouched and stays where it is.** This only puts an explanation of the project above it. Whether the signup should sit above or below the explanation is a call for you, not something I'd change unasked.

## Accuracy

Every command and claim was checked against source rather than written from memory:

- `map`, `explain`, `impact`, `trace`, `status`, `doctor` all exist in `ix-cli/src/cli/commands/`
- `start` is a real subcommand of `ix docker` (`docker.ts:87`, nested under `.command("docker")` at `:83`)
- `IX_DEBUG` is read in `main.ts:38`
- `Ix backend not reachable` is the exact string `errors.ts:213` emits
- ArangoDB and tree-sitter are both accurate — `docker-compose.standalone.yml` and `core-ingestion`'s 27 grammar dependencies

Docs-only; no code paths touched.