### PR TITLE
fix(view): report where the visualizer is actually serving, not what was asked for

### DIFF
--- a/ix-cli/src/cli/__tests__/view-running-port.test.ts
+++ b/ix-cli/src/cli/__tests__/view-running-port.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { runningInstanceLines } from "../commands/view.js";
+
+// `ix view -p <other-port>` against an already-running server exited 0 and
+// printed the port it had just been *asked* for, which refuses connections,
+// while the real server kept serving on the port it was launched with. The PID
+// and scope were both persisted; the port was not, so this branch had nothing
+// to report and echoed the request back as though it were an answer.
+describe("runningInstanceLines", () => {
+  it("reports where the server actually is, not what was asked for", () => {
+    const lines = runningInstanceLines(19123, 19124, true);
+    expect(lines[0]).toBe("  http://localhost:19123");
+    // The requested port must never appear as a URL — that is the whole bug.
+    expect(lines.some((l) => l.includes("http://localhost:19124"))).toBe(false);
+  });
+
+  it("explains the mismatch instead of silently ignoring the flag", () => {
+    // Silently printing the right URL would fix the broken link but leave the
+    // user believing -p had moved the server, which is the other half of the
+    // report: the command "exits successfully".
+    const lines = runningInstanceLines(19123, 19124, true);
+    expect(lines.join("\n")).toContain("You asked for port 19124");
+    expect(lines.join("\n")).toContain("ix view stop");
+  });
+
+  it("stays quiet when the running port is the one that was asked for", () => {
+    expect(runningInstanceLines(8080, 8080, true)).toEqual(["  http://localhost:8080"]);
+  });
+
+  it("stays quiet when no port was asked for", () => {
+    // The default is 8080, so a plain `ix view` against a server on 19123 must
+    // not nag: the user expressed no preference. This is why the caller passes
+    // getOptionValueSource rather than comparing against the default — someone
+    // who explicitly types `-p 8080` gets the warning, and someone who types
+    // nothing does not, even though opts().port reads 8080 in both cases.
+    expect(runningInstanceLines(19123, 8080, false)).toEqual(["  http://localhost:19123"]);
+  });
+
+  it("admits it does not know rather than guessing, for a pre-existing instance", () => {
+    // An instance started before the port file existed is still running and
+    // still serving. Printing any URL here would be a guess, and a confidently
+    // wrong URL is exactly what this fix removes.
+    const lines = runningInstanceLines(null, 8080, false);
+    expect(lines.join("\n")).toContain("not recorded");
+    expect(lines.some((l) => l.includes("http://localhost"))).toBe(false);
+  });
+});

--- a/ix-cli/src/cli/commands/view.ts
+++ b/ix-cli/src/cli/commands/view.ts
@@ -22,6 +22,11 @@ const PID_FILE = join(IX_HOME, "compass.pid");
 // `ix view` launched from a different workspace can warn instead of silently showing the
 // already-running (differently-scoped) instance.
 const SCOPE_FILE = join(IX_HOME, "compass.scope");
+// Records the port the running visualizer was launched on. The scope was tracked
+// this way from the start but the port was not, so the already-running branch had
+// nothing to report and printed the *current* invocation's -p instead — a URL that
+// refuses connections while the real server is up on another port.
+const PORT_FILE = join(IX_HOME, "compass.port");
 const BACKEND_URL = "http://localhost:8090";
 
 /** Resolve the compass dist directory — installed path first, then dev fallback. */
@@ -50,8 +55,53 @@ function readAlivePid(): number | null {
     // Stale PID file
     try { unlinkSync(PID_FILE); } catch { /* ignore */ }
     try { unlinkSync(SCOPE_FILE); } catch { /* ignore */ }
+    try { unlinkSync(PORT_FILE); } catch { /* ignore */ }
     return null;
   }
+}
+
+/**
+ * The port the running visualizer was launched on, or null if it is not
+ * recorded.
+ *
+ * Null is a real answer, not a failure: an instance started before this file
+ * existed is still running and still serving, we simply do not know where. The
+ * caller says so rather than guessing, because guessing the port is the entire
+ * bug — a confidently printed wrong URL is worse than an admitted unknown.
+ */
+function readRunningPort(): number | null {
+  if (!existsSync(PORT_FILE)) return null;
+  const parsed = parseInt(readFileSync(PORT_FILE, "utf-8").trim(), 10);
+  return Number.isInteger(parsed) && parsed > 0 && parsed <= 65535 ? parsed : null;
+}
+
+/**
+ * What to print under "already running", given where it is actually serving.
+ *
+ * Pulled out as a pure function because the bug lived entirely in this decision
+ * — the surrounding branch was correct — and inline in a command action it could
+ * only have been tested by launching a detached server.
+ *
+ * `requestedPort` is deliberately never used to build a URL. It appears only in
+ * the mismatch message, as the thing the user asked for and did not get.
+ */
+export function runningInstanceLines(
+  runningPort: number | null,
+  requestedPort: number,
+  portWasRequested: boolean
+): string[] {
+  if (runningPort === null) {
+    return [
+      "[!] Its port was not recorded, so the URL is unknown.",
+      "    Run 'ix view stop' then 'ix view' to restart it and record the port.",
+    ];
+  }
+  const lines = [`  http://localhost:${runningPort}`];
+  if (portWasRequested && runningPort !== requestedPort) {
+    lines.push(`[!] You asked for port ${requestedPort}, but it is serving on ${runningPort}.`);
+    lines.push(`    Run 'ix view stop' then 'ix view -p ${requestedPort}' to move it.`);
+  }
+  return lines;
 }
 
 /** Check whether a port is already in use. */
@@ -198,6 +248,12 @@ export function registerViewCommand(program: Command): void {
         console.error("[error] Invalid port number.");
         process.exit(1);
       }
+      // Distinguish "-p 19124" from the 8080 default, so the mismatch warning
+      // below fires only when the user actually asked for a port. Comparing
+      // against 8080 instead would stay silent for someone who explicitly passed
+      // `-p 8080` to a server running elsewhere — the exact case they typed the
+      // flag to find out about.
+      const portWasRequested = view.getOptionValueSource("port") === "cli";
 
       // Resolve the workspace this visualizer is scoped to. The proxy stamps it as
       // X-Ix-Workspace on every /v1 call so Compass isolates by workspace without any
@@ -243,7 +299,13 @@ export function registerViewCommand(program: Command): void {
       const existing = readAlivePid();
       if (existing) {
         console.log(`[ok] Visualizer is already running (PID ${existing})`);
-        console.log(`  http://localhost:${port}`);
+        // The running instance's port, never this invocation's. `-p` asks where to
+        // *start* a server; there is nothing to start here, so echoing it back
+        // printed a URL that refuses connections while the real one served fine
+        // elsewhere — and exited 0, so nothing suggested the URL was wrong.
+        for (const line of runningInstanceLines(readRunningPort(), port, portWasRequested)) {
+          console.log(line);
+        }
         // The running instance has a fixed scope (baked at launch). If this directory
         // maps to a different workspace, say so rather than silently showing the old one.
         const runningKey = existsSync(SCOPE_FILE) ? readFileSync(SCOPE_FILE, "utf-8").trim() : null;
@@ -299,10 +361,14 @@ export function registerViewCommand(program: Command): void {
         process.exit(1);
       }
 
-      // Save PID + the scope it was launched with (for the mismatch warning above).
+      // Save PID + the scope and port it was launched with (for the mismatch
+      // warnings above). The port is written here, beside the pid, so the two can
+      // only ever describe the same process — deriving it later from a live socket
+      // would reintroduce the guess this is replacing.
       mkdirSync(dirname(PID_FILE), { recursive: true });
       writeFileSync(PID_FILE, String(child.pid));
       writeFileSync(SCOPE_FILE, scopeKey);
+      writeFileSync(PORT_FILE, String(port));
 
       const url = `http://localhost:${port}`;
       console.log(`[ok] Visualizer started (PID ${child.pid})`);
@@ -338,6 +404,7 @@ export function registerViewCommand(program: Command): void {
 
       try { unlinkSync(PID_FILE); } catch { /* ignore */ }
       try { unlinkSync(SCOPE_FILE); } catch { /* ignore */ }
+      try { unlinkSync(PORT_FILE); } catch { /* ignore */ }
       console.log(`[ok] Visualizer stopped (PID ${pid})`);
     });
 
@@ -348,6 +415,11 @@ export function registerViewCommand(program: Command): void {
       const pid = readAlivePid();
       if (pid) {
         console.log(`[ok] Visualizer is running (PID ${pid})`);
+        // Now that the port is recorded, `status` can answer the question people
+        // actually run it to answer. It stays silent rather than guessing when the
+        // instance predates the port file.
+        const runningPort = readRunningPort();
+        if (runningPort !== null) console.log(`  http://localhost:${runningPort}`);
       } else {
         console.log("[--] Visualizer is not running.");
         console.log("  Run 'ix view' to start it.");


### PR DESCRIPTION
Fixes #355.

## The problem

`ix view -p <other-port>` against an already-running server exits 0 and prints the port it was just *asked* for. That URL refuses connections while the real server keeps serving on the port it was launched with, and nothing in the output suggests the link is wrong.

The PID and the scope were both persisted at launch. The port was not — so the already-running branch had nothing to report and echoed the request back as though it were an answer. `-p` asks where to *start* a server, and in that branch there is nothing to start.

## The fix

Persist the port beside the PID and report that. It's written at the same moment as the pid, so the two can only ever describe the same process — deriving it later from a live socket would reintroduce exactly the guess this replaces.

**Printing the right URL alone wasn't enough.** That would fix the dead link but leave the user believing `-p` had moved the server, which is the other half of the report ("exits successfully"). A mismatch now says so and gives the two commands that would move it.

That warning fires only when the port was genuinely requested, using `getOptionValueSource` rather than a comparison against the default. Someone who explicitly types `-p 8080` at a server running elsewhere is asking precisely the question the warning answers — and `opts().port` reads `8080` whether or not they typed it.

**An instance started before the port file existed** is still running and still serving, and there is no honest way to say where. It says that, rather than guessing. One restart records it.

## Two things that followed

- `ix view status` printed only a PID. Now that the port is known, it can answer the question people run it to ask.
- The stale-pid cleanup and `stop` both clear the new file, so a reused pid can't inherit a previous instance's port.

## Verification

The decision is a pure function, so the bug is under test rather than the file read — inline in the command action it could only have been tested by launching a detached server. Five cases, including the two silence cases and the unknown-port case.

Run against a real server as well, following the issue's steps:

```text
[ok] Visualizer started (PID 100158)
  http://localhost:19123          <- serving here

$ ix view -p 19124 start --no-open
[ok] Visualizer is already running (PID 100158)
  http://localhost:19123
[!] You asked for port 19124, but it is serving on 19123.
    Run 'ix view stop' then 'ix view -p 19124' to move it.

HTTP on 19123: 200
HTTP on 19124: connection refused
```

It used to print `http://localhost:19124` there. 630 tests pass, `tsc --noEmit` clean.