### PR TITLE
fix(resolve): preserve same-kind ambiguity

### DIFF
--- a/ix-cli/src/cli/__tests__/search-ranking.test.ts
+++ b/ix-cli/src/cli/__tests__/search-ranking.test.ts
@@ -193,6 +193,66 @@ describe("resolveEntityFull: method preferred over chunk for PascalCase names", 
   });
 });
 
+describe("resolveEntityFull: same-kind ambiguity", () => {
+  const duplicateClasses = [
+    {
+      id: "alpha-service-id",
+      name: "DuplicateService",
+      kind: "class",
+      provenance: { sourceUri: "src/alpha/DuplicateService.ts" },
+    },
+    {
+      id: "beta-service-id",
+      name: "DuplicateService",
+      kind: "class",
+      provenance: { sourceUri: "src/beta/DuplicateService.ts" },
+    },
+  ];
+
+  it("stays ambiguous when --kind matches multiple exact-name candidates", async () => {
+    const mockClient = {
+      search: vi.fn().mockResolvedValue(duplicateClasses),
+    } as any;
+
+    const result = await resolveEntityFull(
+      mockClient,
+      "DuplicateService",
+      ["class"],
+      { kind: "class" },
+    );
+
+    expect(result.resolved).toBe(false);
+    if (!result.resolved) {
+      expect(result.ambiguous).toBe(true);
+      if (result.ambiguous) {
+        expect(result.result.candidates.map(candidate => candidate.id)).toEqual([
+          "alpha-service-id",
+          "beta-service-id",
+        ]);
+      }
+    }
+  });
+
+  it("honors --pick after --kind leaves multiple candidates", async () => {
+    const mockClient = {
+      search: vi.fn().mockResolvedValue(duplicateClasses),
+    } as any;
+
+    const result = await resolveEntityFull(
+      mockClient,
+      "DuplicateService",
+      ["class"],
+      { kind: "class", pick: 2 },
+    );
+
+    expect(result.resolved).toBe(true);
+    if (result.resolved) {
+      expect(result.entity.id).toBe("beta-service-id");
+      expect(result.entity.path).toBe("src/beta/DuplicateService.ts");
+    }
+  });
+});
+
 describe("resolveEntityFull --path hard exclusion", () => {
   it("excludes out-of-scope candidates even on exact name match", async () => {
     // Simulates Bug 1: etcd has 'Notifier' but prometheus does not.

--- a/ix-cli/src/cli/resolve.ts
+++ b/ix-cli/src/cli/resolve.ts
@@ -330,11 +330,6 @@ function pickBest(
     return { resolved: true, entity: nodeToResolved(best.node, symbol, resolutionMode(best, opts)) };
   }
 
-  // If user specified --kind, take the best — they asked for it
-  if (opts?.kind) {
-    return { resolved: true, entity: nodeToResolved(best.node, symbol, "exact") };
-  }
-
   // Check if all top candidates at the same score tier are the same entity
   const topScore = best.score;
   const topTier = unique.filter(s => s.score === topScore);


### PR DESCRIPTION
Fixes #379.

## Summary

Keep exact-name resolution ambiguous when `--kind` still leaves multiple candidates, so commands do not silently analyze the wrong symbol and `--pick` remains effective.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Remove the resolver shortcut that treated any requested kind as sufficient disambiguation.
- Preserve the existing single-candidate, score-gap, preferred-kind, and path-based resolution rules.
- Add regression coverage for duplicate exact-name classes with `--kind` and `--kind --pick 2`.

## Validation

- `cd ix-cli && npm test` (50 files, 650 tests, parser smoke passed)
- `npm run typecheck`
- `npm run build`
- `npm run lint` (0 errors; 38 existing warnings)
- Resolver-focused tests (2 files, 25 tests passed)
- Anonymous end-to-end fixture: `--kind class` now reports both matching classes; `--kind class --pick 2` selects the second class and reports its two members

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
