### PR TITLE
fix(release): stop make_latest re-pointing latest on a dispatch re-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,15 +326,24 @@ jobs:
         with:
           tag_name: v${{ steps.version.outputs.version }}
           generate_release_notes: true
-          # Without these, a v0.9.0-rc.1 tag publishes as a normal release and
+          # Without this, a v0.9.0-rc.1 tag publishes as a normal release and
           # becomes "latest" — and both install.sh's resolve_version() and the
           # CLI's checkForUpdate() read /releases/latest, so an RC would install
           # itself onto every new user and prompt every existing one to upgrade
           # to it. GitHub excludes prereleases from /releases/latest, so this is
           # what makes a release-candidate tag safe to push at all.
+          #
+          # `make_latest` is deliberately NOT set. The action documents it as
+          # "uses GitHub api default if not provided", and this job also runs on
+          # workflow_dispatch against an arbitrary tag — where it *updates* an
+          # existing release. Passing make_latest:true there would re-point
+          # /releases/latest at whatever old tag was re-run, which is the exact
+          # pointer this block exists to protect. Marking the tag prerelease is
+          # sufficient on its own: GitHub refuses to make a prerelease latest.
           prerelease: ${{ steps.version.outputs.prerelease }}
-          make_latest: ${{ steps.version.outputs.prerelease == 'false' }}
           body: |
+            ${{ steps.version.outputs.prerelease == 'true' && format('> **Release candidate — the install commands below will NOT give you this build.** `/releases/latest` still points at the last stable release, by design. Install this one explicitly with `IX_VERSION={0}` in front of the install command, e.g. `IX_VERSION={0} curl -fsSL https://raw.githubusercontent.com/{1}/main/scripts/install/install.sh | bash`', steps.version.outputs.version, github.repository) || '' }}
+
             ## Install
 
             ### Quick install (no repo needed)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,6 +298,7 @@ jobs:
         env:
           INPUT_TAG: ${{ github.event.inputs.tag }}
           REF_NAME: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
         run: |
           TAG="${INPUT_TAG:-$REF_NAME}"
           VERSION="${TAG#v}"
@@ -305,9 +306,47 @@ jobs:
           # A semver pre-release identifier (0.9.0-rc.1, 1.0.0-beta.2) marks this
           # as not-for-general-consumption. Everything below keys off it.
           case "$VERSION" in
-            *-*) echo "prerelease=true"  >> "$GITHUB_OUTPUT" ;;
-            *)   echo "prerelease=false" >> "$GITHUB_OUTPUT" ;;
+            *-*) PRERELEASE=true  ;;
+            *)   PRERELEASE=false ;;
           esac
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+
+          # The banner that leads a release candidate's own release page.
+          #
+          # Built here rather than inline in the release body because it needs
+          # real newlines for the fenced blocks, and an Actions expression
+          # cannot produce one: `format()` strings have no escape sequences, so
+          # a `\n` in there is emitted as a literal backslash-n. Empty for a
+          # stable release, which leaves the body starting at "## Install".
+          {
+            echo "banner<<IX_BANNER_EOF"
+            if [ "$PRERELEASE" = "true" ]; then
+              cat <<EOF
+          > **Release candidate — the install commands further down will NOT give you this build.**
+          > \`/releases/latest\` deliberately excludes prereleases and still points
+          > at the last stable release, so both installers resolve to that unless
+          > you pin the version. Use one of these instead:
+          >
+          > \`\`\`bash
+          > # macOS / Linux
+          > curl -fsSL https://raw.githubusercontent.com/${REPO}/main/scripts/install/install.sh | IX_VERSION=${VERSION} bash
+          > \`\`\`
+          >
+          > \`\`\`powershell
+          > # Windows
+          > \$env:IX_VERSION="${VERSION}"; irm https://raw.githubusercontent.com/${REPO}/main/scripts/install/install.ps1 | iex
+          > \`\`\`
+          >
+          > On the bash line \`IX_VERSION=\` must sit on \`bash\`, not on \`curl\`: an
+          > assignment prefixing \`curl\` applies to that command alone and never
+          > reaches the installer on the other side of the pipe.
+          >
+          > Homebrew cannot install a release candidate — the formula tracks
+          > stable releases only.
+          EOF
+            fi
+            echo "IX_BANNER_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Download all platform tarballs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -349,7 +388,7 @@ jobs:
           prerelease: ${{ steps.version.outputs.prerelease }}
           make_latest: ${{ steps.version.outputs.prerelease == 'true' && 'false' || 'legacy' }}
           body: |
-            ${{ steps.version.outputs.prerelease == 'true' && format('> **Release candidate — the install commands below will NOT give you this build.** `/releases/latest` still points at the last stable release, by design. Install this one with `curl -fsSL https://raw.githubusercontent.com/{0}/main/scripts/install/install.sh | IX_VERSION={1} bash` — the `IX_VERSION=` assignment must sit on `bash`, not on `curl`, because a prefix on `curl` applies only to the first command of the pipeline and never reaches the installer. The PowerShell and Homebrew paths below cannot install a release candidate at all.', github.repository, steps.version.outputs.version) || '' }}
+            ${{ steps.version.outputs.banner }}
 
             ## Install
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,16 +333,23 @@ jobs:
           # to it. GitHub excludes prereleases from /releases/latest, so this is
           # what makes a release-candidate tag safe to push at all.
           #
-          # `make_latest` is deliberately NOT set. The action documents it as
-          # "uses GitHub api default if not provided", and this job also runs on
-          # workflow_dispatch against an arbitrary tag — where it *updates* an
-          # existing release. Passing make_latest:true there would re-point
-          # /releases/latest at whatever old tag was re-run, which is the exact
-          # pointer this block exists to protect. Marking the tag prerelease is
-          # sufficient on its own: GitHub refuses to make a prerelease latest.
+          # `legacy`, not `true` and not omitted.
+          #
+          # Omitting it does NOT mean "leave the pointer alone": the action's
+          # parseMakeLatest returns undefined for an absent input, the key is
+          # dropped from the payload, and GitHub's REST default of `true`
+          # applies on PATCH as well as POST. Since this job also runs on
+          # workflow_dispatch against an arbitrary tag — where the action
+          # *updates* an existing release — both `true` and omitted would
+          # re-point /releases/latest at whatever old tag was re-run.
+          #
+          # `legacy` asks GitHub to pick latest by date and semver instead, so
+          # re-running v0.8.1 after v0.9.0 has shipped leaves the pointer where
+          # it belongs. Prereleases stay pinned to `false`.
           prerelease: ${{ steps.version.outputs.prerelease }}
+          make_latest: ${{ steps.version.outputs.prerelease == 'true' && 'false' || 'legacy' }}
           body: |
-            ${{ steps.version.outputs.prerelease == 'true' && format('> **Release candidate — the install commands below will NOT give you this build.** `/releases/latest` still points at the last stable release, by design. Install this one explicitly with `IX_VERSION={0}` in front of the install command, e.g. `IX_VERSION={0} curl -fsSL https://raw.githubusercontent.com/{1}/main/scripts/install/install.sh | bash`', steps.version.outputs.version, github.repository) || '' }}
+            ${{ steps.version.outputs.prerelease == 'true' && format('> **Release candidate — the install commands below will NOT give you this build.** `/releases/latest` still points at the last stable release, by design. Install this one with `curl -fsSL https://raw.githubusercontent.com/{0}/main/scripts/install/install.sh | IX_VERSION={1} bash` — the `IX_VERSION=` assignment must sit on `bash`, not on `curl`, because a prefix on `curl` applies only to the first command of the pipeline and never reaches the installer. The PowerShell and Homebrew paths below cannot install a release candidate at all.', github.repository, steps.version.outputs.version) || '' }}
 
             ## Install
 

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -1,5 +1,10 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # Ix — Windows Installer (PowerShell)
+#
+# Environment:
+#   $env:IX_VERSION = "0.9.0-rc.1"   Install a specific release (default: latest
+#                                    stable; required for a release candidate)
+#   $env:IX_HOME    = "C:\ix"        Install root (default: $env:USERPROFILE\.ix)
 # ─────────────────────────────────────────────────────────────────────────────
 
 $ErrorActionPreference = "Stop"
@@ -60,6 +65,16 @@ function Get-LatestVersion {
     } catch { return "0.6.0" }
 }
 
+function Resolve-Version {
+    # Mirrors resolve_version() in install.sh, IX_VERSION included. That
+    # override is the only way to install a release candidate from either
+    # script: /releases/latest excludes prereleases by design, so the network
+    # path above always resolves to the last stable build no matter what was
+    # tagged most recently.
+    if ($env:IX_VERSION) { return $env:IX_VERSION }
+    return Get-LatestVersion
+}
+
 function Test-DockerRunning {
     $output = cmd /c "docker info 2>&1"
     if ($LASTEXITCODE -eq 0) { return $true }
@@ -91,7 +106,7 @@ function Get-CompassLatestVersion {
 
 Write-Host "`nIx Installer`n"
 
-$Version = Get-LatestVersion
+$Version = Resolve-Version
 Write-Host "Version: $Version"
 
 # ── Node ──


### PR DESCRIPTION
Fix-forward on #341, which is already merged. Neither issue affects a fresh RC or GA tag push, so this does not block the version push — but both should land before anyone re-runs the workflow on an old tag.

## `make_latest` can move `/releases/latest` backwards

#341 added `make_latest` alongside `prerelease`. The action documents it as *"Uses GitHub api default if not provided"* — so before that change, the update path left an existing release's flag alone.

This job also runs on `workflow_dispatch` against an arbitrary tag (the input is `required`, "e.g. v0.4.9"), and there `softprops/action-gh-release` **updates** the existing release rather than creating one. So re-running `v0.8.1` to repair a bad asset now PATCHes it with `make_latest: true`, and `/releases/latest` starts serving 0.8.1 to every new install via `resolve_version()` and every existing user via `checkForUpdate()` — the exact pointer #341 exists to protect.

Dropped it. `prerelease` alone is sufficient: GitHub refuses to mark a prerelease as latest, which is the whole mechanism #341 relies on.

## The release body was never prerelease-gated

Every other part of the step keys off `prerelease`; the `body:` did not. An RC's own release page therefore handed testers:

```bash
curl -fsSL .../install.sh | bash
```

which resolves through `/releases/latest` — deliberately the *previous stable* build on an RC. A tester following the RC page's own instructions installs the wrong version and reports results against it. Prereleases now lead with the `IX_VERSION=` form.

Verified the workflow still parses and that `make_latest` is absent while `prerelease` is retained.