### PR TITLE
refactor(stale): drop the client the staleness checks no longer use

### DIFF
--- a/ix-cli/src/cli/__tests__/stale-workspace.test.ts
+++ b/ix-cli/src/cli/__tests__/stale-workspace.test.ts
@@ -3,7 +3,6 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import type { IxClient } from "../../client/api.js";
 import { ingestMtimeCachePath } from "../config.js";
 import { loadIngestBaseline } from "../ingest-baseline.js";
 import { persistIngestBaselineIfClean } from "../commands/ingest.js";
@@ -12,15 +11,6 @@ import { detectStaleFiles } from "../stale.js";
 let home: string;
 let savedHome: string | undefined;
 let savedProfile: string | undefined;
-
-const noPatchReads = {
-  listPatches: async () => {
-    throw new Error("global patches must not be read");
-  },
-  stats: async () => {
-    throw new Error("global stats must not be read");
-  },
-} as unknown as IxClient;
 
 function writeSource(root: string, name: string, source: string): string {
   fs.mkdirSync(root, { recursive: true });
@@ -69,7 +59,7 @@ describe("workspace-scoped staleness", () => {
     ).toBe(true);
 
     moveMtimeForward(fileA);
-    const beforeB = await detectStaleFiles(noPatchReads, rootA);
+    const beforeB = detectStaleFiles(rootA);
     expect(beforeB).toEqual({
       lastIngestAt: ingestedA.toISOString(),
       currentRev: 11,
@@ -88,7 +78,7 @@ describe("workspace-scoped staleness", () => {
       ),
     ).toBe(true);
 
-    expect(await detectStaleFiles(noPatchReads, rootA)).toEqual(beforeB);
+    expect(detectStaleFiles(rootA)).toEqual(beforeB);
   });
 
   it("loads the legacy mtime-only cache and uses its own file timestamp", async () => {
@@ -108,7 +98,7 @@ describe("workspace-scoped staleness", () => {
     fs.utimesSync(cachePath, legacyTimestamp, legacyTimestamp);
     moveMtimeForward(filePath);
 
-    const result = await detectStaleFiles(noPatchReads, root);
+    const result = detectStaleFiles(root);
     expect(result.currentRev).toBe(0);
     expect(result.lastIngestAt).toBe(fs.statSync(cachePath).mtime.toISOString());
     expect(result.staleFiles).toBe(1);
@@ -119,7 +109,7 @@ describe("workspace-scoped staleness", () => {
     const root = path.join(home, "unmapped");
     writeSource(root, "new.js", "export const value = 1;\n");
 
-    expect(await detectStaleFiles(noPatchReads, root)).toEqual({
+    expect(detectStaleFiles(root)).toEqual({
       lastIngestAt: null,
       currentRev: 0,
       staleFiles: 0,
@@ -146,14 +136,14 @@ describe("workspace-scoped staleness", () => {
       ingestedAt,
     );
 
-    expect((await detectStaleFiles(noPatchReads, root)).staleFiles).toBe(0);
+    expect((detectStaleFiles(root)).staleFiles).toBe(0);
 
     fs.utimesSync(
       uncachedFile,
       new Date(ingestedAt.getTime() + 1_000),
       new Date(ingestedAt.getTime() + 1_000),
     );
-    expect(await detectStaleFiles(noPatchReads, root)).toMatchObject({
+    expect(detectStaleFiles(root)).toMatchObject({
       staleFiles: 1,
       sampleChangedFiles: ["uncached.js"],
     });
@@ -185,6 +175,6 @@ describe("workspace-scoped staleness", () => {
     expect(baseline?.currentRev).toBe(7);
     expect(baseline?.lastIngestAt).toBe(oldTimestamp.toISOString());
     expect(baseline?.files.get(filePath)).toBe(oldMtime);
-    expect((await detectStaleFiles(noPatchReads, root)).staleFiles).toBe(1);
+    expect((detectStaleFiles(root)).staleFiles).toBe(1);
   });
 });

--- a/ix-cli/src/cli/commands/explain.ts
+++ b/ix-cli/src/cli/commands/explain.ts
@@ -114,7 +114,7 @@ async function rawExplain(
   let stale = false;
   const sourceUri = node.provenance?.source_uri ?? node.provenance?.sourceUri;
   if (sourceUri) {
-    try { stale = await isFileStale(client, sourceUri); } catch {}
+    try { stale = isFileStale(sourceUri); } catch {}
   }
 
   // Extract snippet fields from attrs

--- a/ix-cli/src/cli/commands/locate.ts
+++ b/ix-cli/src/cli/commands/locate.ts
@@ -95,7 +95,7 @@ export function registerLocateCommand(program: Command): void {
       // Check staleness
       let stale = false;
       if (nodePath) {
-        try { stale = await isFileStale(client, nodePath); } catch {}
+        try { stale = isFileStale(nodePath); } catch {}
       }
 
       // Container context (parent for callables)

--- a/ix-cli/src/cli/commands/read.ts
+++ b/ix-cli/src/cli/commands/read.ts
@@ -44,8 +44,8 @@ interface AmbiguityResult {
   diagnostics?: Array<{ code: string; message: string }>;
 }
 
-async function checkStale(client: IxClient, filePath: string): Promise<boolean> {
-  try { return await isFileStale(client, filePath); } catch { return false; }
+function checkStale(filePath: string): boolean {
+  try { return isFileStale(filePath); } catch { return false; }
 }
 
 function readFileRange(filePath: string, start?: number, end?: number): { content: string; lineStart: number; lineEnd: number } {
@@ -130,7 +130,7 @@ Examples:
       // --- Step 2: Try exact file path ---
       const resolvedPath = path.isAbsolute(rawTarget) ? rawTarget : path.resolve(root, rawTarget);
       if (fs.existsSync(resolvedPath) && fs.statSync(resolvedPath).isFile()) {
-        const stale = await checkStale(client, resolvedPath);
+        const stale = checkStale(resolvedPath);
         const { content, lineStart, lineEnd } = readFileRange(resolvedPath, rangeStart, rangeEnd);
         const result: ReadResult = {
           targetType: lineRangeMatch ? "file-range" : "file",
@@ -152,7 +152,7 @@ Examples:
         if (filenameMatches.length === 1) {
           const matchPath = filenameMatches[0].path;
           if (matchPath && fs.existsSync(matchPath)) {
-            const stale = await checkStale(client, matchPath);
+            const stale = checkStale(matchPath);
             const { content, lineStart, lineEnd } = readFileRange(matchPath, rangeStart, rangeEnd);
             const result: ReadResult = {
               targetType: "filename-match",
@@ -185,7 +185,7 @@ Examples:
         // client-agnostic backend. Resolve it against the active workspace
         // root before any fs call.
         const absSourceUri = sourceUri ? absoluteFromSourceUri(sourceUri, opts.root) : null;
-        const stale = absSourceUri ? await checkStale(client, absSourceUri) : false;
+        const stale = absSourceUri ? checkStale(absSourceUri) : false;
 
         // If the source file exists, extract the symbol's lines
         if (absSourceUri && fs.existsSync(absSourceUri)) {

--- a/ix-cli/src/cli/commands/status.ts
+++ b/ix-cli/src/cli/commands/status.ts
@@ -19,7 +19,7 @@ export function registerStatusCommand(program: Command): void {
         // Detect stale files
         let staleInfo;
         try {
-          staleInfo = await detectStaleFiles(client, root);
+          staleInfo = detectStaleFiles(root);
         } catch {
           staleInfo = null;
         }

--- a/ix-cli/src/cli/explain/facts.ts
+++ b/ix-cli/src/cli/explain/facts.ts
@@ -179,7 +179,7 @@ export async function collectFacts(
   let stale = false;
   if (path) {
     try {
-      stale = await isFileStale(client, path);
+      stale = isFileStale(path);
     } catch {
       /* ignore */
     }

--- a/ix-cli/src/cli/stale.ts
+++ b/ix-cli/src/cli/stale.ts
@@ -1,6 +1,5 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { IxClient } from "../client/api.js";
 import { resolveWorkspaceRoot } from "./config.js";
 import { loadIngestBaseline } from "./ingest-baseline.js";
 import { SUPPORTED_EXTENSIONS } from "./supported-extensions.js";
@@ -74,12 +73,19 @@ function differsFromIngestBaseline(
 /**
  * Detect files that have been modified since the last ingest.
  * Uses the workspace-local ingest baseline so another workspace cannot advance it.
+ *
+ * Takes no client and is not async, by construction rather than by discipline.
+ * Staleness used to be decided from `listPatches({ limit: 1 })`, which carries
+ * no workspace, so it answered with whatever repo was mapped most recently
+ * anywhere on the machine (#353). Keeping an unused client parameter around
+ * left the door open to reaching for it again; without one there is nothing to
+ * reach for, and the local-only property holds because it is the only thing the
+ * signature permits.
  */
-export async function detectStaleFiles(
-  _client: IxClient,
+export function detectStaleFiles(
   root: string,
   maxSamples: number = 5
-): Promise<StaleInfo> {
+): StaleInfo {
   const workspaceRoot = path.resolve(root);
   const baseline = loadIngestBaseline(workspaceRoot);
   if (!baseline) {
@@ -114,11 +120,12 @@ export async function detectStaleFiles(
 
 /**
  * Check if a specific file path differs from the active workspace's ingest baseline.
+ *
+ * Synchronous now that it reads a local file instead of the patch log. It is
+ * called per result on `ix explain`, `ix locate` and `ix read`, so the `await`
+ * this used to need was once a backend round-trip per file.
  */
-export async function isFileStale(
-  _client: IxClient,
-  filePath: string
-): Promise<boolean> {
+export function isFileStale(filePath: string): boolean {
   if (!fs.existsSync(filePath)) return false;
 
   const workspaceRoot = path.resolve(resolveWorkspaceRoot());


### PR DESCRIPTION
Follow-up to #356 (thanks @Hiro-Chiba). **Not a bug fix — I said in review that `isFileStale` still had the cross-workspace bug, and I was wrong. #356 fixed both functions.** This is the cleanup that fix left behind.

`detectStaleFiles` and `isFileStale` both still take an `IxClient` and ignore it (`_client`), and both are still `async` despite no longer doing any I/O.

## Why bother

#356 fixed #353 by moving staleness onto the workspace-local ingest baseline — `listPatches({ limit: 1 })` carries no workspace, so it answered with whatever repo was mapped most recently anywhere on the machine.

Keeping an unused client parameter leaves the door open to reaching for it again. Removing it makes the fix **structural rather than a matter of discipline**: there is no client in scope, so the local-only property holds because it is the only thing the signature permits.

That's the same argument the PR's own test made by injecting a client whose `listPatches`/`stats` throw. That stub goes away here — a parameter that doesn't exist can't be called, which is a stronger guarantee than one that throws when it is.

## Also drops the fake async

Both read a local file now. `isFileStale` runs **per result** on `ix explain`, `ix locate` and `ix read`, so the `await` it used to need was a backend round-trip per file. Those call sites lose the `await` with it — `read.ts`'s `checkStale` wrapper included.

Six call sites updated: `status.ts`, `read.ts` (×3), `explain.ts`, `locate.ts`, `explain/facts.ts`.

## Verification

`tsc --noEmit` clean, `eslint src` clean, full suite green (640 tests). No behaviour change — the staleness logic itself is untouched.