### PR TITLE
fix(release): never publish a release candidate as the latest release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,7 +300,14 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           TAG="${INPUT_TAG:-$REF_NAME}"
-          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          VERSION="${TAG#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # A semver pre-release identifier (0.9.0-rc.1, 1.0.0-beta.2) marks this
+          # as not-for-general-consumption. Everything below keys off it.
+          case "$VERSION" in
+            *-*) echo "prerelease=true"  >> "$GITHUB_OUTPUT" ;;
+            *)   echo "prerelease=false" >> "$GITHUB_OUTPUT" ;;
+          esac
 
       - name: Download all platform tarballs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -319,6 +326,14 @@ jobs:
         with:
           tag_name: v${{ steps.version.outputs.version }}
           generate_release_notes: true
+          # Without these, a v0.9.0-rc.1 tag publishes as a normal release and
+          # becomes "latest" — and both install.sh's resolve_version() and the
+          # CLI's checkForUpdate() read /releases/latest, so an RC would install
+          # itself onto every new user and prompt every existing one to upgrade
+          # to it. GitHub excludes prereleases from /releases/latest, so this is
+          # what makes a release-candidate tag safe to push at all.
+          prerelease: ${{ steps.version.outputs.prerelease }}
+          make_latest: ${{ steps.version.outputs.prerelease == 'false' }}
           body: |
             ## Install
 
@@ -348,6 +363,9 @@ jobs:
             _artifacts/*.sbom.spdx.json
 
       - name: Update Homebrew formula
+        # Never point the formula at a release candidate — `brew install ix`
+        # should track stable versions only.
+        if: ${{ steps.version.outputs.prerelease == 'false' }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Formula/ix.rb
+++ b/Formula/ix.rb
@@ -50,6 +50,11 @@ class Ix < Formula
   end
 
   test do
-    assert_match "Usage:", shell_output("#{bin}/ix --help")
+    # `ix --help` renders a custom help screen (buildHelpText) that has never
+    # contained the word "Usage:", so the previous assertion could only fail.
+    # --version is both stable and meaningful: the install step above syncs
+    # package.json to the formula version, so this proves the built CLI runs
+    # *and* that it is the version brew thinks it installed.
+    assert_match version.to_s, shell_output("#{bin}/ix --version")
   end
 end


### PR DESCRIPTION
Blocks pushing a `v0.9.0-rc.1` tag safely — right now there is no way to do it without shipping the candidate to everyone.

## The problem

`Create Release` passed neither `prerelease` nor `make_latest`, and `softprops/action-gh-release` defaults `prerelease` to **false**. So an RC tag publishes as an ordinary release and is marked **latest**. Three things read that:

| consumer | effect |
|---|---|
| `install.sh` → `resolve_version()` | hits `/releases/latest` — **every new install gets the RC** |
| CLI → `checkForUpdate()` | same endpoint — **every existing user is prompted to upgrade to it** |
| `Update Homebrew formula` | ungated — opens a formula PR pinning `brew install ix` to the candidate |

The second one isn't theoretical. I ran the CLI's own comparison:

```
VERSION_RE accepts 0.9.0-rc.1 : true
isNewer("0.9.0-rc.1", "0.8.1") : true
```

So the RC passes validation *and* compares as newer — users would be told to upgrade, and the download would succeed.

## The fix

The version step now derives `prerelease` from the presence of a semver pre-release identifier, and everything keys off that output:

```yaml
case "$VERSION" in
  *-*) echo "prerelease=true"  >> "$GITHUB_OUTPUT" ;;
  *)   echo "prerelease=false" >> "$GITHUB_OUTPUT" ;;
esac
```

| tag | prerelease | make_latest | Homebrew bump |
|---|---|---|---|
| `v0.9.0` | false | true | yes |
| `v0.9.0-rc.1` | **true** | **false** | **skipped** |
| `v1.0.0-beta.2` | **true** | **false** | **skipped** |

GitHub excludes prereleases from `/releases/latest`, so with this in place `install.sh` and `checkForUpdate` both keep pointing at the last stable release until a real version is cut. That's what makes an RC tag safe to push at all.

## Also: the formula's test could only ever fail

`Formula/ix.rb` asserted:

```ruby
assert_match "Usage:", shell_output("#{bin}/ix --help")
```

`ix --help` renders a custom help screen (`buildHelpText`) that begins `ix — System Intelligence CLI` and contains no "Usage:" anywhere — I ran it to confirm (0 matches). So `brew test ix` could only fail. It now asserts `--version`, which the install step syncs to the formula version, proving both that the binary runs and that it's the version brew believes it installed.

While checking that, I verified the formula's pinned `sha256` still matches the v0.8.1 source tarball — it does, so the tap itself is sound.

`release.yml` is valid YAML; the prerelease branch logic was exercised against five version strings.