### PR TITLE
fix(map): suppress progress outside terminals

### DIFF
--- a/ix-cli/src/cli/__tests__/ingest-progress.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-progress.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldRenderIngestProgress } from "../commands/ingest.js";
+
+describe("shouldRenderIngestProgress", () => {
+  it("renders text progress only when stderr is an interactive terminal", () => {
+    expect(shouldRenderIngestProgress("text", true)).toBe(true);
+    expect(shouldRenderIngestProgress("text", false)).toBe(false);
+    expect(shouldRenderIngestProgress("text", undefined)).toBe(false);
+  });
+
+  it("does not render progress for machine-readable formats", () => {
+    expect(shouldRenderIngestProgress("json", true)).toBe(false);
+    expect(shouldRenderIngestProgress("llm", true)).toBe(false);
+  });
+});

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -351,6 +351,13 @@ function renderProgressLine(phase: string, current: number, total: number): stri
   return `  ${phase.padEnd(8)}  ${bar}  ${pctStr}  ${count}`.padEnd(PROG_LINE_WIDTH);
 }
 
+export function shouldRenderIngestProgress(
+  format: string,
+  stderrIsTTY: boolean | undefined,
+): boolean {
+  return format === 'text' && stderrIsTTY === true;
+}
+
 // ---------------------------------------------------------------------------
 // Command registration
 // ---------------------------------------------------------------------------
@@ -700,7 +707,7 @@ export async function ingestFiles(
   let progressTotal   = 0;
   let progressStart   = performance.now();
 
-  const interval = opts.format === 'text' ? setInterval(() => {
+  const interval = shouldRenderIngestProgress(opts.format, process.stderr.isTTY) ? setInterval(() => {
     if (debug && currentWorkLabel) {
       const workElapsed = performance.now() - currentWorkStart;
       if (workElapsed >= SLOW_WORK_LOG_MS && (lastSlowWorkNotice === 0 || workElapsed - lastSlowWorkNotice >= SLOW_WORK_REPEAT_MS)) {


### PR DESCRIPTION
Fixes #354.

## Summary

Only render the ingest progress interval when text output is going to an interactive stderr terminal. Redirected and agent-captured output remains line-oriented instead of retaining carriage-return refresh frames.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Gate the text progress interval on `process.stderr.isTTY === true`.
- Add regression coverage for interactive, redirected, undefined-TTY, JSON, and LLM output modes.

## Validation

- `cd ix-cli && npm test` (48 files, 627 tests, parser smoke passed)
- `npm run typecheck`
- `npm run build`
- Targeted Vitest, ESLint, Prettier, and `git diff --check`
- Redirected local CLI smoke test completed with exit 0, zero stderr bytes, and zero carriage returns

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
