### PR TITLE
fix(status): decide staleness from this workspace's ingest, not the newest patch

### DIFF
--- a/ix-cli/src/cli/__tests__/stale-workspace-scope.test.ts
+++ b/ix-cli/src/cli/__tests__/stale-workspace-scope.test.ts
@@ -8,20 +8,28 @@ import { ingestMtimeCachePath } from "../config.js";
 import type { IxClient } from "../../client/api.js";
 
 let home: string;
-let realHome: string | undefined;
+const saved: Record<string, string | undefined> = {};
+
+// HOME *and* USERPROFILE: os.homedir() reads USERPROFILE on Windows and HOME on
+// POSIX, so overriding only one sends the Windows run at the real profile — where
+// ~/.ix may not exist and the seed write fails with ENOENT before any assertion
+// runs. Setting both keeps every platform inside the temp directory.
+const HOME_VARS = ["HOME", "USERPROFILE"] as const;
 
 beforeEach(() => {
-  // The cache path is derived from homedir() at call time, so pointing HOME at a
-  // temp directory keeps these tests off the developer's real ~/.ix.
-  realHome = process.env.HOME;
   home = mkdtempSync(join(tmpdir(), "ix-stale-home-"));
-  process.env.HOME = home;
+  for (const key of HOME_VARS) {
+    saved[key] = process.env[key];
+    process.env[key] = home;
+  }
   mkdirSync(join(home, ".ix"), { recursive: true });
 });
 
 afterEach(() => {
-  if (realHome === undefined) delete process.env.HOME;
-  else process.env.HOME = realHome;
+  for (const key of HOME_VARS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
   rmSync(home, { recursive: true, force: true });
 });
 

--- a/ix-cli/src/cli/__tests__/stale-workspace-scope.test.ts
+++ b/ix-cli/src/cli/__tests__/stale-workspace-scope.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, statSync, utimesSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { detectStaleFiles } from "../stale.js";
+import { ingestMtimeCachePath } from "../config.js";
+import type { IxClient } from "../../client/api.js";
+
+let home: string;
+let realHome: string | undefined;
+
+beforeEach(() => {
+  // The cache path is derived from homedir() at call time, so pointing HOME at a
+  // temp directory keeps these tests off the developer's real ~/.ix.
+  realHome = process.env.HOME;
+  home = mkdtempSync(join(tmpdir(), "ix-stale-home-"));
+  process.env.HOME = home;
+  mkdirSync(join(home, ".ix"), { recursive: true });
+});
+
+afterEach(() => {
+  if (realHome === undefined) delete process.env.HOME;
+  else process.env.HOME = realHome;
+  rmSync(home, { recursive: true, force: true });
+});
+
+/** A workspace with one source file, and the ingest record that matches it. */
+function seedWorkspace(name: string): { root: string; file: string } {
+  const root = mkdtempSync(join(tmpdir(), `ix-ws-${name}-`));
+  const file = join(root, `${name}.js`);
+  writeFileSync(file, `export const value = "${name}";\n`);
+  writeFileSync(
+    ingestMtimeCachePath(root),
+    JSON.stringify({ root, files: { [file]: statSync(file).mtimeMs } })
+  );
+  return { root, file };
+}
+
+function touch(file: string): void {
+  const future = new Date(Date.now() + 10_000);
+  utimesSync(file, future, future);
+}
+
+/**
+ * detectStaleFiles only calls listPatches, for the graph revision. `rev` is the
+ * knob the bug turned: mapping another workspace advanced it, and with it the
+ * timestamp the old code compared every file against.
+ */
+function fakeClient(rev: number, timestamp: string): IxClient {
+  return {
+    listPatches: async () => [{ rev, timestamp, patch_id: "x", intent: "", source_uri: "" }],
+    // Unused by detectStaleFiles now, but stubbed so these tests can also be run
+    // against the previous implementation, which called it and discarded the
+    // result. Without it every case fails on a missing method rather than on the
+    // behaviour under test, which would make the comparison worthless.
+    stats: async () => ({}),
+  } as unknown as IxClient;
+}
+
+describe("detectStaleFiles is scoped to the workspace it was asked about", () => {
+  it("reports a modified file as stale", async () => {
+    const a = seedWorkspace("a");
+    touch(a.file);
+
+    const info = await detectStaleFiles(fakeClient(1, new Date().toISOString()), a.root);
+
+    expect(info.staleFiles).toBe(1);
+    expect(info.sampleChangedFiles).toEqual(["a.js"]);
+    rmSync(a.root, { recursive: true, force: true });
+  });
+
+  // The reported bug. Mapping an unrelated workspace advanced the newest patch,
+  // and because the comparison used that patch's timestamp rather than anything
+  // belonging to workspace A, every file in A fell behind it and A was declared
+  // current — while still being genuinely modified.
+  it("stays stale when an unrelated workspace is mapped afterwards", async () => {
+    const a = seedWorkspace("a");
+    touch(a.file);
+
+    const before = await detectStaleFiles(fakeClient(1, new Date().toISOString()), a.root);
+    expect(before.staleFiles).toBe(1);
+
+    // Workspace B is mapped: a newer patch, at a later timestamp, and B gets its
+    // own ingest record. Nothing about A changed.
+    const b = seedWorkspace("b");
+    const after = await detectStaleFiles(
+      fakeClient(2, new Date(Date.now() + 60_000).toISOString()),
+      a.root
+    );
+
+    expect(after.staleFiles).toBe(1);
+    expect(after.sampleChangedFiles).toEqual(["a.js"]);
+    // The graph revision is shared by every workspace and is expected to move.
+    // Reporting it was never the bug; reporting B's staleness for A was.
+    expect(after.currentRev).toBe(2);
+
+    rmSync(a.root, { recursive: true, force: true });
+    rmSync(b.root, { recursive: true, force: true });
+  });
+
+  it("takes lastIngestAt from this workspace, not from the newest patch anywhere", async () => {
+    const a = seedWorkspace("a");
+    // A patch timestamped a year out. The old code echoed this back as "last
+    // ingest" for whatever root it was handed.
+    const distant = new Date(Date.now() + 365 * 24 * 3600_000).toISOString();
+
+    const info = await detectStaleFiles(fakeClient(2, distant), a.root);
+
+    expect(info.lastIngestAt).not.toBe(distant);
+    // It is the ingest record for this root, written when this root was mapped.
+    const written = statSync(ingestMtimeCachePath(a.root)).mtime.toISOString();
+    expect(info.lastIngestAt).toBe(written);
+
+    rmSync(a.root, { recursive: true, force: true });
+  });
+
+  it("treats a root with no ingest record as having nothing to be stale against", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ix-ws-never-"));
+    writeFileSync(join(root, "x.js"), "export const x = 1;\n");
+
+    const info = await detectStaleFiles(fakeClient(7, new Date().toISOString()), root);
+
+    expect(info.lastIngestAt).toBeNull();
+    expect(info.staleFiles).toBe(0);
+    // Still reports the graph revision — that part is genuinely global.
+    expect(info.currentRev).toBe(7);
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("counts a file that did not exist at ingest time", async () => {
+    // Absent from the baseline is new, and new is stale — the same conclusion
+    // ingest reaches, since a path with no cached mtime is never skipped.
+    const a = seedWorkspace("a");
+    writeFileSync(join(a.root, "added.js"), "export const added = 1;\n");
+
+    const info = await detectStaleFiles(fakeClient(1, new Date().toISOString()), a.root);
+
+    expect(info.sampleChangedFiles).toContain("added.js");
+    rmSync(a.root, { recursive: true, force: true });
+  });
+});

--- a/ix-cli/src/cli/commands/explain.ts
+++ b/ix-cli/src/cli/commands/explain.ts
@@ -114,7 +114,7 @@ async function rawExplain(
   let stale = false;
   const sourceUri = node.provenance?.source_uri ?? node.provenance?.sourceUri;
   if (sourceUri) {
-    try { stale = await isFileStale(client, sourceUri); } catch {}
+    try { stale = isFileStale(sourceUri); } catch {}
   }
 
   // Extract snippet fields from attrs

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -10,7 +10,7 @@ import { ParsePool } from './parse-pool.js';
 import chalk from 'chalk';
 import { IxClient } from '../../client/api.js';
 import type { GraphPatchPayload } from '../../client/types.js';
-import { getEndpoint, resolveWorkspaceRoot, ingestMtimeCachePath } from '../config.js';
+import { getEndpoint, resolveWorkspaceRoot, ingestMtimeCachePath, loadIngestMtimeCache } from '../config.js';
 import { resolveGitHubToken } from '../github/auth.js';
 import { parseGitHubRepo, fetchGitHubData } from '../github/fetch.js';
 import { loadIngestionModules } from './ingestion-loader.js';
@@ -309,17 +309,10 @@ interface MtimeCache {
   files: Record<string, number>; // absolute path → mtime (ms)
 }
 
-function loadMtimeCache(projectRoot: string): Map<string, number> {
-  try {
-    const raw = fs.readFileSync(ingestMtimeCachePath(projectRoot), 'utf-8');
-    const data = JSON.parse(raw) as MtimeCache;
-    if (data.root !== projectRoot) return new Map();
-    return new Map(Object.entries(data.files));
-  } catch {
-    return new Map();
-  }
-}
-
+// The loader moved to config.ts, beside the path helper, because `ix status`
+// now reads the same record: it decides staleness with the exact test this file
+// uses to decide what to re-ingest, so the two commands cannot disagree about
+// whether a given file is stale.
 function saveMtimeCache(projectRoot: string, mtimes: Map<string, number>): void {
   try {
     const dir = nodePath.join(os.homedir(), '.ix');
@@ -806,7 +799,7 @@ export async function ingestFiles(
     const projectRoot = fs.statSync(resolvedPath).isDirectory() ? resolvedPath : nodePath.dirname(resolvedPath);
     // A just-migrated workspace (new path-based id) has no nodes under the new id, so
     // skip the mtime pre-filter and re-ingest everything, exactly like --force.
-    const mtimeCache  = (opts.force || workspaceMigrated) ? new Map<string, number>() : loadMtimeCache(projectRoot);
+    const mtimeCache  = (opts.force || workspaceMigrated) ? new Map<string, number>() : loadIngestMtimeCache(projectRoot);
     const currentMtimes = new Map<string, number>();
 
     // DB-reset guard: if the mtime cache has entries but the server returns no hashes

--- a/ix-cli/src/cli/commands/locate.ts
+++ b/ix-cli/src/cli/commands/locate.ts
@@ -95,7 +95,7 @@ export function registerLocateCommand(program: Command): void {
       // Check staleness
       let stale = false;
       if (nodePath) {
-        try { stale = await isFileStale(client, nodePath); } catch {}
+        try { stale = isFileStale(nodePath); } catch {}
       }
 
       // Container context (parent for callables)

--- a/ix-cli/src/cli/commands/read.ts
+++ b/ix-cli/src/cli/commands/read.ts
@@ -45,7 +45,7 @@ interface AmbiguityResult {
 }
 
 async function checkStale(client: IxClient, filePath: string): Promise<boolean> {
-  try { return await isFileStale(client, filePath); } catch { return false; }
+  try { return isFileStale(filePath); } catch { return false; }
 }
 
 function readFileRange(filePath: string, start?: number, end?: number): { content: string; lineStart: number; lineEnd: number } {

--- a/ix-cli/src/cli/config.ts
+++ b/ix-cli/src/cli/config.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync, rmSync, chmodSync, renameSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, rmSync, chmodSync, renameSync, statSync } from "node:fs";
 import { join, resolve as resolvePath } from "node:path";
 import { homedir } from "node:os";
 import { createHash } from "node:crypto";
@@ -19,6 +19,49 @@ export function ingestMtimeCachePath(projectRoot: string): string {
 /** Remove the ingest mtime cache so the next map re-ingests every file. Best-effort. */
 export function clearIngestMtimeCache(projectRoot: string): void {
   try { rmSync(ingestMtimeCachePath(projectRoot), { force: true }); } catch { /* non-critical */ }
+}
+
+interface MtimeCache {
+  root: string;
+  files: Record<string, number>; // absolute path → mtime (ms) as of that ingest
+}
+
+/**
+ * The mtimes recorded the last time this project root was ingested, or an empty
+ * map if it never was.
+ *
+ * Lives here beside the path helper, and not privately in ingest.ts, because
+ * `ix status` reads it too: staleness has to be decided by the same record `ix
+ * map` writes, or the two commands disagree about the same file. The `root`
+ * check is what makes it workspace-scoped — a cache written for a different
+ * project is not this project's baseline even if the hash somehow collided.
+ */
+export function loadIngestMtimeCache(projectRoot: string): Map<string, number> {
+  try {
+    const raw = readFileSync(ingestMtimeCachePath(projectRoot), "utf-8");
+    const data = JSON.parse(raw) as MtimeCache;
+    if (data.root !== projectRoot) return new Map();
+    return new Map(Object.entries(data.files));
+  } catch {
+    return new Map();
+  }
+}
+
+/**
+ * When this project root was last ingested, from the cache file's own mtime, or
+ * null if it never was.
+ *
+ * The patch log cannot answer this: patches carry no workspace, so its newest
+ * entry is whatever workspace was mapped most recently anywhere on the machine.
+ * This file is written at the end of each ingest *for this root*, so its mtime
+ * is the one timestamp on the machine that means "this workspace, last ingest".
+ */
+export function lastIngestAtFor(projectRoot: string): Date | null {
+  try {
+    return statSync(ingestMtimeCachePath(projectRoot)).mtime;
+  } catch {
+    return null;
+  }
 }
 
 export interface WorkspaceConfig {

--- a/ix-cli/src/cli/explain/facts.ts
+++ b/ix-cli/src/cli/explain/facts.ts
@@ -179,7 +179,7 @@ export async function collectFacts(
   let stale = false;
   if (path) {
     try {
-      stale = await isFileStale(client, path);
+      stale = isFileStale(path);
     } catch {
       /* ignore */
     }

--- a/ix-cli/src/cli/stale.ts
+++ b/ix-cli/src/cli/stale.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { IxClient } from "../client/api.js";
 import { SUPPORTED_EXTENSIONS } from "./supported-extensions.js";
+import { lastIngestAtFor, loadIngestMtimeCache, resolveWorkspaceRoot } from "./config.js";
 
 export interface StaleInfo {
   lastIngestAt: string | null;
@@ -58,45 +59,60 @@ function collectFiles(dir: string, limit: number = 5000): string[] {
 }
 
 /**
- * Detect files that have been modified since the last ingest.
- * Uses mtime comparison against the latest patch timestamp.
+ * Whether a file differs from what this workspace's last ingest recorded.
+ *
+ * Exact inequality, not "newer than": this is the same test ingest applies when
+ * deciding what to re-parse (`mtimeCache.get(path) === mtime` => skip), so
+ * status and map cannot disagree about a given file. A path absent from the
+ * baseline is new, and new is stale.
+ */
+function differsFromBaseline(filePath: string, baseline: Map<string, number>): boolean {
+  try {
+    return baseline.get(filePath) !== fs.statSync(filePath).mtimeMs;
+  } catch {
+    return false; // inaccessible: not something the user can act on
+  }
+}
+
+/**
+ * Detect files modified since this workspace was last ingested.
+ *
+ * Compares against the per-root ingest record, not the patch log. The patch log
+ * carries no workspace — a patch document has no workspace field at all — so
+ * `listPatches({limit: 1})` returns whatever workspace was mapped most recently
+ * *anywhere on the machine*. Mapping an unrelated repo therefore advanced the
+ * timestamp this compared against, and every file in the workspace you were
+ * actually asking about fell behind it and was reported current. The filesystem
+ * scan was correctly rooted the whole time; only the thing it compared to was
+ * global.
+ *
+ * `currentRev` stays global on purpose. It is the graph's revision counter,
+ * shared by every workspace, and reporting it is not the bug — reporting
+ * another workspace's *staleness* was.
  */
 export async function detectStaleFiles(
   client: IxClient,
   root: string,
   maxSamples: number = 5
 ): Promise<StaleInfo> {
-  // Get latest patch to determine last ingest time
   const patches = await client.listPatches({ limit: 1 });
-  const stats = await client.stats();
+  const currentRev = patches[0]?.rev ?? 0;
 
-  const lastPatch = patches[0];
-  const lastIngestAt = lastPatch?.timestamp ?? null;
-  const currentRev = lastPatch?.rev ?? 0;
-
-  if (!lastIngestAt) {
-    return { lastIngestAt: null, currentRev: 0, staleFiles: 0, sampleChangedFiles: [] };
+  const lastIngest = lastIngestAtFor(root);
+  if (!lastIngest) {
+    // This root has no ingest record, so there is no baseline to be stale
+    // against. Saying "0 changed" matches what the old code did with an empty
+    // patch log, and beats inventing a number from a baseline that is not ours.
+    return { lastIngestAt: null, currentRev, staleFiles: 0, sampleChangedFiles: [] };
   }
 
-  const lastIngestTime = new Date(lastIngestAt).getTime();
-  const files = collectFiles(root);
-  const changedFiles: string[] = [];
-
-  for (const filePath of files) {
-    try {
-      const stat = fs.statSync(filePath);
-      if (stat.mtimeMs > lastIngestTime) {
-        // Make path relative to root for display
-        const relative = path.relative(root, filePath);
-        changedFiles.push(relative);
-      }
-    } catch {
-      // skip inaccessible files
-    }
-  }
+  const baseline = loadIngestMtimeCache(root);
+  const changedFiles = collectFiles(root)
+    .filter((filePath) => differsFromBaseline(filePath, baseline))
+    .map((filePath) => path.relative(root, filePath));
 
   return {
-    lastIngestAt,
+    lastIngestAt: lastIngest.toISOString(),
     currentRev,
     staleFiles: changedFiles.length,
     sampleChangedFiles: changedFiles.slice(0, maxSamples),
@@ -104,23 +120,18 @@ export async function detectStaleFiles(
 }
 
 /**
- * Check if a specific file path is stale (modified since last ingest).
+ * Check if a specific file is stale (changed since its workspace was ingested).
+ *
+ * Takes no client: it used to fetch the newest patch on every call, which was
+ * both an HTTP round-trip per file on paths like `ix explain` and `ix locate`,
+ * and the same cross-workspace comparison as above.
  */
-export async function isFileStale(
-  client: IxClient,
-  filePath: string
-): Promise<boolean> {
-  if (!fs.existsSync(filePath)) return false;
+export function isFileStale(filePath: string): boolean {
+  const absolute = path.resolve(filePath);
+  if (!fs.existsSync(absolute)) return false;
 
-  const patches = await client.listPatches({ limit: 1 });
-  const lastPatch = patches[0];
-  if (!lastPatch?.timestamp) return false;
+  const root = resolveWorkspaceRoot();
+  if (!lastIngestAtFor(root)) return false;
 
-  const lastIngestTime = new Date(lastPatch.timestamp).getTime();
-  try {
-    const stat = fs.statSync(filePath);
-    return stat.mtimeMs > lastIngestTime;
-  } catch {
-    return false;
-  }
+  return differsFromBaseline(absolute, loadIngestMtimeCache(root));
 }


### PR DESCRIPTION
Fixes #353.

## The problem

`ix status --root <workspace>` scans the right directory, then compares every file against the newest patch in the **entire backend**. Mapping an unrelated repo advances that timestamp, so a genuinely modified file in the first workspace falls behind it and is reported up to date — `staleFiles` goes 1 → 0 with nothing in that workspace having changed.

## Why the suggested fix isn't available

The issue proposes passing a workspace to `listPatches`. That isn't possible today, and it's worth recording why, because it looks like a one-line change:

- `GET /v1/patches` accepts **only** `limit` (`PatchRoutes.scala:31`). Verified against a live backend: a real workspace id, a nonsense one, and none at all return byte-identical results, and the `X-Ix-Workspace` header the Compass proxy uses is ignored on this route too.
- More fundamentally, **a patch document has no workspace field at all** — not omitted from the query, absent from the schema. I dumped one from a live backend to check.

So scoping the patch log would mean writing the field at commit time, a backend release, and a decision about the existing patches that would still have no workspace. That's a backend change in another repo. This is fixable in the CLI without any of it.

## The fix

The per-root ingest mtime cache is already exactly the missing record: written at the end of each ingest *for that root*, keyed on the root, holding every file's mtime as of that ingest.

Staleness now comes from it, using **the same test ingest applies** when deciding what to re-parse — exact mtime inequality, absent-means-new. So `ix status` and `ix map` can no longer disagree about whether a given file is stale, which they previously could in both directions.

`lastIngestAt` becomes that cache file's own mtime — the one timestamp on the machine that means "this workspace, last ingest".

`currentRev` **stays global on purpose.** It's the graph's revision counter, shared by every workspace. Reporting it was never the bug; reporting another workspace's staleness was. Worth flagging since the issue mentions the revision too.

## Two things that came with it

- **`isFileStale` had the same defect**, and is used by `explain`, `locate`, `read` and `facts`. It no longer takes a client at all — it was doing an HTTP fetch of the newest patch on *every call, once per file*, to run the same cross-workspace comparison.
- **The cache loader moved to `config.ts`**, beside the path helper whose comment already says all consumers must agree on it. One implementation instead of a private copy in `ingest.ts` plus a second reading of the same file elsewhere.

## Verification

Tests reproduce the issue's exact sequence — map A, modify, map B, re-check A — and I ran them against the previous implementation to confirm they catch the bug rather than merely describing it:

| | old | new |
|---|---|---|
| stays stale after an unrelated workspace is mapped | ✗ | ✓ |
| lastIngestAt comes from this workspace | ✗ | ✓ |
| root with no ingest record | ✗ | ✓ |
| file added since ingest | ✗ | ✓ |
| modified file is stale | ✓ | ✓ |

The fake client stubs `stats()` purely so it can run against the old code, which called it and discarded the result — otherwise every case would fail on a missing method rather than on the behaviour under test.

630 tests pass, `tsc --noEmit` clean, no new lint warnings.