### PR TITLE
fix(cli): register a Pro stub for `goals`

### DIFF
--- a/ix-cli/src/cli/__tests__/pro-stub-message.test.ts
+++ b/ix-cli/src/cli/__tests__/pro-stub-message.test.ts
@@ -57,6 +57,7 @@ describe("Pro stubs", () => {
     ["truth", ["truth", "add", "Support 100k file repos"]],
     ["truth", ["truth", "list", "--format", "json"]],
     ["goal", ["goal", "create", "Support GitHub", "--format", "json"]],
+    ["goals", ["goals", "--status", "active", "--format", "json"]],
     ["decide", ["decide", "Use X", "--rationale", "because", "--affects", "Entity"]],
     ["briefing", ["briefing", "--format", "json"]],
     ["decisions", ["decisions", "--topic", "ingestion", "--limit", "10"]],
@@ -69,6 +70,22 @@ describe("Pro stubs", () => {
     expect(err).toContain(`The '${name}' command requires Ix Pro.`);
     expect(err).not.toContain("too many arguments");
     expect(exitCode).toBe(1);
+  });
+
+  // @ix/pro registers a plural list command alongside each singular manager
+  // (`bug`/`bugs`, `plan`/`plans`, `task`/`tasks`, `goal`/`goals`). Stubbing only
+  // the singular is the failure this pins: `ix goals` fell through to commander's
+  // "unknown command" instead of the sentinel above, so an agent told to stop on
+  // `requires Ix Pro.` saw an unrecognized error and had nothing to match.
+  it.each([
+    ["bug", "bugs"],
+    ["plan", "plans"],
+    ["task", "tasks"],
+    ["goal", "goals"],
+  ])("stubs both %s and %s", (singular, plural) => {
+    for (const name of [singular, plural]) {
+      expect(runStub([name]).err).toContain(`The '${name}' command requires Ix Pro.`);
+    }
   });
 
   it("emits the message verbatim as CLAUDE.md quotes it", () => {

--- a/ix-cli/src/cli/register/oss.ts
+++ b/ix-cli/src/cli/register/oss.ts
@@ -42,6 +42,7 @@ const PRO_COMMANDS: { name: string; desc: string }[] = [
   { name: "decide", desc: "Record a design decision" },
   { name: "decisions", desc: "List recorded design decisions" },
   { name: "goal", desc: "Manage project goals" },
+  { name: "goals", desc: "List all goals" },
   { name: "patches", desc: "List recent patches" },
   { name: "plan", desc: "Manage plans and plan tasks" },
   { name: "task", desc: "Manage tasks" },


### PR DESCRIPTION
## Summary

`PRO_COMMANDS` in `ix-cli/src/cli/register/oss.ts` stubs `goal` but not `goals`, so on an OSS install `ix goals` printed `error: unknown command 'goals'` instead of the `The '<name>' command requires Ix Pro.` sentinel that CLAUDE.md tells agents to detect and stop on.

`@ix/pro` registers a plural list command alongside each singular manager — `bug`/`bugs`, `plan`/`plans`, `task`/`tasks`, `goal`/`goals`. Every one of those pairs was stubbed except the last.

`ix goals` is a real, fully implemented Pro command (`Ix-pro/src/cli/commands/goals.ts` — `.command("goals")` with `--status`, `--format`, and an action calling `client.listGoals()`), not an alias. It isn't reachable from the OSS docs, which consistently say `ix goal list`, but anyone who learned it on a Pro install — or any plugin or skill that calls it — hit the wrong error.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Add `{ name: "goals", desc: "List all goals" }` to `PRO_COMMANDS`, matching the description `@ix/pro` uses and the phrasing of the existing `bugs` / `plans` / `tasks` entries.
- Cover `goals` in the existing argument-passing case table in `pro-stub-message.test.ts`.
- Add a pair-based regression test that walks `bug`/`bugs`, `plan`/`plans`, `task`/`tasks`, `goal`/`goals` and asserts both halves stub. Enumerating commands one at a time is what let this one go missing, so the guard now checks the rule instead of the list.

## Validation

Both new tests fail on `main` with exactly the reported symptom, and pass with the fix:

```
× reports Pro for goals with arguments
× stubs both goal and goals
AssertionError: expected 'error: unknown command \'goals\'…' to contain 'The \'goals\' command requires Ix Pro.'
```

- `npx vitest run src/cli/__tests__/pro-stub-message.test.ts` — 21 passed
- `npx vitest run` (full `ix-cli` suite) — 50 files, 653 tests passed
- `npm run typecheck` — clean
- `npm run lint` — 0 errors (38 pre-existing warnings, unchanged)

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works

---

Context: found while reviewing ix-claude-plugin#31 and ix-opencode-plugin#13, which both replaced `ix goals` with `ix goal list` on the stated grounds that `ix goals` "does not exist". Those replacements work and are fine to keep, but the reasoning came from checking the OSS command list only — this is the actual gap.
