### PR TITLE
fix(upgrade): compare prerelease versions so RC users see the GA

### DIFF
--- a/ix-cli/src/cli/__tests__/upgrade-version-compare.test.ts
+++ b/ix-cli/src/cli/__tests__/upgrade-version-compare.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isNewer } from "../commands/upgrade.js";
+import { isNewer, VERSION_RE } from "../commands/upgrade.js";
 
 describe("isNewer", () => {
   it("compares plain releases", () => {
@@ -81,7 +81,8 @@ describe("isNewer", () => {
   it("accepts a tag carrying both a pre-release and build metadata", () => {
     // VERSION_RE gates every version that reaches isNewer. It used to reject
     // this shape, which surfaced as "Could not reach GitHub" and exit 1.
-    const VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+    // Imported, not re-declared: a local copy of the literal passes no matter
+    // what upgrade.ts actually does, so it would guard nothing.
     expect(VERSION_RE.test("0.9.0-rc.1+abc1234")).toBe(true);
     expect(VERSION_RE.test("0.9.0-rc.1")).toBe(true);
     expect(VERSION_RE.test("0.9.0+abc1234")).toBe(true);

--- a/ix-cli/src/cli/__tests__/upgrade-version-compare.test.ts
+++ b/ix-cli/src/cli/__tests__/upgrade-version-compare.test.ts
@@ -52,9 +52,42 @@ describe("isNewer", () => {
     }
   });
 
+  it("handles pre-release identifiers that themselves contain hyphens", () => {
+    // `split("-", 2)` truncates rather than capturing the remainder, so a first
+    // attempt at this parsed `0.9.0-rc-1` as pre-release ["rc"] and dropped the
+    // "-1" — making rc-1 and rc-2 compare equal in both directions, i.e. the
+    // same stranded-on-a-candidate bug this function exists to fix.
+    expect(isNewer("0.9.0-rc-2", "0.9.0-rc-1")).toBe(true);
+    expect(isNewer("0.9.0-rc-1", "0.9.0-rc-2")).toBe(false);
+    expect(isNewer("0.9.0-next-20260201", "0.9.0-next-20260101")).toBe(true);
+    expect(isNewer("0.9.0", "0.9.0-rc-1")).toBe(true);
+  });
+
+  it("keeps comparing when two numeric identifiers are textually different but equal", () => {
+    // Returning on an undecided comparison ends the whole thing as "not newer".
+    expect(isNewer("1.0.0-rc.01.2", "1.0.0-rc.1.1")).toBe(true);
+    expect(isNewer("1.0.0-rc.1.1", "1.0.0-rc.01.2")).toBe(false);
+  });
+
   it("ignores build metadata, which carries no precedence", () => {
     expect(isNewer("0.9.0+abc123", "0.9.0")).toBe(false);
     expect(isNewer("0.9.1+abc123", "0.9.0")).toBe(true);
+    // Stripping must happen before the pre-release split, or the metadata ends
+    // up inside the last identifier and compares lexically.
+    expect(isNewer("0.9.0", "0.9.0-rc.1+abc123")).toBe(true);
+    expect(isNewer("0.9.0-rc.2+aaa", "0.9.0-rc.1+zzz")).toBe(true);
+  });
+
+  it("accepts a tag carrying both a pre-release and build metadata", () => {
+    // VERSION_RE gates every version that reaches isNewer. It used to reject
+    // this shape, which surfaced as "Could not reach GitHub" and exit 1.
+    const VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+    expect(VERSION_RE.test("0.9.0-rc.1+abc1234")).toBe(true);
+    expect(VERSION_RE.test("0.9.0-rc.1")).toBe(true);
+    expect(VERSION_RE.test("0.9.0+abc1234")).toBe(true);
+    expect(VERSION_RE.test("0.9.0")).toBe(true);
+    expect(VERSION_RE.test("not-a-version")).toBe(false);
+    expect(VERSION_RE.test("0.9")).toBe(false);
   });
 
   it("does not throw on malformed input", () => {

--- a/ix-cli/src/cli/__tests__/upgrade-version-compare.test.ts
+++ b/ix-cli/src/cli/__tests__/upgrade-version-compare.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { isNewer } from "../commands/upgrade.js";
+
+describe("isNewer", () => {
+  it("compares plain releases", () => {
+    expect(isNewer("0.9.0", "0.8.1")).toBe(true);
+    expect(isNewer("0.8.1", "0.9.0")).toBe(false);
+    expect(isNewer("0.9.0", "0.9.0")).toBe(false);
+    expect(isNewer("1.0.0", "0.99.99")).toBe(true);
+    expect(isNewer("0.10.0", "0.9.0")).toBe(true);
+  });
+
+  it("offers the GA release to someone running its release candidate", () => {
+    // The regression this exists for. `"0.9.0-rc.1".split(".").map(Number)` is
+    // [0, 9, NaN, 1]; NaN lost every comparison and was coerced to 0, so this
+    // returned false and RC testers were never told the real release shipped.
+    expect(isNewer("0.9.0", "0.9.0-rc.1")).toBe(true);
+    expect(isNewer("1.0.0", "1.0.0-beta.2")).toBe(true);
+  });
+
+  it("does not offer a release candidate to someone already on the GA", () => {
+    expect(isNewer("0.9.0-rc.1", "0.9.0")).toBe(false);
+  });
+
+  it("orders release candidates against each other", () => {
+    expect(isNewer("0.9.0-rc.2", "0.9.0-rc.1")).toBe(true);
+    expect(isNewer("0.9.0-rc.1", "0.9.0-rc.2")).toBe(false);
+    // Numeric identifiers compare numerically, not as strings — the case a
+    // lexical sort gets wrong.
+    expect(isNewer("0.9.0-rc.10", "0.9.0-rc.9")).toBe(true);
+    expect(isNewer("0.9.0-rc.9", "0.9.0-rc.10")).toBe(false);
+  });
+
+  it("follows semver precedence for mixed pre-release identifiers", () => {
+    // The ordering example from the semver spec itself.
+    const ordered = [
+      "1.0.0-alpha",
+      "1.0.0-alpha.1",
+      "1.0.0-alpha.beta",
+      "1.0.0-beta",
+      "1.0.0-beta.2",
+      "1.0.0-beta.11",
+      "1.0.0-rc.1",
+      "1.0.0",
+    ];
+    for (let i = 0; i < ordered.length - 1; i++) {
+      const lower = ordered[i]!;
+      const higher = ordered[i + 1]!;
+      expect(isNewer(higher, lower), `${higher} > ${lower}`).toBe(true);
+      expect(isNewer(lower, higher), `${lower} !> ${higher}`).toBe(false);
+    }
+  });
+
+  it("ignores build metadata, which carries no precedence", () => {
+    expect(isNewer("0.9.0+abc123", "0.9.0")).toBe(false);
+    expect(isNewer("0.9.1+abc123", "0.9.0")).toBe(true);
+  });
+
+  it("does not throw on malformed input", () => {
+    // getCurrentVersion falls back to "0.0.0", and a tampered cache is rejected
+    // upstream, but this must not be the thing that throws.
+    expect(() => isNewer("", "0.9.0")).not.toThrow();
+    expect(() => isNewer("not-a-version", "0.9.0")).not.toThrow();
+    expect(isNewer("0.9.0", "0.0.0")).toBe(true);
+  });
+});

--- a/ix-cli/src/cli/commands/upgrade.ts
+++ b/ix-cli/src/cli/commands/upgrade.ts
@@ -96,12 +96,64 @@ function writeCache(latest: string, compassLatest?: string, backendLatest?: stri
   }
 }
 
-function isNewer(latest: string, current: string): boolean {
-  const l = latest.split(".").map(Number);
-  const c = current.split(".").map(Number);
+/**
+ * Split a version into its numeric release triple and its pre-release
+ * identifiers. `0.9.0-rc.1` -> `[[0,9,0], ["rc","1"]]`.
+ */
+function splitVersion(v: string): [number[], string[]] {
+  // Build metadata (`+sha`) never participates in precedence.
+  const [core = "", pre = ""] = v.split("+")[0]!.split("-", 2) as [string, string?];
+  const nums = core.split(".").map((n) => {
+    const parsed = Number(n);
+    return Number.isFinite(parsed) ? parsed : 0;
+  });
+  return [nums, pre ? pre.split(".") : []];
+}
+
+/**
+ * Is `latest` a higher version than `current`?
+ *
+ * The old implementation was `split(".").map(Number)`, which turns
+ * `0.9.0-rc.1` into `[0, 9, NaN, 1]`. Every NaN compared false and was then
+ * coerced to 0 by `(l[i] || 0)`, so `isNewer("0.9.0", "0.9.0-rc.1")` returned
+ * false: anyone running a release candidate was never told the GA shipped, and
+ * `ix upgrade` reported them already current. `0.9.0-rc.2` over `0.9.0-rc.1`
+ * failed the same way, so candidates could not even be updated to each other.
+ *
+ * Follows semver precedence: compare the release triple numerically; a version
+ * with no pre-release outranks one that has it; otherwise compare pre-release
+ * identifiers left to right, numeric ones numerically and below alphanumeric
+ * ones, and a longer identifier list wins when all preceding fields are equal.
+ */
+export function isNewer(latest: string, current: string): boolean {
+  const [lNums, lPre] = splitVersion(latest);
+  const [cNums, cPre] = splitVersion(current);
+
   for (let i = 0; i < 3; i++) {
-    if ((l[i] || 0) > (c[i] || 0)) return true;
-    if ((l[i] || 0) < (c[i] || 0)) return false;
+    const a = lNums[i] ?? 0;
+    const b = cNums[i] ?? 0;
+    if (a > b) return true;
+    if (a < b) return false;
+  }
+
+  // Same release triple. A release outranks any pre-release of itself.
+  if (lPre.length === 0 && cPre.length === 0) return false;
+  if (lPre.length === 0) return true;
+  if (cPre.length === 0) return false;
+
+  for (let i = 0; i < Math.max(lPre.length, cPre.length); i++) {
+    const a = lPre[i];
+    const b = cPre[i];
+    if (a === undefined) return false; // shorter list is lower
+    if (b === undefined) return true;
+    if (a === b) continue;
+
+    const aNum = /^\d+$/.test(a);
+    const bNum = /^\d+$/.test(b);
+    if (aNum && bNum) return Number(a) > Number(b);
+    // Numeric identifiers always rank below alphanumeric ones.
+    if (aNum !== bNum) return bNum;
+    return a > b;
   }
   return false;
 }

--- a/ix-cli/src/cli/commands/upgrade.ts
+++ b/ix-cli/src/cli/commands/upgrade.ts
@@ -43,7 +43,12 @@ function getCurrentVersion(): string {
 // download URLs, so it is validated here at the source: anything that isn't a
 // plain version is rejected (CodeQL js/http-to-file-access barrier + general
 // hardening against a tampered/unexpected tag).
-const VERSION_RE = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
+// The pre-release and build parts are separate optional groups. Written as one
+// `(?:[-+]...)?` group, the character class had no `+`, so a tag carrying both
+// — `0.9.0-rc.1+abc1234`, valid semver — failed the test. fetchLatestRelease
+// then returned null and `ix upgrade` reported "Could not reach GitHub to check
+// for updates" and exited 1 against a perfectly reachable GitHub.
+const VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 
 async function fetchLatestRelease(repo: string): Promise<string | null> {
   try {
@@ -102,7 +107,15 @@ function writeCache(latest: string, compassLatest?: string, backendLatest?: stri
  */
 function splitVersion(v: string): [number[], string[]] {
   // Build metadata (`+sha`) never participates in precedence.
-  const [core = "", pre = ""] = v.split("+")[0]!.split("-", 2) as [string, string?];
+  const withoutBuild = v.split("+")[0]!;
+  // Split at the FIRST hyphen and keep everything after it. `split("-", 2)`
+  // looks right and is not: the limit truncates rather than capturing the
+  // remainder, so `0.9.0-rc-1` would yield pre-release "rc" and drop the "-1"
+  // — making 0.9.0-rc-1 and 0.9.0-rc-2 compare equal, which is the same
+  // stranded-on-a-candidate bug this function exists to fix.
+  const hyphen = withoutBuild.indexOf("-");
+  const core = hyphen === -1 ? withoutBuild : withoutBuild.slice(0, hyphen);
+  const pre = hyphen === -1 ? "" : withoutBuild.slice(hyphen + 1);
   const nums = core.split(".").map((n) => {
     const parsed = Number(n);
     return Number.isFinite(parsed) ? parsed : 0;
@@ -150,7 +163,16 @@ export function isNewer(latest: string, current: string): boolean {
 
     const aNum = /^\d+$/.test(a);
     const bNum = /^\d+$/.test(b);
-    if (aNum && bNum) return Number(a) > Number(b);
+    if (aNum && bNum) {
+      // Only return once the comparison is actually decided. Two identifiers
+      // can differ as text but not as numbers (`01` vs `1`), and returning
+      // here would end the whole comparison as "not newer" instead of moving
+      // on to the next identifier.
+      const na = Number(a);
+      const nb = Number(b);
+      if (na !== nb) return na > nb;
+      continue;
+    }
     // Numeric identifiers always rank below alphanumeric ones.
     if (aNum !== bNum) return bNum;
     return a > b;

--- a/ix-cli/src/cli/commands/upgrade.ts
+++ b/ix-cli/src/cli/commands/upgrade.ts
@@ -48,7 +48,7 @@ function getCurrentVersion(): string {
 // — `0.9.0-rc.1+abc1234`, valid semver — failed the test. fetchLatestRelease
 // then returned null and `ix upgrade` reported "Could not reach GitHub to check
 // for updates" and exited 1 against a perfectly reachable GitHub.
-const VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+export const VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 
 async function fetchLatestRelease(repo: string): Promise<string | null> {
   try {


### PR DESCRIPTION
Found while reviewing the release-candidate flow. This one directly breaks the RC → GA handoff, so it matters before **v0.9.0-rc.1** goes out.

`isNewer` did `split(".").map(Number)`:

```js
"0.9.0-rc.1".split(".").map(Number)   // [0, 9, NaN, 1]
```

Every NaN comparison is false, and `(l[i] || 0)` then coerces it to 0 — so the release triple compares equal and the function returns false.

| call | before | correct |
|---|---|---|
| `isNewer("0.9.0", "0.9.0-rc.1")` | **false** | true |
| `isNewer("0.9.0-rc.2", "0.9.0-rc.1")` | **false** | true |
| `isNewer("0.9.0-rc.1", "0.9.0")` | false | false |

So a tester who installs the RC is never shown the update notice when the real 0.9.0 ships, and `ix upgrade` tells them `[ok] CLI already on the latest version (0.9.0-rc.1)`. They are stranded on the candidate with no error and no way to find the GA build from the CLI. Candidates can't be moved forward to each other either.

Note the release workflow does `npm version "$VERSION"` on the packaged tarball, so an RC install really does carry `0.9.0-rc.1` in its package.json — this is the live path, not a hypothetical.

Replaced with semver precedence: numeric triple, then a release outranks any prerelease of itself, then prerelease identifiers left to right with numeric ones compared numerically and ranked below alphanumeric. Build metadata stripped.

Tests cover RC → GA, RC → RC including `rc.10` vs `rc.9` (which a lexical compare gets wrong), the ordering example from the semver spec, build metadata, and malformed input. Reverting to the old implementation fails four of them. Full suite green (573).