### PR TITLE
fix(status): keep staleness scoped to each workspace

### DIFF
--- a/ix-cli/src/cli/__tests__/stale-workspace.test.ts
+++ b/ix-cli/src/cli/__tests__/stale-workspace.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import type { IxClient } from "../../client/api.js";
+import { ingestMtimeCachePath } from "../config.js";
+import { loadIngestBaseline } from "../ingest-baseline.js";
+import { persistIngestBaselineIfClean } from "../commands/ingest.js";
+import { detectStaleFiles } from "../stale.js";
+
+let home: string;
+let savedHome: string | undefined;
+let savedProfile: string | undefined;
+
+const noPatchReads = {
+  listPatches: async () => {
+    throw new Error("global patches must not be read");
+  },
+  stats: async () => {
+    throw new Error("global stats must not be read");
+  },
+} as unknown as IxClient;
+
+function writeSource(root: string, name: string, source: string): string {
+  fs.mkdirSync(root, { recursive: true });
+  const filePath = path.join(root, name);
+  fs.writeFileSync(filePath, source);
+  return filePath;
+}
+
+function moveMtimeForward(filePath: string): number {
+  const next = fs.statSync(filePath).mtimeMs + 2_000;
+  fs.utimesSync(filePath, next / 1_000, next / 1_000);
+  return fs.statSync(filePath).mtimeMs;
+}
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "ix-stale-workspace-"));
+  savedHome = process.env.HOME;
+  savedProfile = process.env.USERPROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+});
+
+afterEach(() => {
+  process.env.HOME = savedHome;
+  process.env.USERPROFILE = savedProfile;
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+describe("workspace-scoped staleness", () => {
+  it("keeps workspace A stale after workspace B records a newer ingest", async () => {
+    const rootA = path.join(home, "a");
+    const rootB = path.join(home, "b");
+    const fileA = writeSource(rootA, "a.js", "export const value = 'a';\n");
+    const fileB = writeSource(rootB, "b.js", "export const value = 'b';\n");
+    const ingestedA = new Date("2026-08-09T18:00:00.000Z");
+
+    expect(
+      persistIngestBaselineIfClean(
+        rootA,
+        new Map([[fileA, fs.statSync(fileA).mtimeMs]]),
+        11,
+        0,
+        0,
+        ingestedA,
+      ),
+    ).toBe(true);
+
+    moveMtimeForward(fileA);
+    const beforeB = await detectStaleFiles(noPatchReads, rootA);
+    expect(beforeB).toEqual({
+      lastIngestAt: ingestedA.toISOString(),
+      currentRev: 11,
+      staleFiles: 1,
+      sampleChangedFiles: ["a.js"],
+    });
+
+    expect(
+      persistIngestBaselineIfClean(
+        rootB,
+        new Map([[fileB, fs.statSync(fileB).mtimeMs]]),
+        12,
+        0,
+        0,
+        new Date("2026-08-09T18:01:00.000Z"),
+      ),
+    ).toBe(true);
+
+    expect(await detectStaleFiles(noPatchReads, rootA)).toEqual(beforeB);
+  });
+
+  it("loads the legacy mtime-only cache and uses its own file timestamp", async () => {
+    const root = path.join(home, "legacy");
+    const filePath = writeSource(root, "legacy.js", "export const value = 1;\n");
+    const originalMtime = fs.statSync(filePath).mtimeMs;
+    const cachePath = ingestMtimeCachePath(root);
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    fs.writeFileSync(
+      cachePath,
+      JSON.stringify({
+        root,
+        files: { [filePath]: originalMtime },
+      }),
+    );
+    const legacyTimestamp = new Date("2026-08-09T17:00:00.000Z");
+    fs.utimesSync(cachePath, legacyTimestamp, legacyTimestamp);
+    moveMtimeForward(filePath);
+
+    const result = await detectStaleFiles(noPatchReads, root);
+    expect(result.currentRev).toBe(0);
+    expect(result.lastIngestAt).toBe(fs.statSync(cachePath).mtime.toISOString());
+    expect(result.staleFiles).toBe(1);
+    expect(result.sampleChangedFiles).toEqual(["legacy.js"]);
+  });
+
+  it("returns the unmapped state when the workspace has no baseline", async () => {
+    const root = path.join(home, "unmapped");
+    writeSource(root, "new.js", "export const value = 1;\n");
+
+    expect(await detectStaleFiles(noPatchReads, root)).toEqual({
+      lastIngestAt: null,
+      currentRev: 0,
+      staleFiles: 0,
+      sampleChangedFiles: [],
+    });
+  });
+
+  it("uses ingest time for files absent from the mtime cache", async () => {
+    const root = path.join(home, "partial-cache");
+    const mappedFile = writeSource(root, "mapped.js", "export const mapped = true;\n");
+    const uncachedFile = writeSource(root, "uncached.js", "");
+    const ingestedAt = new Date("2026-08-09T18:00:00.000Z");
+    fs.utimesSync(
+      uncachedFile,
+      new Date(ingestedAt.getTime() - 1_000),
+      new Date(ingestedAt.getTime() - 1_000),
+    );
+    persistIngestBaselineIfClean(
+      root,
+      new Map([[mappedFile, fs.statSync(mappedFile).mtimeMs]]),
+      13,
+      0,
+      0,
+      ingestedAt,
+    );
+
+    expect((await detectStaleFiles(noPatchReads, root)).staleFiles).toBe(0);
+
+    fs.utimesSync(
+      uncachedFile,
+      new Date(ingestedAt.getTime() + 1_000),
+      new Date(ingestedAt.getTime() + 1_000),
+    );
+    expect(await detectStaleFiles(noPatchReads, root)).toMatchObject({
+      staleFiles: 1,
+      sampleChangedFiles: ["uncached.js"],
+    });
+  });
+
+  it.each([
+    { parseErrors: 1, commitErrors: 0 },
+    { parseErrors: 0, commitErrors: 1 },
+  ])("does not advance the baseline when a map fails", async ({ parseErrors, commitErrors }) => {
+    const root = path.join(home, "failed-map");
+    const filePath = writeSource(root, "index.js", "export const value = 1;\n");
+    const oldMtime = fs.statSync(filePath).mtimeMs;
+    const oldTimestamp = new Date("2026-08-09T16:00:00.000Z");
+    persistIngestBaselineIfClean(root, new Map([[filePath, oldMtime]]), 7, 0, 0, oldTimestamp);
+
+    const changedMtime = moveMtimeForward(filePath);
+    expect(
+      persistIngestBaselineIfClean(
+        root,
+        new Map([[filePath, changedMtime]]),
+        8,
+        parseErrors,
+        commitErrors,
+        new Date("2026-08-09T16:01:00.000Z"),
+      ),
+    ).toBe(false);
+
+    const baseline = loadIngestBaseline(root);
+    expect(baseline?.currentRev).toBe(7);
+    expect(baseline?.lastIngestAt).toBe(oldTimestamp.toISOString());
+    expect(baseline?.files.get(filePath)).toBe(oldMtime);
+    expect((await detectStaleFiles(noPatchReads, root)).staleFiles).toBe(1);
+  });
+});

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -10,7 +10,8 @@ import { ParsePool } from './parse-pool.js';
 import chalk from 'chalk';
 import { IxClient } from '../../client/api.js';
 import type { GraphPatchPayload } from '../../client/types.js';
-import { getEndpoint, resolveWorkspaceRoot, ingestMtimeCachePath } from '../config.js';
+import { getEndpoint, resolveWorkspaceRoot } from '../config.js';
+import { loadIngestBaseline, saveIngestBaseline } from '../ingest-baseline.js';
 import { resolveGitHubToken } from '../github/auth.js';
 import { parseGitHubRepo, fetchGitHubData } from '../github/fetch.js';
 import { loadIngestionModules } from './ingestion-loader.js';
@@ -304,31 +305,21 @@ async function retryOnConflict<T>(fn: () => Promise<T>, maxRetries: number): Pro
 // Mtime cache — skip readFileSync+sha256 for unchanged files
 // ---------------------------------------------------------------------------
 
-interface MtimeCache {
-  root: string;
-  files: Record<string, number>; // absolute path → mtime (ms)
-}
-
 function loadMtimeCache(projectRoot: string): Map<string, number> {
-  try {
-    const raw = fs.readFileSync(ingestMtimeCachePath(projectRoot), 'utf-8');
-    const data = JSON.parse(raw) as MtimeCache;
-    if (data.root !== projectRoot) return new Map();
-    return new Map(Object.entries(data.files));
-  } catch {
-    return new Map();
-  }
+  return loadIngestBaseline(projectRoot)?.files ?? new Map();
 }
 
-function saveMtimeCache(projectRoot: string, mtimes: Map<string, number>): void {
-  try {
-    const dir = nodePath.join(os.homedir(), '.ix');
-    fs.mkdirSync(dir, { recursive: true });
-    const data: MtimeCache = { root: projectRoot, files: Object.fromEntries(mtimes) };
-    fs.writeFileSync(ingestMtimeCachePath(projectRoot), JSON.stringify(data));
-  } catch {
-    // Non-critical: ignore write errors
-  }
+export function persistIngestBaselineIfClean(
+  projectRoot: string,
+  mtimes: Map<string, number>,
+  currentRev: number,
+  parseErrors: number,
+  commitErrors: number,
+  now?: Date,
+): boolean {
+  if (!ingestCompletedCleanly(parseErrors, commitErrors) || mtimes.size === 0) return false;
+  saveIngestBaseline(projectRoot, mtimes, currentRev, now);
+  return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -1361,9 +1352,13 @@ export async function ingestFiles(
     // three guards would start caching mtimes for files whose patches never
     // landed. The next run would skip them as unchanged and they would stay
     // missing from the graph until a --force.
-    if (!opts.force && ingestCompletedCleanly(parseErrors, commitErrors) && currentMtimes.size > 0) {
-      saveMtimeCache(projectRoot, currentMtimes);
-    }
+    persistIngestBaselineIfClean(
+      projectRoot,
+      currentMtimes,
+      latestRev,
+      parseErrors,
+      commitErrors,
+    );
 
     // Migration cleanup (Ix#225 gap 2): the re-ingest under the new path-based id has
     // committed, so delete the OLD id's now-orphaned nodes/edges/patches. Best-effort —

--- a/ix-cli/src/cli/ingest-baseline.ts
+++ b/ix-cli/src/cli/ingest-baseline.ts
@@ -1,0 +1,65 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { ingestMtimeCachePath } from "./config.js";
+
+interface SerializedIngestBaseline {
+  root: string;
+  files: Record<string, number>;
+  currentRev?: number;
+  lastIngestAt?: string;
+}
+
+export interface IngestBaseline {
+  files: Map<string, number>;
+  currentRev: number;
+  lastIngestAt: string;
+}
+
+export function loadIngestBaseline(projectRoot: string): IngestBaseline | null {
+  const cachePath = ingestMtimeCachePath(projectRoot);
+  try {
+    const data = JSON.parse(fs.readFileSync(cachePath, "utf-8")) as SerializedIngestBaseline;
+    if (data.root !== projectRoot || !data.files || typeof data.files !== "object") return null;
+
+    const files = new Map<string, number>();
+    for (const [filePath, mtime] of Object.entries(data.files)) {
+      if (Number.isFinite(mtime)) files.set(filePath, mtime);
+    }
+
+    const parsedTimestamp = data.lastIngestAt ? Date.parse(data.lastIngestAt) : Number.NaN;
+    const lastIngestAt = Number.isFinite(parsedTimestamp)
+      ? new Date(parsedTimestamp).toISOString()
+      : fs.statSync(cachePath).mtime.toISOString();
+    const currentRev =
+      typeof data.currentRev === "number" &&
+      Number.isInteger(data.currentRev) &&
+      data.currentRev >= 0
+        ? data.currentRev
+        : 0;
+
+    return { files, currentRev, lastIngestAt };
+  } catch {
+    return null;
+  }
+}
+
+export function saveIngestBaseline(
+  projectRoot: string,
+  mtimes: Map<string, number>,
+  currentRev: number,
+  now: Date = new Date(),
+): void {
+  try {
+    const previousRev = loadIngestBaseline(projectRoot)?.currentRev ?? 0;
+    const data: SerializedIngestBaseline = {
+      root: projectRoot,
+      files: Object.fromEntries(mtimes),
+      currentRev: currentRev > 0 ? currentRev : previousRev,
+      lastIngestAt: now.toISOString(),
+    };
+    fs.mkdirSync(path.dirname(ingestMtimeCachePath(projectRoot)), { recursive: true });
+    fs.writeFileSync(ingestMtimeCachePath(projectRoot), JSON.stringify(data));
+  } catch {
+    // The cache is an optimization and freshness hint. Ingestion itself succeeded.
+  }
+}

--- a/ix-cli/src/cli/stale.ts
+++ b/ix-cli/src/cli/stale.ts
@@ -1,6 +1,8 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { IxClient } from "../client/api.js";
+import type { IxClient } from "../client/api.js";
+import { resolveWorkspaceRoot } from "./config.js";
+import { loadIngestBaseline } from "./ingest-baseline.js";
 import { SUPPORTED_EXTENSIONS } from "./supported-extensions.js";
 
 export interface StaleInfo {
@@ -57,37 +59,44 @@ function collectFiles(dir: string, limit: number = 5000): string[] {
   return results;
 }
 
+function differsFromIngestBaseline(
+  filePath: string,
+  mtimeMs: number,
+  ingestedMtimes: Map<string, number>,
+  lastIngestAt: string,
+): boolean {
+  const ingestedMtime = ingestedMtimes.get(filePath);
+  return ingestedMtime === undefined
+    ? mtimeMs > Date.parse(lastIngestAt)
+    : ingestedMtime !== mtimeMs;
+}
+
 /**
  * Detect files that have been modified since the last ingest.
- * Uses mtime comparison against the latest patch timestamp.
+ * Uses the workspace-local ingest baseline so another workspace cannot advance it.
  */
 export async function detectStaleFiles(
-  client: IxClient,
+  _client: IxClient,
   root: string,
   maxSamples: number = 5
 ): Promise<StaleInfo> {
-  // Get latest patch to determine last ingest time
-  const patches = await client.listPatches({ limit: 1 });
-  const stats = await client.stats();
-
-  const lastPatch = patches[0];
-  const lastIngestAt = lastPatch?.timestamp ?? null;
-  const currentRev = lastPatch?.rev ?? 0;
-
-  if (!lastIngestAt) {
+  const workspaceRoot = path.resolve(root);
+  const baseline = loadIngestBaseline(workspaceRoot);
+  if (!baseline) {
     return { lastIngestAt: null, currentRev: 0, staleFiles: 0, sampleChangedFiles: [] };
   }
 
-  const lastIngestTime = new Date(lastIngestAt).getTime();
-  const files = collectFiles(root);
+  const files = collectFiles(workspaceRoot);
   const changedFiles: string[] = [];
 
   for (const filePath of files) {
     try {
       const stat = fs.statSync(filePath);
-      if (stat.mtimeMs > lastIngestTime) {
+      if (
+        differsFromIngestBaseline(filePath, stat.mtimeMs, baseline.files, baseline.lastIngestAt)
+      ) {
         // Make path relative to root for display
-        const relative = path.relative(root, filePath);
+        const relative = path.relative(workspaceRoot, filePath);
         changedFiles.push(relative);
       }
     } catch {
@@ -96,30 +105,34 @@ export async function detectStaleFiles(
   }
 
   return {
-    lastIngestAt,
-    currentRev,
+    lastIngestAt: baseline.lastIngestAt,
+    currentRev: baseline.currentRev,
     staleFiles: changedFiles.length,
     sampleChangedFiles: changedFiles.slice(0, maxSamples),
   };
 }
 
 /**
- * Check if a specific file path is stale (modified since last ingest).
+ * Check if a specific file path differs from the active workspace's ingest baseline.
  */
 export async function isFileStale(
-  client: IxClient,
+  _client: IxClient,
   filePath: string
 ): Promise<boolean> {
   if (!fs.existsSync(filePath)) return false;
 
-  const patches = await client.listPatches({ limit: 1 });
-  const lastPatch = patches[0];
-  if (!lastPatch?.timestamp) return false;
+  const workspaceRoot = path.resolve(resolveWorkspaceRoot());
+  const baseline = loadIngestBaseline(workspaceRoot);
+  if (!baseline) return false;
 
-  const lastIngestTime = new Date(lastPatch.timestamp).getTime();
   try {
-    const stat = fs.statSync(filePath);
-    return stat.mtimeMs > lastIngestTime;
+    const absolutePath = path.resolve(filePath);
+    return differsFromIngestBaseline(
+      absolutePath,
+      fs.statSync(absolutePath).mtimeMs,
+      baseline.files,
+      baseline.lastIngestAt,
+    );
   } catch {
     return false;
   }


### PR DESCRIPTION
Fixes #353.

## Summary

Keep staleness metadata in the existing workspace-root-specific ingest cache so mapping another workspace cannot make the current workspace appear up to date.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Extend the per-workspace mtime cache with the last successful ingest time and revision while retaining compatibility with legacy cache files.
- Make `status` and symbol freshness checks use that local baseline instead of graph-wide patch and stats reads.
- Preserve the previous baseline after parse or commit failures and fall back to ingest time for files not represented in the cache.
- Add regression coverage for two workspaces, legacy caches, unmapped workspaces, uncached files, and failed maps.

## Validation

- `cd ix-cli && npm test` (48 files, 631 tests, parser smoke passed)
- `npm run typecheck`
- `npm run build`
- Targeted Vitest, ESLint, Prettier, and `git diff --check`

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
