### PR TITLE
fix(view): say when -p was not honoured, and show the URL in status

### DIFF
--- a/ix-cli/src/cli/__tests__/view-running-port.test.ts
+++ b/ix-cli/src/cli/__tests__/view-running-port.test.ts
@@ -180,11 +180,18 @@ describe("view running port state", () => {
     expect(await runView(["status"])).toContain("http://localhost:19123");
   });
 
-  it("omits the URL from status when the port is unknown", async () => {
+  it("says the port is unknown from status instead of printing nothing", async () => {
     seedRunningState();
     vi.spyOn(process, "kill").mockReturnValue(true);
 
-    expect(await runView(["status"])).not.toContain("http://localhost");
+    const output = await runView(["status"]);
+
+    // Still no guessed URL — that is the bug #358 removed. But silence left
+    // someone who ran status *for* the URL with nothing to act on, while
+    // `ix view` in the identical state told them how to recover.
+    expect(output).not.toContain("http://localhost");
+    expect(output).toContain("unknown");
+    expect(output).toContain("ix view stop");
   });
 });
 

--- a/ix-cli/src/cli/__tests__/view-running-port.test.ts
+++ b/ix-cli/src/cli/__tests__/view-running-port.test.ts
@@ -150,4 +150,65 @@ describe("view running port state", () => {
     expect(existsSync(scopeFile())).toBe(false);
     expect(existsSync(portFile())).toBe(false);
   });
+
+  it("says the requested port was not honoured", async () => {
+    seedRunningState(19123);
+    vi.spyOn(process, "kill").mockReturnValue(true);
+
+    const output = await runView(["-p", "19124", "start", "--no-open", "--all"]);
+
+    // Printing only the correct URL leaves the user believing -p moved the
+    // server. It did not, and the difference is one digit.
+    expect(output).toContain("You asked for port 19124");
+    expect(output).toContain("it is serving on 19123");
+  });
+
+  it("stays quiet when no port was asked for", async () => {
+    seedRunningState(19123);
+    vi.spyOn(process, "kill").mockReturnValue(true);
+
+    const output = await runView(["start", "--no-open", "--all"]);
+
+    expect(output).toContain("http://localhost:19123");
+    expect(output).not.toContain("You asked for port");
+  });
+
+  it("reports the URL from status", async () => {
+    seedRunningState(19123);
+    vi.spyOn(process, "kill").mockReturnValue(true);
+
+    expect(await runView(["status"])).toContain("http://localhost:19123");
+  });
+
+  it("omits the URL from status when the port is unknown", async () => {
+    seedRunningState();
+    vi.spyOn(process, "kill").mockReturnValue(true);
+
+    expect(await runView(["status"])).not.toContain("http://localhost");
+  });
+});
+
+describe("runningInstanceLines", () => {
+  it("never builds a URL from the requested port", async () => {
+    const { runningInstanceLines } = await import("../commands/view.js");
+    const lines = runningInstanceLines(19123, 19124, true);
+
+    expect(lines[0]).toBe("  http://localhost:19123");
+    expect(lines.some(l => l.includes("http://localhost:19124"))).toBe(false);
+  });
+
+  it("does not warn when the running port is the one that was asked for", async () => {
+    const { runningInstanceLines } = await import("../commands/view.js");
+    expect(runningInstanceLines(8080, 8080, true)).toEqual(["  http://localhost:8080"]);
+  });
+
+  it("admits it does not know rather than guessing", async () => {
+    const { runningInstanceLines } = await import("../commands/view.js");
+    const lines = runningInstanceLines(null, 8080, true);
+
+    // A confidently wrong URL is the bug #358 removed; do not reintroduce it
+    // through the warning path.
+    expect(lines.some(l => l.includes("http://localhost"))).toBe(false);
+    expect(lines.join("\n")).toContain("unknown");
+  });
 });

--- a/ix-cli/src/cli/commands/view.ts
+++ b/ix-cli/src/cli/commands/view.ts
@@ -430,11 +430,15 @@ export function registerViewCommand(program: Command): void {
       if (pid) {
         console.log(`[ok] Visualizer is running (PID ${pid})`);
         // Now that the port is recorded, status can answer the question people
-        // actually run it to answer. Silent rather than guessing for an instance
-        // started before the port file existed and with no server script to
-        // recover it from.
-        const runningPort = readRunningPort();
-        if (runningPort !== null) console.log(`  http://localhost:${runningPort}`);
+        // actually run it to answer. Shares runningInstanceLines with the
+        // already-running branch above so the two cannot drift: an instance
+        // started before the port file existed still has no port to report, and
+        // saying so beats printing nothing to someone who ran status *for* the
+        // URL. Never guessed either way — a confidently wrong URL is #358.
+        // `status` takes no -p, so the mismatch branch cannot fire here.
+        for (const line of runningInstanceLines(readRunningPort(), 0, false)) {
+          console.log(line);
+        }
       } else {
         console.log("[--] Visualizer is not running.");
         console.log("  Run 'ix view' to start it.");

--- a/ix-cli/src/cli/commands/view.ts
+++ b/ix-cli/src/cli/commands/view.ts
@@ -76,6 +76,38 @@ function readRunningPort(): number | null {
   }
 }
 
+/**
+ * What to print under "already running", given where it is actually serving.
+ *
+ * #358 made this branch report the running port instead of echoing back the one
+ * just requested, which fixed the unreachable URL. It stayed silent about the
+ * request itself though, so `ix view -p 19124` against a server on 19123 prints
+ * a correct URL for a port you did not ask for and never says the flag was
+ * ignored — you find out by noticing the number changed.
+ *
+ * Pure, because the decision is all this is, and inline in a command action it
+ * could only be exercised by launching a detached server.
+ */
+export function runningInstanceLines(
+  runningPort: number | null,
+  requestedPort: number,
+  portWasRequested: boolean,
+): string[] {
+  if (runningPort === null) {
+    return [
+      "[!] The running visualizer's port is unknown.",
+      "    Run 'ix view stop' then 'ix view' to restart it.",
+    ];
+  }
+
+  const lines = [`  http://localhost:${runningPort}`];
+  if (portWasRequested && runningPort !== requestedPort) {
+    lines.push(`[!] You asked for port ${requestedPort}, but it is serving on ${runningPort}.`);
+    lines.push(`    Run 'ix view stop' then 'ix view -p ${requestedPort}' to move it.`);
+  }
+  return lines;
+}
+
 /** Read PID from file and check if the process is alive. */
 function readAlivePid(): number | null {
   if (!existsSync(PID_FILE)) {
@@ -241,6 +273,11 @@ export function registerViewCommand(program: Command): void {
         console.error("[error] Invalid port number.");
         process.exit(1);
       }
+      // Whether -p was typed, not whether it differs from 8080. Comparing against
+      // the default instead would stay silent for someone who explicitly passed
+      // `-p 8080` to a server running elsewhere — the exact case they typed the
+      // flag to find out about — and would nag anyone who typed nothing.
+      const portWasRequested = view.getOptionValueSource("port") === "cli";
 
       // Resolve the workspace this visualizer is scoped to. The proxy stamps it as
       // X-Ix-Workspace on every /v1 call so Compass isolates by workspace without any
@@ -286,12 +323,8 @@ export function registerViewCommand(program: Command): void {
       const existing = readAlivePid();
       if (existing) {
         console.log(`[ok] Visualizer is already running (PID ${existing})`);
-        const runningPort = readRunningPort();
-        if (runningPort !== null) {
-          console.log(`  http://localhost:${runningPort}`);
-        } else {
-          console.log("[!] The running visualizer's port is unknown.");
-          console.log("    Run 'ix view stop' then 'ix view' to restart it.");
+        for (const line of runningInstanceLines(readRunningPort(), port, portWasRequested)) {
+          console.log(line);
         }
         // The running instance has a fixed scope (baked at launch). If this directory
         // maps to a different workspace, say so rather than silently showing the old one.
@@ -396,6 +429,12 @@ export function registerViewCommand(program: Command): void {
       const pid = readAlivePid();
       if (pid) {
         console.log(`[ok] Visualizer is running (PID ${pid})`);
+        // Now that the port is recorded, status can answer the question people
+        // actually run it to answer. Silent rather than guessing for an instance
+        // started before the port file existed and with no server script to
+        // recover it from.
+        const runningPort = readRunningPort();
+        if (runningPort !== null) console.log(`  http://localhost:${runningPort}`);
       } else {
         console.log("[--] Visualizer is not running.");
         console.log("  Run 'ix view' to start it.");


### PR DESCRIPTION
Follow-up to #358 (thanks @Hiro-Chiba), picking up the two pieces I flagged when closing #360.

## `-p` is still silently ignored

#358 fixed the real bug — the already-running branch printed an unreachable URL built from the port just requested. It reports the running port now, but says nothing about the request:

```
$ ix view -p 19124 start
[ok] Visualizer is already running (PID 65764)
  http://localhost:19123
```

The URL is right. But you asked for 19124, got 19123, and nothing said so — you find out by noticing the number changed. Now:

```
[ok] Visualizer is already running (PID 65764)
  http://localhost:19123
[!] You asked for port 19124, but it is serving on 19123.
    Run 'ix view stop' then 'ix view -p 19124' to move it.
```

Keyed on whether `-p` was **typed** (`getOptionValueSource("port") === "cli"`), not on whether it differs from 8080. Comparing against the default would stay silent for someone who explicitly passed `-p 8080` to a server running elsewhere — exactly the case they typed the flag to find out about — and would nag anyone who typed nothing.

## `status` can answer its own question now

The port is recorded as of #358, so:

```
$ ix view status
[ok] Visualizer is running (PID 65764)
  http://localhost:19123
```

Silent rather than guessing for an instance old enough to have neither a port file nor a server script to recover one from — a confidently wrong URL is what #358 removed and this must not reintroduce it through the warning path.

## Tests

Extends #358's `view-running-port.test.ts` rather than adding a competing file: five more cases through their `runView` harness (mismatch warns, no-flag stays quiet, status shows the URL, status stays silent when unknown), plus three unit cases on the extracted `runningInstanceLines`.

Full suite green — 647 tests, `tsc --noEmit` clean, `eslint src` clean.