### PR TITLE
fix(upgrade): pair the tar binary with the path form it understands

### DIFF
--- a/ix-cli/src/cli/__tests__/upgrade-compass-bundle.test.ts
+++ b/ix-cli/src/cli/__tests__/upgrade-compass-bundle.test.ts
@@ -16,6 +16,8 @@ import {
   cleanupCompassSwap,
   installCompassBundle,
   sweepUpgradeOrphans,
+  systemTarPath,
+  tarAttempts,
 } from "../commands/upgrade.js";
 
 // The compass repair used to empty COMPASS_DIR and extract into the hole, so
@@ -208,5 +210,87 @@ describe("installCompassBundle", () => {
     // .cli-staging-*, and a leaked copy of the bundle stays there forever.
     expect(existsSync(staging())).toBe(false);
     expect(existsSync(backup())).toBe(false);
+  });
+});
+
+// The Windows compass extract converted its paths to Cygwin form whenever
+// `cygpath` was on the box, and then ran whatever `tar` PATH resolved to. Git
+// for Windows supplies cygpath; Windows 10 1803+ supplies System32\tar.exe. On
+// a machine with both — an ordinary Windows dev box — the rewrite happened and
+// bsdtar was handed the result:
+//
+//   tar: Error opening archive: Failed to open '/cygdrive/c/Users/...'
+//
+// The binary and the path form have to be chosen as a pair.
+describe("tarAttempts", () => {
+  const realPlatform = process.platform;
+  const setPlatform = (value: string) =>
+    Object.defineProperty(process, "platform", { value, configurable: true });
+
+  afterEach(() => setPlatform(realPlatform));
+
+  it("is a single native invocation off Windows", () => {
+    setPlatform("linux");
+    expect(tarAttempts("/tmp/c.tar.gz", "/tmp/dest")).toEqual([
+      { bin: "tar", file: "/tmp/c.tar.gz", dest: "/tmp/dest" },
+    ]);
+  });
+
+  // A box that has cygpath, which is what made the old code convert.
+  const cygpath = (p: string) =>
+    "/cygdrive/" + p[0].toLowerCase() + p.slice(2).replace(/\\/g, "/");
+
+  it("tries native Windows paths before any converted form", () => {
+    setPlatform("win32");
+    const attempts = tarAttempts("C:\\Temp\\c.tar.gz", "C:\\Users\\me\\.ix\\staging", cygpath);
+
+    // The whole bug: the only invocation used a converted path, so a tar taking
+    // native paths could never succeed. Native must come first.
+    expect(attempts[0].file).toBe("C:\\Temp\\c.tar.gz");
+    expect(attempts[0].dest).toBe("C:\\Users\\me\\.ix\\staging");
+
+    // ...and the converted form must still be offered, for a real MSYS-only box.
+    expect(attempts.some(a => a.file.startsWith("/cygdrive/"))).toBe(true);
+
+    const firstConverted = attempts.findIndex(a => a.file.startsWith("/cygdrive/"));
+    const lastNative = attempts.map(a => a.file.startsWith("/cygdrive/")).lastIndexOf(false);
+    expect(firstConverted).toBeGreaterThan(lastNative);
+  });
+
+  it("offers only native paths when there is no cygpath", () => {
+    setPlatform("win32");
+    const attempts = tarAttempts("C:\\Temp\\c.tar.gz", "C:\\dest", () => null);
+    expect(attempts.every(a => a.file === "C:\\Temp\\c.tar.gz")).toBe(true);
+  });
+
+  it("never pairs a converted path with the system tar", () => {
+    setPlatform("win32");
+    for (const attempt of tarAttempts("C:\\Temp\\c.tar.gz", "C:\\dest", cygpath)) {
+      // bsdtar cannot open a cygdrive path; pairing the two is the failure.
+      if (attempt.bin.toLowerCase().includes("system32")) {
+        expect(attempt.file.startsWith("/cygdrive/")).toBe(false);
+      }
+    }
+  });
+});
+
+describe("systemTarPath", () => {
+  it("finds bsdtar under SystemRoot", () => {
+    expect(systemTarPath({ SystemRoot: "C:\\Windows" }, () => true))
+      .toBe(join("C:\\Windows", "System32", "tar.exe"));
+  });
+
+  it("falls back to windir when SystemRoot is unset", () => {
+    expect(systemTarPath({ windir: "D:\\Win" }, () => true))
+      .toBe(join("D:\\Win", "System32", "tar.exe"));
+  });
+
+  it("is null when the binary is not there", () => {
+    // Windows before 1803. The PATH fallbacks are the only option.
+    expect(systemTarPath({ SystemRoot: "C:\\Windows" }, () => false)).toBeNull();
+  });
+
+  it("is null with no Windows root in the environment", () => {
+    expect(systemTarPath({}, () => true)).toBeNull();
   });
 });

--- a/ix-cli/src/cli/commands/upgrade.ts
+++ b/ix-cli/src/cli/commands/upgrade.ts
@@ -431,30 +431,110 @@ export function installStagedTree(
  *
  * Throws with the working compass still in place.
  */
+export interface TarAttempt {
+  bin: string;
+  file: string;
+  dest: string;
+}
+
+/**
+ * Windows' own bsdtar, or null if this box predates it.
+ *
+ * Present since Windows 10 1803. It takes native paths and is not reached
+ * through any MSYS argument rewriting, so it is the one combination on Windows
+ * that cannot be mismatched.
+ */
+export function systemTarPath(
+  env: NodeJS.ProcessEnv = process.env,
+  exists: (p: string) => boolean = existsSync
+): string | null {
+  const root = env.SystemRoot || env.windir;
+  if (!root) return null;
+  const candidate = join(root, "System32", "tar.exe");
+  return exists(candidate) ? candidate : null;
+}
+
+/**
+ * The ways to invoke tar, best first, as matched (binary, path-form) pairs.
+ *
+ * The binary and the shape of the paths handed to it have to be chosen
+ * together, and they used to be decided independently: the paths were rewritten
+ * to Cygwin form whenever `cygpath` existed, while the binary was left to
+ * whatever PATH resolved. Git for Windows supplies `cygpath`, and Windows 10
+ * 1803+ supplies System32\tar.exe, so on an ordinary Windows dev box the
+ * rewrite happened and then bsdtar — which has never heard of `/cygdrive/c` —
+ * was asked to open the result:
+ *
+ *     tar: Error opening archive: Failed to open '/cygdrive/c/Users/...'
+ *
+ * So: prefer the system tar with native paths, which is unambiguous. Fall back
+ * to PATH tar with native paths, then to PATH tar with converted paths for a
+ * genuine MSYS-only environment. Trying rather than detecting, because "which
+ * tar is this" has no reliable answer and the cost of being wrong is one failed
+ * extract into a scratch directory.
+ */
+export function cygpathToUnix(windowsPath: string): string | null {
+  try {
+    const converted = execFileSync("cygpath", ["-u", windowsPath], { encoding: "utf-8" }).trim();
+    return converted || null;
+  } catch {
+    // No cygpath: there is no MSYS tar to need the converted form either.
+    return null;
+  }
+}
+
+export function tarAttempts(
+  tarPath: string,
+  destDir: string,
+  // Injectable so the ordering can be tested off Windows, where cygpath does
+  // not exist and every attempt would otherwise collapse to the native form —
+  // hiding the very inversion this exists to prevent.
+  convert: (p: string) => string | null = cygpathToUnix
+): TarAttempt[] {
+  if (process.platform !== "win32") {
+    return [{ bin: "tar", file: tarPath, dest: destDir }];
+  }
+
+  const attempts: TarAttempt[] = [];
+  const systemTar = systemTarPath();
+  if (systemTar) attempts.push({ bin: systemTar, file: tarPath, dest: destDir });
+  attempts.push({ bin: "tar", file: tarPath, dest: destDir });
+
+  const file = convert(tarPath);
+  const dest = convert(destDir);
+  if (file && dest) attempts.push({ bin: "tar", file, dest });
+
+  return attempts;
+}
+
 export function installCompassBundle(
   tarPath: string,
   compassDir: string,
   stagingDir: string,
   backupDir: string
 ): void {
-  rmQuiet(stagingDir);
-  mkdirSync(stagingDir, { recursive: true });
-
-  let tarFile = tarPath;
-  let tarDest = stagingDir;
-  if (process.platform === "win32") {
+  let lastError: unknown = null;
+  for (const attempt of tarAttempts(tarPath, stagingDir)) {
+    // Each attempt gets a clean directory: a tar that fails partway still
+    // leaves files behind, and the index.html check below would then be
+    // answering about the wreckage of an earlier try.
+    rmQuiet(stagingDir);
+    mkdirSync(stagingDir, { recursive: true });
     try {
-      tarFile = execFileSync("cygpath", ["-u", tarPath], { encoding: "utf-8" }).trim();
-      tarDest = execFileSync("cygpath", ["-u", stagingDir], { encoding: "utf-8" }).trim();
-    } catch { /* use as-is */ }
+      execFileSync(
+        attempt.bin,
+        ["-xzf", attempt.file, "-C", attempt.dest, "--strip-components=1"],
+        // Capture stderr rather than discarding it: this is the step that failed
+        // on Windows and it left nothing behind to diagnose.
+        { stdio: ["ignore", "ignore", "pipe"] }
+      );
+      lastError = null;
+      break;
+    } catch (err) {
+      lastError = err;
+    }
   }
-  execFileSync(
-    "tar",
-    ["-xzf", tarFile, "-C", tarDest, "--strip-components=1"],
-    // Capture stderr rather than discarding it: this is the step that failed on
-    // Windows and it left nothing behind to diagnose.
-    { stdio: ["ignore", "ignore", "pipe"] }
-  );
+  if (lastError) throw lastError;
 
   // An extract that "succeeded" without producing index.html is not a compass.
   // Swapping it in would replace a working bundle with one findCompassDist


### PR DESCRIPTION
The failure seen on the v0.9.0 upgrade path on Windows:

```
[!!] Compass extract failed: Command failed: tar -xzf /cygdrive/c/Users/ianja/AppData/Local/Temp/ix-compass-XOEabx/compass-0.2.0.tar.gz -C /cygdrive/c/Users/ianja/.ix/.compass-staging-55528 --strip-components=1
tar: Error opening archive: Failed to open '/cygdrive/c/Users/ianja/AppData/Local/Temp/ix-compass-XOEabx/compass-0.2.0.tar.gz'
```

## Cause

`installCompassBundle` rewrote its paths to Cygwin form whenever `cygpath` was on the box, then ran whatever `tar` PATH resolved to:

```js
if (process.platform === "win32") {
  try {
    tarFile = execFileSync("cygpath", ["-u", tarPath], …).trim();   // → /cygdrive/c/...
    tarDest = execFileSync("cygpath", ["-u", stagingDir], …).trim();
  } catch { /* use as-is */ }
}
execFileSync("tar", ["-xzf", tarFile, "-C", tarDest, …]);           // ← may be bsdtar
```

Two independent decisions, and the code assumed they agreed: *cygpath exists* ⟹ *tar is a Cygwin tar*.

Git for Windows supplies `cygpath`. Windows 10 1803+ supplies `System32\tar.exe`. On a machine with both — which is an ordinary Windows dev box — the rewrite happens and bsdtar, which has never heard of `/cygdrive/c`, is handed the result. The CLI extract sidesteps all of this by using `extractZipOnWindows`; this was the only remaining `tar` shell-out.

## Fix

Choose the binary and the path form as matched pairs, best first:

1. **System tar with native paths** — `System32\tar.exe` is unambiguous and isn't reached through any MSYS argument rewriting.
2. **PATH tar with native paths.**
3. **PATH tar with converted paths** — a genuine MSYS-only environment.

Trying rather than detecting, because "which tar is this" has no reliable answer and being wrong costs one failed extract into a scratch directory — which is now wiped between attempts, so the `index.html` check can't end up answering about the wreckage of an earlier try.

## Tests

The converter is injectable, because off Windows `cygpath` doesn't exist and every attempt would collapse to the native form — hiding the very inversion the test exists to catch. With a stub converter the ordering is provable anywhere.

Verified it fails against the old logic:

```
AssertionError: expected '/cygdrive/c/Temp/c.tar.gz' to be 'C:\Temp\c.tar.gz'
```

Seven new cases covering ordering, the no-cygpath path, never pairing a converted path with the system tar, and `systemTarPath` resolution via `SystemRoot`/`windir`. Full suite green — 648 tests, `tsc` and `eslint` clean.

## Related

This failure was masking a worse one: the bundled compass ships unversioned, so `ix upgrade` replaces it with an older `ix-compass-dist` build. #365 fixes that; here the extract merely failed, which is why Windows kept the correct compass and other platforms didn't.