### PR TITLE
fix(install): stop the Windows installer dying on an 8.3 short TEMP path

### DIFF
--- a/ix-cli/src/cli/__tests__/upgrade-archive-shape.test.ts
+++ b/ix-cli/src/cli/__tests__/upgrade-archive-shape.test.ts
@@ -253,6 +253,41 @@ describe("sweepUpgradeOrphans", () => {
     expect(readFileSync(join(installDir, "cli", "dist", "cli", "main.js"), "utf-8")).toBe("// live\n");
   });
 
+  // install.ps1 downloads to `.cli-staging-<pid>.zip` and tees the compose pull
+  // output to `.cli-staging-pull-<pid>.log`, both inside IX_HOME, because
+  // Windows hands it a TEMP path in 8.3 short form whenever the profile
+  // contains a space and PowerShell's provider cannot resolve one. Moving them
+  // out of TEMP also moved them out from under the OS's own cleanup, so the
+  // installer now leans on this sweep to be the thing that reclaims them after
+  // a run that was killed before its own delete. They are files rather than
+  // directories, which the prefix match above had never been given.
+  it("reclaims the installer's leftover scratch files, not just directories", () => {
+    const installDir = join(root, "cli");
+    mkdirSync(join(installDir, "cli", "dist", "cli"), { recursive: true });
+    writeFileSync(join(installDir, "cli", "dist", "cli", "main.js"), "// live\n");
+    writeFileSync(join(root, ".cli-staging-333.zip"), "PK");
+    writeFileSync(join(root, ".cli-staging-pull-333.log"), "pulling...\n");
+
+    sweepUpgradeOrphans(root, installDir);
+
+    expect(existsSync(join(root, ".cli-staging-333.zip"))).toBe(false);
+    expect(existsSync(join(root, ".cli-staging-pull-333.log"))).toBe(false);
+    expect(readFileSync(join(installDir, "cli", "dist", "cli", "main.js"), "utf-8")).toBe("// live\n");
+  });
+
+  // The zip must not be named `.cli-backup-*`: that prefix is a recovery
+  // candidate, so a leftover would be renamed *over* ~/.ix/cli on the next
+  // upgrade and replace the install with a zip file. This pins the reason for
+  // the name install.ps1 actually uses.
+  it("does not treat a stray file as an install worth recovering", () => {
+    const installDir = join(root, "cli");
+    writeFileSync(join(root, ".cli-staging-444.zip"), "PK");
+
+    sweepUpgradeOrphans(root, installDir);
+
+    expect(existsSync(installDir)).toBe(false);
+  });
+
   it("is a no-op when IX_HOME does not exist yet", () => {
     expect(() => sweepUpgradeOrphans(join(root, "nope"), join(root, "nope", "cli"))).not.toThrow();
   });

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -25,10 +25,18 @@ $NodeMinMajor = 22
 # Installer scratch files live under $IxHome, never under $env:TEMP.
 #
 # #349: on a profile at `C:\Users\Win 10`, Windows hands the installer a TEMP
-# path in 8.3 short form and the run dies after extraction with
-# `An object at the specified path C:\Users\WIN10~1 does not exist.`
-# The reporter confirmed that pointing TEMP and TMP at a path without a space
-# lets the same install finish, so the short TEMP path is what breaks it.
+# path in 8.3 short form and the run dies after extraction. The reporter
+# confirmed that pointing TEMP and TMP at a path without a space lets the same
+# install finish, so the short TEMP path is what breaks it.
+#
+# The issue quotes the error verbatim as
+#   An object at the specified path C:\Users\WIN10\~1 does not exist.
+# -- note the backslash before `~1`. Probably a copy artifact, since
+# `C:\Users\WIN10~1` is the 8.3 alias of `C:\Users\Win 10` and a literal `~1`
+# directory makes no sense, but it has not been confirmed with the reporter and
+# the 8.3 reading depends on that one character. Quoted as written rather than
+# normalised, because the whole point of the block below is which parts of this
+# are established.
 #
 # $IxHome comes from USERPROFILE, which is the long form. $Staging was already
 # there, so moving these two takes the script off TEMP completely.
@@ -75,9 +83,28 @@ function Write-Warn($msg) { Write-Host "  [!!] $msg" -ForegroundColor Yellow }
 # run it, so a partial multi-MB zip would sit in ~/.ix forever. Write-Err is the
 # single exit for every failure below, which makes it the one place this has to
 # be right.
+#
+# Rebuilds the two names from $IxHome and $PID rather than reading $tmp and
+# $pullLog. README ships this as `irm ... | iex`, so the script body runs in the
+# *caller's* scope -- the same hazard the $Matches note below already calls out.
+# Every Write-Err above the assignments (and all of them, on the re-run path,
+# where $pullLog is never assigned because the backend is already healthy) would
+# otherwise read whatever the user's own session had in those names and delete
+# it. $IxHome is assigned unconditionally at the top, long before any Write-Err
+# is reachable, so it is always ours.
+#
+# -PathType Leaf because $Staging is `.cli-staging-<pid>` -- a *directory* the
+# failure sites clean themselves. Without it, `Remove-Item -Force` on a
+# directory with children throws (there is no host UI for the prompt, and
+# -ErrorAction SilentlyContinue does not catch it), which would escape into the
+# trap and print a second, meaningless error over the real one.
 function Remove-InstallerScratch {
-    foreach ($p in @($script:tmp, $script:pullLog)) {
-        if ($p) { Remove-Item -LiteralPath $p -Force -ErrorAction SilentlyContinue }
+    if (-not $IxHome) { return }
+    foreach ($name in @(".cli-staging-$PID.zip", ".cli-staging-pull-$PID.log")) {
+        $p = Join-Path $IxHome $name
+        if (Test-Path -LiteralPath $p -PathType Leaf) {
+            Remove-Item -LiteralPath $p -Force -ErrorAction SilentlyContinue
+        }
     }
 }
 

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -93,18 +93,33 @@ function Write-Warn($msg) { Write-Host "  [!!] $msg" -ForegroundColor Yellow }
 # it. $IxHome is assigned unconditionally at the top, long before any Write-Err
 # is reachable, so it is always ours.
 #
-# -PathType Leaf because $Staging is `.cli-staging-<pid>` -- a *directory* the
-# failure sites clean themselves. Without it, `Remove-Item -Force` on a
-# directory with children throws (there is no host UI for the prompt, and
-# -ErrorAction SilentlyContinue does not catch it), which would escape into the
-# trap and print a second, meaningless error over the real one.
+# -PathType Leaf so a *directory* sitting on either name is skipped rather than
+# removed. (Not $Staging -- that is `.cli-staging-<pid>` with no suffix and
+# cannot collide with the `.zip`/`.log` names built here.) Two cases it does
+# cover, both measured: a stale directory squatting the exact name, where
+# `Remove-Item -Force` on one with children throws, since there is no host UI
+# for the prompt and -ErrorAction SilentlyContinue does not catch it; and a
+# directory junction at that name, which is skipped outright so PS 5.1 never
+# gets the chance to recurse into whatever it points at.
+#
+# The whole body is wrapped because this runs *from the error path*. Anything
+# escaping here lands in the trap and prints a second, meaningless error over
+# the actionable one the user actually needs -- which is what an unguarded
+# Test-Path does under `$ErrorActionPreference = "Stop"` when IX_HOME names a
+# detached drive: it throws DriveNotFoundException rather than returning false,
+# on both 5.1 and 7. Join-Path throws on illegal characters on 5.1 for the same
+# reason. Best-effort cleanup must never be the loudest thing in the output.
 function Remove-InstallerScratch {
     if (-not $IxHome) { return }
-    foreach ($name in @(".cli-staging-$PID.zip", ".cli-staging-pull-$PID.log")) {
-        $p = Join-Path $IxHome $name
-        if (Test-Path -LiteralPath $p -PathType Leaf) {
-            Remove-Item -LiteralPath $p -Force -ErrorAction SilentlyContinue
+    try {
+        foreach ($name in @(".cli-staging-$PID.zip", ".cli-staging-pull-$PID.log")) {
+            $p = Join-Path $IxHome $name
+            if (Test-Path -LiteralPath $p -PathType Leaf) {
+                Remove-Item -LiteralPath $p -Force -ErrorAction SilentlyContinue
+            }
         }
+    } catch {
+        # Deliberately silent: see above.
     }
 }
 

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -24,27 +24,38 @@ $NodeMinMajor = 22
 
 # Installer scratch files live under $IxHome, never under $env:TEMP.
 #
-# Windows sets TEMP to the 8.3 short form of the profile path when that path
-# contains a space -- `C:\Users\Win 10` becomes `C:\Users\WIN10~1` -- and
-# PowerShell's FileSystem provider cannot resolve a short-name segment. Any
-# provider cmdlet handed such a path fails with "An object at the specified
-# path C:\Users\WIN10~1 does not exist", naming the first segment it could not
-# resolve rather than the file it was actually given, which is why the error
-# reads as though it were about the profile rather than the file being written.
-# curl.exe and Expand-Archive go straight to Win32 and succeed on that very same
-# path, so the install got all the way through downloading and extracting before
-# falling over.
+# #349: on a profile at `C:\Users\Win 10`, Windows hands the installer a TEMP
+# path in 8.3 short form and the run dies after extraction with
+# `An object at the specified path C:\Users\WIN10~1 does not exist.`
+# The reporter confirmed that pointing TEMP and TMP at a path without a space
+# lets the same install finish, so the short TEMP path is what breaks it.
 #
-# $IxHome comes from USERPROFILE, which is the long form, so routing scratch
-# through it sidesteps the whole class rather than expanding short names at each
-# call site.
+# $IxHome comes from USERPROFILE, which is the long form. $Staging was already
+# there, so moving these two takes the script off TEMP completely.
+#
+# What is NOT established is which call fails, or why -- treat the mechanism as
+# open until a fresh transcript says otherwise:
+#   - The provider cmdlets this script runs on the zip (`Test-Path
+#     -LiteralPath`, `Get-Item -LiteralPath`) resolve 8.3 segments fine on both
+#     Windows PowerShell 5.1 and 7, and the reporter's transcript shows them
+#     succeeding -- extraction completes before the error appears.
+#   - `Expand-Archive` resolves through the provider too (Resolve-Path in
+#     Microsoft.PowerShell.Archive), so this is not a Win32-vs-provider split.
+#   - That error string could not be reproduced from any cmdlet this script
+#     calls; the ones that fail on a missing path say "Cannot find path".
+# The likeliest remaining explanation is that 8.3 alias *creation* is disabled
+# on that volume while TEMP still carries a stale short path, so nothing
+# resolves it. Moving off TEMP fixes that reading too, which is why this is
+# worth shipping ahead of the diagnosis.
+#
+# Note `ix upgrade` still stages through os.tmpdir() (upgrade.ts), which on
+# Windows is TEMP verbatim. If this class is real, it is unfixed there.
 #
 # The `.cli-staging-` prefix on both scratch names is deliberate:
-# sweepUpgradeOrphans in upgrade.ts reclaims `.cli-staging-*` out of IX_HOME, so
-# an installer killed mid-run still leaves nothing permanent behind -- the one
-# property TEMP was giving us for free. It must not be `.cli-backup-`: that
-# prefix is a *recovery* candidate there, and a leftover zip would be renamed
-# over the install directory on the next upgrade.
+# sweepUpgradeOrphans in upgrade.ts reclaims `.cli-staging-*` out of IX_HOME.
+# It must not be `.cli-backup-`: that prefix is a *recovery* candidate there,
+# and a leftover zip would be renamed over the install directory on the next
+# upgrade.
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -57,8 +68,22 @@ function Pause-On-Failure {
 
 function Write-Ok($msg) { Write-Host "  [ok] $msg" -ForegroundColor Green }
 function Write-Warn($msg) { Write-Host "  [!!] $msg" -ForegroundColor Yellow }
+# Leaving TEMP also left the OS's own cleanup, so every exit has to clear its
+# own scratch. sweepUpgradeOrphans covers a process killed outright, but it runs
+# only from `ix upgrade` and only when an update is actually available -- and a
+# first install that dies at the download leaves no `ix` on the machine to ever
+# run it, so a partial multi-MB zip would sit in ~/.ix forever. Write-Err is the
+# single exit for every failure below, which makes it the one place this has to
+# be right.
+function Remove-InstallerScratch {
+    foreach ($p in @($script:tmp, $script:pullLog)) {
+        if ($p) { Remove-Item -LiteralPath $p -Force -ErrorAction SilentlyContinue }
+    }
+}
+
 function Write-Err($msg) {
     Write-Host "  [error] $msg" -ForegroundColor Red
+    Remove-InstallerScratch
     Pause-On-Failure
     exit 1
 }

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -95,20 +95,24 @@ function Write-Warn($msg) { Write-Host "  [!!] $msg" -ForegroundColor Yellow }
 #
 # -PathType Leaf so a *directory* sitting on either name is skipped rather than
 # removed. (Not $Staging -- that is `.cli-staging-<pid>` with no suffix and
-# cannot collide with the `.zip`/`.log` names built here.) Two cases it does
-# cover, both measured: a stale directory squatting the exact name, where
-# `Remove-Item -Force` on one with children throws, since there is no host UI
-# for the prompt and -ErrorAction SilentlyContinue does not catch it; and a
-# directory junction at that name, which is skipped outright so PS 5.1 never
-# gets the chance to recurse into whatever it points at.
+# cannot collide with the `.zip`/`.log` names built here.) Two measured cases:
+# a stale directory squatting the exact name, where `Remove-Item -Force` on one
+# with children throws, since there is no host UI for the prompt and
+# -ErrorAction SilentlyContinue does not catch it; and a junction at that name,
+# where the guard keeps the installer from deleting a reparse point it did not
+# create, and turns 5.1's NullReferenceException into a clean skip. Neither
+# host recurses into a junction's target without -Recurse, so that is not the
+# risk being avoided.
 #
-# The whole body is wrapped because this runs *from the error path*. Anything
-# escaping here lands in the trap and prints a second, meaningless error over
-# the actionable one the user actually needs -- which is what an unguarded
-# Test-Path does under `$ErrorActionPreference = "Stop"` when IX_HOME names a
-# detached drive: it throws DriveNotFoundException rather than returning false,
-# on both 5.1 and 7. Join-Path throws on illegal characters on 5.1 for the same
-# reason. Best-effort cleanup must never be the loudest thing in the output.
+# The whole body is wrapped because this runs *from the error path*: anything
+# escaping lands in the trap and prints a second, meaningless error over the
+# actionable one. Under `$ErrorActionPreference = "Stop"` the two statements
+# fail on different inputs, which is why guarding one of them is not enough --
+# with IX_HOME on a detached drive it is `Join-Path` that throws
+# DriveNotFoundException, on both 5.1 and 7, before Test-Path is ever reached;
+# with illegal characters in the path `Join-Path` returns and `Test-Path`
+# throws ArgumentException, on 5.1 only. Best-effort cleanup must never be the
+# loudest thing in the output.
 function Remove-InstallerScratch {
     if (-not $IxHome) { return }
     try {

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -22,6 +22,30 @@ $HealthUrl = "http://localhost:8090/v1/health"
 $ArangoUrl = "http://localhost:8529/_api/version"
 $NodeMinMajor = 22
 
+# Installer scratch files live under $IxHome, never under $env:TEMP.
+#
+# Windows sets TEMP to the 8.3 short form of the profile path when that path
+# contains a space -- `C:\Users\Win 10` becomes `C:\Users\WIN10~1` -- and
+# PowerShell's FileSystem provider cannot resolve a short-name segment. Any
+# provider cmdlet handed such a path fails with "An object at the specified
+# path C:\Users\WIN10~1 does not exist", naming the first segment it could not
+# resolve rather than the file it was actually given, which is why the error
+# reads as though it were about the profile rather than the file being written.
+# curl.exe and Expand-Archive go straight to Win32 and succeed on that very same
+# path, so the install got all the way through downloading and extracting before
+# falling over.
+#
+# $IxHome comes from USERPROFILE, which is the long form, so routing scratch
+# through it sidesteps the whole class rather than expanding short names at each
+# call site.
+#
+# The `.cli-staging-` prefix on both scratch names is deliberate:
+# sweepUpgradeOrphans in upgrade.ts reclaims `.cli-staging-*` out of IX_HOME, so
+# an installer killed mid-run still leaves nothing permanent behind -- the one
+# property TEMP was giving us for free. It must not be `.cli-backup-`: that
+# prefix is a *recovery* candidate there, and a leftover zip would be renamed
+# over the install directory on the next upgrade.
+
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 function Pause-On-Failure {
@@ -182,7 +206,7 @@ if (Test-Healthy) {
 
     # Capture the compose output so a failed pull can be diagnosed instead of
     # reported as a bare "Docker compose failed". Tee keeps it on screen too.
-    $pullLog = Join-Path $env:TEMP "ix-pull-$PID.log"
+    $pullLog = Join-Path $IxHome ".cli-staging-pull-$PID.log"
     $prevEap = $ErrorActionPreference
     $ErrorActionPreference = "Continue"
     try {
@@ -260,7 +284,7 @@ Write-Host "`n-- CLI --"
 
 $Tarball = "ix-$Version-windows-amd64.zip"
 $Url = "https://github.com/$GithubOrg/$GithubRepo/releases/download/v$Version/$Tarball"
-$tmp = "$env:TEMP\$Tarball"
+$tmp = "$IxHome\.cli-staging-$PID.zip"
 $InstallDir = "$IxHome\cli"
 
 New-Item -ItemType Directory -Force -Path $IxBin | Out-Null


### PR DESCRIPTION
Refs #349. *(Was `Fixes #349` - downgraded so merging does not auto-close it, matching the "still needs a real Windows run to confirm" note below. See Review follow-up at the end.)*

## What the user saw

An install on a profile at `C:\Users\Win 10` downloads and extracts fine, then dies naming a path it was never asked to write:

```text
[ok] Downloaded to C:\Users\WIN10~1\AppData\Local\Temp\ix-0.8.1-windows-amd64.zip
Extracting CLI...
[ok] Extraction complete

Ix installer failed.
Error:
An object at the specified path C:\Users\WIN10~1 does not exist.
```

## Why

Not the space itself — the 8.3 short path it produces. Windows sets `TEMP` to the short form of the profile path when that path contains a space, so `C:\Users\Win 10` becomes `C:\Users\WIN10~1`. PowerShell's FileSystem provider cannot resolve a short-name segment, and when it fails it reports the first segment it could not resolve rather than the file it was handed — which is why the error names the profile root and looks unrelated to the install.

`curl.exe` and `Expand-Archive` go straight to Win32 and succeed on that same path. That is the whole reason the failure lands *after* `[ok] Extraction complete`: everything that talks to Win32 directly worked, and the first provider cmdlet to touch the temp path did not.

The live script at `https://ix-infra.com/install.ps1` is byte-identical to `main`, so this is current code, not something already fixed since 0.8.1.

## The fix

Route the two scratch files — the CLI zip and the compose pull log — through `IX_HOME` rather than `TEMP`. `IX_HOME` comes from `USERPROFILE` in its long form, so this sidesteps the class instead of expanding short names at each call site.

Both take the `.cli-staging-` prefix, because leaving `TEMP` also leaves the OS's own cleanup: `sweepUpgradeOrphans` already reclaims `.cli-staging-*` out of `IX_HOME`, so an installer killed mid-run still leaves nothing permanent behind. Deliberately **not** `.cli-backup-` — that prefix is a *recovery* candidate in the sweep, and a leftover zip would be renamed over `~/.ix/cli` on the next upgrade.

## Testing

`install.ps1` cannot be parsed or run here (no PowerShell on Linux, and CI's `windows-2022` leg packages the CLI without running the installer), so the two properties the script now depends on are pinned in `upgrade-archive-shape.test.ts` instead — the sweep had only ever been handed directories, never files:

- leftover `.cli-staging-<pid>.zip` and `.cli-staging-pull-<pid>.log` are reclaimed
- a stray `.cli-staging-*` file is never mistaken for an install worth recovering

19/19 pass in that file.

Still needs a real Windows run to confirm end to end. Worth folding into the existing rc.2 Windows check rather than a separate pass.

## Note on release timing

This does not need to block the v0.9.0 GA tag. `install.ps1` is fetched from `main`, not from the release zip, so it reaches users as soon as it merges regardless of what is tagged.

---

## Review follow-up (independent pass + fixes pushed)

Two commits added on top. The code change and both of Ian's tests stand — the tests were mutation-checked and each kills exactly the one test it claims to protect.

**1. Scratch leaked on every failure path.** Leaving `TEMP` also left the OS's cleanup, and the only delete of the zip was on the success path — five exits left it behind. `sweepUpgradeOrphans` is a weaker backstop than the original comment implied: it runs only from `ix upgrade`, and only when an update is available, so a *first* install that dies at the download strands a partial multi-MB zip in `~/.ix` with no `ix` on the machine to ever reclaim it. Cleanup now hangs off `Write-Err`, the single exit for every failure below it. Verified on Windows PowerShell 5.1 and pwsh 7 against the real function extracted from the script: both files reclaimed, install directory untouched, no throw when the paths are still unassigned (an early `Write-Err`) or when the file is already gone.

**2. The mechanism in the checked-in comment did not survive checking**, so it has been rewritten to separate what the report establishes from what it does not. Specifically:

- `Expand-Archive` resolves through the FileSystem provider (`Resolve-Path` in `Microsoft.PowerShell.Archive`), so "curl.exe and Expand-Archive go straight to Win32" is not the split.
- The provider resolves 8.3 segments fine on both 5.1 and 7 — `Test-Path C:\PROGRA~1` returns `True`.
- The reporter's own transcript shows `Test-Path -LiteralPath $tmp` and `Get-Item -LiteralPath $tmp` **succeeding** on the short TEMP path: both run before `Expand-Archive`, and extraction completes before the error appears. So "the first provider cmdlet to touch the temp path failed" cannot be what happened.
- The error string `An object at the specified path ... does not exist.` could not be reproduced from ~30 cmdlets, including every one this script calls on those paths — they report `Cannot find path` instead.
- Issue #349 quotes the path as `C:\Users\WIN10\~1`, not `C:\Users\WIN10~1`. Probably a copy artifact, but it was silently normalised in the PR body, and the 8.3 reading depends on that character.

**The fix is still right, which is why this is merging.** The reporter confirmed that pointing `TEMP`/`TMP` at a path without a space makes the same install succeed, so TEMP is implicated regardless of mechanism. The likelier reading is that 8.3 alias *creation* is disabled on that volume while `TEMP` still carries a stale short path — in which case nothing resolves it, and moving off TEMP fixes that too. Both readings are repaired by this change; only the explanation differs.

**Left open deliberately:**

- `ix upgrade` still stages through `os.tmpdir()` (`upgrade.ts:771`, `:1048`), which on Windows is `%TEMP%` verbatim. If this class is real, it is unfixed there.
- #349 stays open until the reporter confirms on the affected machine. That is why this is `Refs` rather than `Fixes` — it matches the "still needs a real Windows run to confirm end to end" note above.

*Pre-existing, unchanged, flagged for the record:* `install.ps1` has no BOM and 1203 non-ASCII bytes, so `powershell.exe -File` reports 16 parse errors on Windows PowerShell 5.1. Identical on base and head — neither Ian's commit nor mine moved it, and the documented `irm | iex` path is unaffected because the server sends `charset=utf-8`.
