### PR TITLE
fix(ingest): stop DEP0151 warnings from flooding the ix map progress bar

### DIFF
--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -16,7 +16,12 @@ import Parser from 'tree-sitter';
 //   @tree-sitter-grammars/tree-sitter-lua   optional  type=module    -> 1
 //   tree-sitter-css                         optional  type=module    -> 1
 //   the other 11 required grammars          required  type=commonjs  -> 0
-//   every other optional grammar            optional  type=commonjs  -> 0
+//   the other 11 optional grammars          optional  type=commonjs  -> 0
+//   tree-sitter-sas                         optional  type=module    -> 0
+//                                             (full-filename main + "exports")
+//
+// The two 11s are a coincidence, not a copy-paste: 12 required grammars minus
+// c-sharp, and 14 optional minus lua, css and sas.
 //
 // So the rule is `"type": "module"` + a directory `"main"` + no `"exports"`,
 // which today means exactly c-sharp (static, below), plus css and lua (dynamic,

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -3,49 +3,62 @@ import * as crypto from 'node:crypto';
 import { createRequire } from 'node:module';
 // @ts-ignore — tree-sitter has no bundled types
 import Parser from 'tree-sitter';
-// Every grammar below is imported by the explicit path to its binding rather
-// than by the bare package name.
+// A grammar is imported by the explicit path to its binding ONLY when Node
+// would otherwise emit DEP0151 for it. That is a narrower set than it looks.
 //
-// All of these publish `"main": "bindings/node"` with no filename, extension or
-// `exports` field, so resolving the bare specifier from ESM makes Node fall
-// back to directory-index lookup and emit a DEP0151 deprecation warning. The
-// parse pool loads this module once per worker, so on a Node release that emits
-// DEP0151 the warnings arrive twelve at a time per worker and shred the `ix map`
-// progress bar, which shares stderr with them.
+// DEP0151 fires when an **ESM** resolution lands on a `"main"` with no filename
+// or extension. It is gated on the resolved format: a CommonJS package with
+// `"main": "bindings/node"` never warns, however it is imported. Almost every
+// grammar here is CJS, so almost none of them warn — measured per package in a
+// fresh process on Node 26:
 //
-// This is the same fix already applied to tree-sitter-css further down, and for
-// the same reason; it was only ever applied to that one grammar. The optional
-// grammars are unaffected because `tryLoadGrammar` goes through createRequire,
-// and CJS resolution does not warn. `tree-sitter` itself needs nothing — its
-// main is a real filename.
+//   tree-sitter-c-sharp                     type=module    -> 1 warning
+//   @tree-sitter-grammars/tree-sitter-lua   type=module    -> 1 warning
+//   tree-sitter-css                         type=module    -> 1 warning
+//   the other ten required grammars         type=commonjs  -> 0
 //
-// Verified equivalent: for all twelve, the bare and explicit specifiers resolve
-// to the same export keys, including the multi-grammar packages
-// (typescript -> {typescript, tsx}, php -> {php, php_only}).
+// So the rule is `"type": "module"` + a directory `"main"` + no `"exports"`,
+// which today means exactly c-sharp (static, below), plus css and lua (dynamic,
+// through tryImportGrammar further down). The parse pool loads this module once
+// per worker and every worker shares the parent's stderr, so each warning
+// arrives once per worker and shreds the `ix map` progress bar.
+//
+// Do NOT pre-emptively convert the CJS grammars "for consistency". A subpath
+// import is a dependency on a package's internal layout, and it fails *hard* —
+// a static import that cannot resolve takes down this whole module, every
+// language with it. tree-sitter-sas is already the counterexample: it ships
+// `"exports": { ".": "./bindings/node/index.js" }`, so its bare specifier is
+// fine and `tree-sitter-sas/bindings/node/index.js` throws
+// ERR_PACKAGE_PATH_NOT_EXPORTED. That is the direction these packages are
+// migrating, so the explicit form is the exception to justify, not the default.
+//
+// `tree-sitter` itself needs nothing — its main is a real filename.
 // @ts-ignore
-import JavaScript from 'tree-sitter-javascript/bindings/node/index.js';
+import JavaScript from 'tree-sitter-javascript';
 // @ts-ignore
-import TypeScript from 'tree-sitter-typescript/bindings/node/index.js';
+import TypeScript from 'tree-sitter-typescript';
 // @ts-ignore
-import Python from 'tree-sitter-python/bindings/node/index.js';
+import Python from 'tree-sitter-python';
 // @ts-ignore
-import Java from 'tree-sitter-java/bindings/node/index.js';
+import Java from 'tree-sitter-java';
 // @ts-ignore
-import C from 'tree-sitter-c/bindings/node/index.js';
+import C from 'tree-sitter-c';
 // @ts-ignore
-import CPP from 'tree-sitter-cpp/bindings/node/index.js';
+import CPP from 'tree-sitter-cpp';
+// tree-sitter-c-sharp is `"type": "module"` with a directory `"main"` and no
+// `"exports"` — the one required grammar that actually triggers DEP0151.
 // @ts-ignore
 import CSharp from 'tree-sitter-c-sharp/bindings/node/index.js';
 // @ts-ignore
-import Go from 'tree-sitter-go/bindings/node/index.js';
+import Go from 'tree-sitter-go';
 // @ts-ignore
-import Rust from 'tree-sitter-rust/bindings/node/index.js';
+import Rust from 'tree-sitter-rust';
 // @ts-ignore
-import Ruby from 'tree-sitter-ruby/bindings/node/index.js';
+import Ruby from 'tree-sitter-ruby';
 // @ts-ignore
-import PHP from 'tree-sitter-php/bindings/node/index.js';
+import PHP from 'tree-sitter-php';
 // @ts-ignore
-import Scala from 'tree-sitter-scala/bindings/node/index.js';
+import Scala from 'tree-sitter-scala';
 const _require = createRequire(import.meta.url);
 function tryLoadGrammar(pkg: string): any {
   try { return _require(pkg); } catch { return null; }
@@ -81,12 +94,20 @@ const Hcl = HclPkg?.default ?? HclPkg;
 // import() through the quiet helper above. A grammar that can't load on this
 // platform (e.g. tree-sitter-sas has no win32 prebuild) is simply absent; its
 // files go unparsed, exactly as with any unavailable CJS grammar.
+//
+// These three are genuine ESM imports, so the DEP0151 rule described at the top
+// of this file applies to them exactly as it does to the static ones — being
+// optional and going through a helper does not exempt them.
+//
+// tree-sitter-sas stays bare: its `main` is already a full filename and it
+// declares `"exports"`, so it never warns and a subpath import of it throws
+// ERR_PACKAGE_PATH_NOT_EXPORTED.
 const SAS = await tryImportGrammar('tree-sitter-sas');
-const Lua = await tryImportGrammar('@tree-sitter-grammars/tree-sitter-lua');
-// Import the binding by its explicit file path. tree-sitter-css's package.json
-// `main` is "bindings/node" (no filename/extension), which makes Node emit a
-// DEP0151 deprecation warning on every ESM resolution, once per parse worker,
-// flooding `ix map`. Pointing straight at the file skips that resolution.
+// Lua and CSS are both `"type": "module"` with a directory `"main"` and no
+// `"exports"`, so the bare specifier makes Node fall back to directory-index
+// lookup and warn — once per parse worker, onto the same stderr the `ix map`
+// progress bar draws on. Pointing straight at the file skips that resolution.
+const Lua = await tryImportGrammar('@tree-sitter-grammars/tree-sitter-lua/bindings/node/index.js');
 const Css = await tryImportGrammar('tree-sitter-css/bindings/node/index.js');
 
 import { SupportedLanguages, languageFromPath } from './languages.js';

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -12,10 +12,11 @@ import Parser from 'tree-sitter';
 // grammar here is CJS, so almost none of them warn — measured per package in a
 // fresh process on Node 26:
 //
-//   tree-sitter-c-sharp                     type=module    -> 1 warning
-//   @tree-sitter-grammars/tree-sitter-lua   type=module    -> 1 warning
-//   tree-sitter-css                         type=module    -> 1 warning
-//   the other ten required grammars         type=commonjs  -> 0
+//   tree-sitter-c-sharp                     required  type=module    -> 1
+//   @tree-sitter-grammars/tree-sitter-lua   optional  type=module    -> 1
+//   tree-sitter-css                         optional  type=module    -> 1
+//   the other 11 required grammars          required  type=commonjs  -> 0
+//   every other optional grammar            optional  type=commonjs  -> 0
 //
 // So the rule is `"type": "module"` + a directory `"main"` + no `"exports"`,
 // which today means exactly c-sharp (static, below), plus css and lua (dynamic,

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -3,30 +3,49 @@ import * as crypto from 'node:crypto';
 import { createRequire } from 'node:module';
 // @ts-ignore — tree-sitter has no bundled types
 import Parser from 'tree-sitter';
+// Every grammar below is imported by the explicit path to its binding rather
+// than by the bare package name.
+//
+// All of these publish `"main": "bindings/node"` with no filename, extension or
+// `exports` field, so resolving the bare specifier from ESM makes Node fall
+// back to directory-index lookup and emit a DEP0151 deprecation warning. The
+// parse pool loads this module once per worker, so on a Node release that emits
+// DEP0151 the warnings arrive twelve at a time per worker and shred the `ix map`
+// progress bar, which shares stderr with them.
+//
+// This is the same fix already applied to tree-sitter-css further down, and for
+// the same reason; it was only ever applied to that one grammar. The optional
+// grammars are unaffected because `tryLoadGrammar` goes through createRequire,
+// and CJS resolution does not warn. `tree-sitter` itself needs nothing — its
+// main is a real filename.
+//
+// Verified equivalent: for all twelve, the bare and explicit specifiers resolve
+// to the same export keys, including the multi-grammar packages
+// (typescript -> {typescript, tsx}, php -> {php, php_only}).
 // @ts-ignore
-import JavaScript from 'tree-sitter-javascript';
+import JavaScript from 'tree-sitter-javascript/bindings/node/index.js';
 // @ts-ignore
-import TypeScript from 'tree-sitter-typescript';
+import TypeScript from 'tree-sitter-typescript/bindings/node/index.js';
 // @ts-ignore
-import Python from 'tree-sitter-python';
+import Python from 'tree-sitter-python/bindings/node/index.js';
 // @ts-ignore
-import Java from 'tree-sitter-java';
+import Java from 'tree-sitter-java/bindings/node/index.js';
 // @ts-ignore
-import C from 'tree-sitter-c';
+import C from 'tree-sitter-c/bindings/node/index.js';
 // @ts-ignore
-import CPP from 'tree-sitter-cpp';
+import CPP from 'tree-sitter-cpp/bindings/node/index.js';
 // @ts-ignore
-import CSharp from 'tree-sitter-c-sharp';
+import CSharp from 'tree-sitter-c-sharp/bindings/node/index.js';
 // @ts-ignore
-import Go from 'tree-sitter-go';
+import Go from 'tree-sitter-go/bindings/node/index.js';
 // @ts-ignore
-import Rust from 'tree-sitter-rust';
+import Rust from 'tree-sitter-rust/bindings/node/index.js';
 // @ts-ignore
-import Ruby from 'tree-sitter-ruby';
+import Ruby from 'tree-sitter-ruby/bindings/node/index.js';
 // @ts-ignore
-import PHP from 'tree-sitter-php';
+import PHP from 'tree-sitter-php/bindings/node/index.js';
 // @ts-ignore
-import Scala from 'tree-sitter-scala';
+import Scala from 'tree-sitter-scala/bindings/node/index.js';
 const _require = createRequire(import.meta.url);
 function tryLoadGrammar(pkg: string): any {
   try { return _require(pkg); } catch { return null; }


### PR DESCRIPTION
Reported from `ix map` on Windows, Node 23.9.0: a wall of DEP0151 warnings interleaved with the progress bar, which shares stderr with them. The bar was unreadable and the run looked hung at `0% 0 / 125`.

```
(node:61632) [DEP0151] DeprecationWarning: Package ...\tree-sitter-c-sharp\ has a "main"
field set to "bindings/node", excluding the full filename and extension to the resolved
file at "bindings\node\index.js", imported from ...\core-ingestion\dist\index.js.
```

## Cause

All twelve required grammars publish `"main": "bindings/node"` — no filename, no extension, no `exports` field. Resolving the bare specifier from ESM therefore falls back to directory-index lookup, which is what DEP0151 objects to. The parse pool loads this module once per worker, so the warnings arrive twelve at a time, per worker.

**The fix already exists in this file.** `tree-sitter-css` is imported by explicit path with a comment describing this exact failure — "once per parse worker, flooding `ix map`". It was only ever applied to that one grammar. This extends it to the other twelve.

The optional grammars were never affected: `tryLoadGrammar` goes through `createRequire`, and CJS resolution does not warn. `tree-sitter` itself needs nothing — its `main` is a real filename.

## Verification

I checked the specifiers are interchangeable rather than assuming it. For all twelve, bare and explicit resolve to **identical export keys**, including the multi-grammar packages:

```
OK  tree-sitter-typescript   bare=[tsx,typescript]  explicit=[tsx,typescript]
OK  tree-sitter-php          bare=[php,php_only]    explicit=[php,php_only]
...                                                          ALL 12 IDENTICAL
```

Then built `dist` and parsed real snippets through it, since the failure is a runtime resolution one and the tests import from `src`:

```
OK  A.cs      entities=[A.cs,N,Greeter,Hi]
OK  a.ts      entities=[a.ts,Foo,bar]
OK  a.php     entities=[a.php,P,q]
OK  a.scala   entities=[a.scala,S,m]
OK  a.rs      entities=[a.rs,R,R,go]
OK  a.go      entities=[a.go,Go]
```

`tsc --noEmit` clean. The suite is unchanged at **6 failed / 271 passed** — byte-identical to `main`'s pre-existing failures, none of them touched by this.

## What I could not verify

**The warning itself does not reproduce here.** Neither Node 22.22 nor 24.19 emits DEP0151 for these packages, with or without `--pending-deprecation`; only the reporter's Node 23.9 did. Node 23 is odd-numbered and already out of support, so this may not fire on any currently supported runtime.

I still think the change is right: the deprecation is real, the packages genuinely have the shape it objects to, a future Node can reinstate it, and the repo had already decided this was worth fixing for css. But it is a fix I cannot demonstrate working — confirmation needs a `ix map` run on Node 23.

Worth noting separately that `package.json` sets `"engines": { "node": ">=22" }`, which admits 23. If Node 23 is not a runtime we intend to support, narrowing that is a different and possibly better conversation than this patch.
