### PR TITLE
fix(release): stamp the bundled compass with the release it ships in

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,6 +264,8 @@ jobs:
             node -e "const c=require('crypto'),f=require('fs'),p=process.argv[1];process.stdout.write(c.createHash('sha256').update(f.readFileSync(p)).digest('hex')+'  '+p+'\n')" "$1"
           }
           COMPASS_STAGED=0
+          ARCHIVE_LIST="$(mktemp)"
+          trap 'rm -f "$ARCHIVE_LIST"' EXIT
           mkdir -p "$STAGING/cli" "$STAGING/core-ingestion" "$STAGING/compass"
           cp -rL ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
           cp -rL core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
@@ -312,7 +314,14 @@ jobs:
             # Verify the stamp survived archiving rather than trusting the tool
             # to carry a dot-named file. If it is ever dropped, every upgrade
             # silently reverts the compass — a failure with no error to notice.
-            if [ "$COMPASS_STAGED" = "1" ] && ! 7z l "$STAGING.zip" | grep -q '\.version'; then
+            #
+            # Listed to a file rather than piped into `grep -q`: this shell runs
+            # with `pipefail`, and grep -q exits at the first match, so the
+            # lister gets SIGPIPE and the pipeline reports *its* failure. That
+            # turns the check into a race the archiver usually wins and
+            # sometimes does not — it failed exactly once across four platforms.
+            7z l "$STAGING.zip" > "$ARCHIVE_LIST"
+            if [ "$COMPASS_STAGED" = "1" ] && ! grep -q '\.version' "$ARCHIVE_LIST"; then
               echo "::error::compass/.version is missing from $STAGING.zip — 7z dropped the dot-named stamp, which makes every 'ix upgrade' replace the bundled compass with an older one."
               exit 1
             fi
@@ -325,7 +334,11 @@ jobs:
           WRAPPER
             chmod +x "$STAGING/ix"
             tar -czf "$STAGING.tar.gz" "$STAGING"
-            if [ "$COMPASS_STAGED" = "1" ] && ! tar -tzf "$STAGING.tar.gz" | grep -q 'compass/\.version'; then
+            # See the note on the zip branch: listed to a file, not piped into
+            # `grep -q`, because pipefail turns the lister's SIGPIPE into a
+            # spurious failure of this check.
+            tar -tzf "$STAGING.tar.gz" > "$ARCHIVE_LIST"
+            if [ "$COMPASS_STAGED" = "1" ] && ! grep -q 'compass/\.version' "$ARCHIVE_LIST"; then
               echo "::error::compass/.version is missing from $STAGING.tar.gz — without it every 'ix upgrade' replaces the bundled compass with an older one."
               exit 1
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,12 +263,37 @@ jobs:
           sha256file() {
             node -e "const c=require('crypto'),f=require('fs'),p=process.argv[1];process.stdout.write(c.createHash('sha256').update(f.readFileSync(p)).digest('hex')+'  '+p+'\n')" "$1"
           }
+          COMPASS_STAGED=0
           mkdir -p "$STAGING/cli" "$STAGING/core-ingestion" "$STAGING/compass"
           cp -rL ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
           cp -rL core-ingestion/dist core-ingestion/node_modules core-ingestion/package.json "$STAGING/core-ingestion/"
           if [ -f compass-dist/index.html ]; then
             cp -r compass-dist/* "$STAGING/compass/"
-            echo "compass: $(find "$STAGING/compass" -type f | wc -l) files staged"
+            # Stamp the bundle with the release it ships in, so it declares its
+            # own provenance instead of relying on whoever unpacks it to guess.
+            #
+            # Without this the bundled compass is unversioned, so
+            # getInstalledCompassVersion() reads 0.0.0 and `ix upgrade` treats a
+            # compass it just shipped as "not installed" — then replaces it with
+            # whatever ix-compass-dist has, which is older than the bundle built
+            # from compass main at release time. v0.9.0 shipped exactly that: on
+            # Windows an unrelated tar failure masked it, and everywhere else the
+            # swap succeeded and silently reverted the map to a June build.
+            #
+            # The Ix version rather than a compass version: the bundle is built
+            # from compass main at release time, so it is always at least as new
+            # as any ix-compass-dist release cut before it. That makes the Ix
+            # version a monotonic stand-in, and isNewer() still offers a genuine
+            # dist upgrade published later at a higher number.
+            #
+            # install.sh writes this same file after extracting, using the dist
+            # release number. Either value suppresses the spurious update; the
+            # stamp being present at all is what matters.
+            printf '%s' "$VERSION" > "$STAGING/compass/.version"
+            test -s "$STAGING/compass/.version" \
+              || { echo "::error::failed to stamp $STAGING/compass/.version"; exit 1; }
+            COMPASS_STAGED=1
+            echo "compass: $(find "$STAGING/compass" -type f | wc -l) files staged, stamped $VERSION"
           elif [ "$REQUIRE_COMPASS" = "true" ]; then
             # v0.7.0 through v0.8.1 all shipped an empty compass/ because this
             # was a silent no-op. `ix view` then fails for every user with
@@ -284,6 +309,13 @@ jobs:
           node "%~dp0cli\dist\cli\main.js" %*
           WRAPPER
             7z a -tzip "$STAGING.zip" "$STAGING" >/dev/null
+            # Verify the stamp survived archiving rather than trusting the tool
+            # to carry a dot-named file. If it is ever dropped, every upgrade
+            # silently reverts the compass — a failure with no error to notice.
+            if [ "$COMPASS_STAGED" = "1" ] && ! 7z l "$STAGING.zip" | grep -q '\.version'; then
+              echo "::error::compass/.version is missing from $STAGING.zip — 7z dropped the dot-named stamp, which makes every 'ix upgrade' replace the bundled compass with an older one."
+              exit 1
+            fi
             sha256file "$STAGING.zip" > "$STAGING.zip.sha256"
           else
             cat > "$STAGING/ix" <<'WRAPPER'
@@ -293,6 +325,10 @@ jobs:
           WRAPPER
             chmod +x "$STAGING/ix"
             tar -czf "$STAGING.tar.gz" "$STAGING"
+            if [ "$COMPASS_STAGED" = "1" ] && ! tar -tzf "$STAGING.tar.gz" | grep -q 'compass/\.version'; then
+              echo "::error::compass/.version is missing from $STAGING.tar.gz — without it every 'ix upgrade' replaces the bundled compass with an older one."
+              exit 1
+            fi
             sha256file "$STAGING.tar.gz" > "$STAGING.tar.gz.sha256"
           fi
 


### PR DESCRIPTION
**This is the bug that made v0.9.0 revert its own compass.** Found while diagnosing an unrelated Windows tar failure on the GA upgrade path.

## What happens

The compass in the release tarball has no `.version` marker. So after `ix upgrade` replaces `$IX_HOME/cli/` — compass included — `getInstalledCompassVersion()` finds `index.html` but no stamp and returns `0.0.0`:

```
Compass update available: none → 0.2.0
```

`none` is a compass that was just shipped. `isNewer("0.2.0", "0.0.0")` is true, so the upgrader replaces it with `ix-compass-dist` v0.2.0 — published **2026-06-08**, two months before the fixes v0.9.0 exists to deliver. I checked that bundle: `smaller regions`, `__ix_tail__` all absent.

On Windows a separate tar failure (fixed in #366) masked it. Everywhere else the swap succeeds and the map silently reverts.

`install.sh` already writes this file after extracting, so a **fresh install was fine** — only the upgrade path lost the stamp, because the tarball it unpacks never had one.

## The fix

Stamp `compass/.version` at package time so the bundle declares its own provenance instead of relying on whoever unpacks it to guess.

The **Ix** version rather than a compass version: the bundle is built from compass `main` at release time, so it's always at least as new as any `ix-compass-dist` release cut before it. That makes the Ix version a monotonic stand-in, and a genuine dist release published later at a higher number is still offered normally. `install.sh` writes the dist number into the same file; either value suppresses the spurious update, and the stamp being present at all is what matters.

The repair path is untouched: a missing or broken bundle still has no `index.html`, still reads `0.0.0`, and still re-downloads.

## Both archives verify the stamp

`tar` and `7z` are trusted to carry a dot-named file, so both branches now check it's actually inside the artifact. Losing it produces **no error at all** — every upgrade just quietly reverts the compass — so it has to fail at packaging or not at all.

Simulated both paths locally: the stamp round-trips through `tar -czf` → `--strip-components=1` and reads back as the version, and the guard fires when the stamp is stripped from the archive.

## Note

v0.9.0 is already out with this defect. I cut [`ix-compass-dist` v0.3.0](https://github.com/ix-infrastructure/ix-compass-dist/releases/tag/v0.3.0) from compass `main` as the immediate mitigation — installed CLIs now pull the correct bundle, and anyone already reverted is repaired by upgrading again. This PR stops it recurring.