### PR TITLE
docs(readme): drop the stray <br/> that padded the Kartr section break

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ The graph lives on your machine, and it persists — so context survives between
 sessions, and your assistant can navigate a real map of your system instead of
 re-deriving it from whatever fits in a prompt.
 
-<br/>
-
 ## Sign up for Kartr
 
 We built Kartr on top of this technology.


### PR DESCRIPTION
The break between **What Ix is** and **Sign up for Kartr** was the only section break in the README carrying an explicit `<br/>` on top of the heading's own top margin, so it rendered as a dead gap next to every other section.

Every other `## ` heading in the file (Problem, Demo, Results, Install, …) follows its paragraph with just a blank line. This one now matches.

The `<br/>` at the top of the file — the header/badges → first-section separator — is left alone; that one is doing real work.

```diff
 re-deriving it from whatever fits in a prompt.
 
-<br/>
-
 ## Sign up for Kartr
```

Docs-only, no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)