### PR TITLE
chore(release): 0.9.2

### DIFF
--- a/ix-cli/package-lock.json
+++ b/ix-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ix/cli",
-  "version": "0.6.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ix/cli",
-      "version": "0.6.1",
+      "version": "0.9.2",
       "dependencies": {
         "chalk": "^6.0.0",
         "commander": "^15.0.0",

--- a/ix-cli/package.json
+++ b/ix-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ix/cli",
-  "version": "0.6.1",
+  "version": "0.9.2",
   "type": "module",
   "description": "Ix Memory — Persistent Memory for LLM Systems",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Version bump for the v0.9.2 tag.

`ix-cli/package.json` had drifted to **0.6.1** while releases ran to 0.9.1. That never reached users — the release workflow derives the version from the git tag and runs `npm version "$VERSION" --no-git-tag-version --allow-same-version` at build time — which is how it went unnoticed for three minors.

It does still feed `getCurrentVersion()`, so a source checkout reported `0.6.1` and told contributors they were several versions behind. This realigns it.

## Type
- [x] CI

## Validation
Version-only change; the release workflow rewrites this file from the tag regardless.

## Release checklist (if merging to main)
- [x] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag v0.9.2 && git push origin v0.9.2`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first — n/a
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works — n/a