### PR TITLE
fix(security): close the file-system race in view, and the two lockfile CVEs

### DIFF
--- a/core-ingestion/package-lock.json
+++ b/core-ingestion/package-lock.json
@@ -1439,9 +1439,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/ix-cli/package-lock.json
+++ b/ix-cli/package-lock.json
@@ -2384,16 +2384,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/chai": {
@@ -3185,9 +3185,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/ix-cli/src/cli/__tests__/ingest-baseline-rev.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-baseline-rev.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { ingestMtimeCachePath } from "../config.js";
+import { loadIngestBaseline, saveIngestBaseline } from "../ingest-baseline.js";
+
+let home: string;
+let savedHome: string | undefined;
+let savedProfile: string | undefined;
+
+/** The rev exactly as it sits on disk — loadIngestBaseline would launder it. */
+function rawRev(root: string): unknown {
+  return JSON.parse(fs.readFileSync(ingestMtimeCachePath(root), "utf-8")).currentRev;
+}
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "ix-baseline-rev-"));
+  savedHome = process.env.HOME;
+  savedProfile = process.env.USERPROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+});
+
+afterEach(() => {
+  process.env.HOME = savedHome;
+  process.env.USERPROFILE = savedProfile;
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+// The rev comes off the backend's commit response. loadIngestBaseline has always
+// insisted it be a non-negative integer; saveIngestBaseline used to accept
+// whatever arrived. Anything that clears a bare `> 0` but is not an integer got
+// written, was then rejected on the next read, and reset the rev to 0 — a full
+// re-ingest every run, silently.
+describe("ingest baseline rev normalization", () => {
+  const files = new Map<string, number>([["a.ts", 1_000]]);
+
+  it("persists a real rev unchanged", () => {
+    const root = path.join(home, "p");
+    saveIngestBaseline(root, files, 7);
+
+    expect(rawRev(root)).toBe(7);
+    expect(loadIngestBaseline(root)?.currentRev).toBe(7);
+  });
+
+  it("keeps the previous rev when the backend answers with a numeric string", () => {
+    const root = path.join(home, "p");
+    saveIngestBaseline(root, files, 5);
+    saveIngestBaseline(root, files, "9" as unknown as number);
+
+    // "9" > 0 is true, so the old code wrote the string through. Round-tripping
+    // it is what mattered: the read side drops a non-number and hands back 0.
+    expect(rawRev(root)).toBe(5);
+    expect(loadIngestBaseline(root)?.currentRev).toBe(5);
+  });
+
+  it("keeps the previous rev when the backend answers with a fraction", () => {
+    const root = path.join(home, "p");
+    saveIngestBaseline(root, files, 5);
+    saveIngestBaseline(root, files, 6.5);
+
+    expect(rawRev(root)).toBe(5);
+    expect(loadIngestBaseline(root)?.currentRev).toBe(5);
+  });
+
+  it("still records the rest of the baseline when the rev is rejected", () => {
+    const root = path.join(home, "p");
+    saveIngestBaseline(root, files, Number.NaN);
+
+    // A bad rev must not cost the mtime cache — that is the part that makes the
+    // next map fast, and it never came from the backend at all.
+    expect(loadIngestBaseline(root)?.files.get("a.ts")).toBe(1_000);
+    expect(loadIngestBaseline(root)?.currentRev).toBe(0);
+  });
+});

--- a/ix-cli/src/cli/__tests__/ingest-baseline-rev.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-baseline-rev.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 
 import { ingestMtimeCachePath } from "../config.js";
 import { loadIngestBaseline, saveIngestBaseline } from "../ingest-baseline.js";
+import { advanceRev } from "../commands/ingest.js";
 
 let home: string;
 let savedHome: string | undefined;
@@ -30,10 +31,11 @@ afterEach(() => {
 });
 
 // The rev comes off the backend's commit response. loadIngestBaseline has always
-// insisted it be a non-negative integer; saveIngestBaseline used to accept
-// whatever arrived. Anything that clears a bare `> 0` but is not an integer got
-// written, was then rejected on the next read, and reset the rev to 0 — a full
-// re-ingest every run, silently.
+// insisted on a non-negative integer; saveIngestBaseline used to accept whatever
+// arrived, so anything that cleared a bare `> 0` without being an integer got
+// written and was then rejected on the next read. `ix status` is the only reader
+// — incremental skipping runs off the mtime map — so the cost is a wrong
+// Revision line, not a re-ingest.
 describe("ingest baseline rev normalization", () => {
   const files = new Map<string, number>([["a.ts", 1_000]]);
 
@@ -65,13 +67,40 @@ describe("ingest baseline rev normalization", () => {
     expect(loadIngestBaseline(root)?.currentRev).toBe(5);
   });
 
-  it("still records the rest of the baseline when the rev is rejected", () => {
+  it("still records the mtimes when the rev is rejected", () => {
     const root = path.join(home, "p");
-    saveIngestBaseline(root, files, Number.NaN);
+    saveIngestBaseline(root, files, "9" as unknown as number);
 
     // A bad rev must not cost the mtime cache — that is the part that makes the
     // next map fast, and it never came from the backend at all.
     expect(loadIngestBaseline(root)?.files.get("a.ts")).toBe(1_000);
-    expect(loadIngestBaseline(root)?.currentRev).toBe(0);
+  });
+});
+
+// The save side is the last stop, not the first. The same malformed value enters
+// at the accumulator, where a bare `>` compares it as a string: "9" becomes the
+// max, then "10" > "9" is false and the max walks backwards. It also ships to
+// the user as the `latestRev` field of `ix ingest --format json`.
+describe("advanceRev", () => {
+  it("takes a larger real rev", () => {
+    expect(advanceRev(3, 9)).toBe(9);
+  });
+
+  it("keeps the current max when the incoming rev is smaller", () => {
+    expect(advanceRev(9, 3)).toBe(9);
+  });
+
+  it("ignores a numeric string instead of letting it become the max", () => {
+    // The bug this pins: "9" > 0 coerces true, so the string won and the next
+    // comparison silently became lexicographic.
+    expect(advanceRev(0, "9")).toBe(0);
+    expect(advanceRev(9, "10")).toBe(9);
+  });
+
+  it("ignores fractions, NaN, null and undefined", () => {
+    expect(advanceRev(3, 6.5)).toBe(3);
+    expect(advanceRev(3, Number.NaN)).toBe(3);
+    expect(advanceRev(3, null)).toBe(3);
+    expect(advanceRev(3, undefined)).toBe(3);
   });
 });

--- a/ix-cli/src/cli/__tests__/view-running-port.test.ts
+++ b/ix-cli/src/cli/__tests__/view-running-port.test.ts
@@ -138,6 +138,22 @@ describe("view running port state", () => {
     expect(existsSync(portFile())).toBe(false);
   });
 
+  it("clears the state when the PID file exists but cannot be read", async () => {
+    // A directory where the PID file belongs: existsSync passes, the read
+    // throws. The old check-then-read shape let that EISDIR escape the command
+    // instead of treating it as "not running", and no amount of existsSync
+    // could close the window anyway — the file can change between the two calls.
+    mkdirSync(pidFile(), { recursive: true });
+    writeFileSync(scopeFile(), "*all*");
+    writeFileSync(portFile(), "19123");
+
+    const output = await runView(["status"]);
+
+    expect(output).toContain("Visualizer is not running.");
+    expect(existsSync(scopeFile())).toBe(false);
+    expect(existsSync(portFile())).toBe(false);
+  });
+
   it("removes persisted state when the visualizer stops", async () => {
     seedRunningState(19123);
     const kill = vi.spyOn(process, "kill").mockReturnValue(true);

--- a/ix-cli/src/cli/__tests__/view-running-port.test.ts
+++ b/ix-cli/src/cli/__tests__/view-running-port.test.ts
@@ -138,20 +138,62 @@ describe("view running port state", () => {
     expect(existsSync(portFile())).toBe(false);
   });
 
-  it("clears the state when the PID file exists but cannot be read", async () => {
-    // A directory where the PID file belongs: existsSync passes, the read
-    // throws. The old check-then-read shape let that EISDIR escape the command
-    // instead of treating it as "not running", and no amount of existsSync
-    // could close the window anyway — the file can change between the two calls.
+  it("refuses to read an unreadable PID file as 'not running'", async () => {
+    // A directory where the PID file belongs: present, but the read fails. Only
+    // ENOENT means absent; anything else has to surface. Answering "not
+    // running" here would delete a live server's only record, because both
+    // callers of readAlivePid treat null as licence to act.
     mkdirSync(pidFile(), { recursive: true });
     writeFileSync(scopeFile(), "*all*");
     writeFileSync(portFile(), "19123");
 
-    const output = await runView(["status"]);
+    await expect(runView(["status"])).rejects.toThrow(/EISDIR|EPERM|EACCES/);
 
-    expect(output).toContain("Visualizer is not running.");
-    expect(existsSync(scopeFile())).toBe(false);
-    expect(existsSync(portFile())).toBe(false);
+    expect(existsSync(scopeFile())).toBe(true);
+    expect(existsSync(portFile())).toBe(true);
+  });
+
+  it("does not spawn a second server when the PID file is unreadable", async () => {
+    // The sharper half of the same bug: swallowing the read error let `start`
+    // run all the way to spawn(), and only then die writing the PID — leaving a
+    // detached visualizer with nothing recording it, which `ix view stop` then
+    // reports as not running and no later `ix view` can get past.
+    mkdirSync(pidFile(), { recursive: true });
+
+    await expect(
+      runView(["start", "--no-open", "--all"]),
+    ).rejects.toThrow(/EISDIR|EPERM|EACCES/);
+
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+
+  it("warns when the running instance is scoped to another workspace", async () => {
+    // Nothing in the suite reached this branch before: every case seeded the
+    // scope file as "*all*" and launched with --all, so the keys always matched
+    // and the warning block never ran.
+    writeFileSync(pidFile(), "4242");
+    writeFileSync(scopeFile(), "some-other-workspace");
+    writeFileSync(portFile(), "19123");
+    vi.spyOn(process, "kill").mockReturnValue(true);
+
+    const output = await runView(["start", "--no-open", "--all"]);
+
+    expect(output).toContain("It is scoped to");
+    expect(output).toContain("rescope");
+  });
+
+  it("treats an empty scope file as unknown, not as a workspace named ''", async () => {
+    // A start interrupted between opening and writing compass.scope leaves it
+    // zero-length. Reading that as a scope makes every later `ix view` tell the
+    // user to tear down an instance that is already scoped correctly.
+    writeFileSync(pidFile(), "4242");
+    writeFileSync(scopeFile(), "");
+    writeFileSync(portFile(), "19123");
+    vi.spyOn(process, "kill").mockReturnValue(true);
+
+    const output = await runView(["start", "--no-open", "--all"]);
+
+    expect(output).not.toContain("It is scoped to");
   });
 
   it("removes persisted state when the visualizer stops", async () => {

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -11,7 +11,7 @@ import chalk from 'chalk';
 import { IxClient } from '../../client/api.js';
 import type { GraphPatchPayload } from '../../client/types.js';
 import { getEndpoint, resolveWorkspaceRoot } from '../config.js';
-import { loadIngestBaseline, saveIngestBaseline } from '../ingest-baseline.js';
+import { isRev, loadIngestBaseline, saveIngestBaseline } from '../ingest-baseline.js';
 import { resolveGitHubToken } from '../github/auth.js';
 import { parseGitHubRepo, fetchGitHubData } from '../github/fetch.js';
 import { loadIngestionModules } from './ingestion-loader.js';
@@ -482,6 +482,21 @@ async function retryOnConflict<T>(fn: () => Promise<T>, maxRetries: number): Pro
       await new Promise<void>(r => setTimeout(r, delay));
     }
   }
+}
+
+/**
+ * Advance the running max revision, ignoring anything that is not a revision.
+ *
+ * `result.rev` comes off the wire, and a bare `>` is not safe on it. A string
+ * "9" clears `> 0` by coercion and becomes the max; the next comparison is then
+ * string-to-string, so `"10" > "9"` is false and the max walks backwards. That
+ * value also reaches the user verbatim as the `latestRev` field of
+ * `ix ingest --format json`, where every consumer reads it as a number.
+ * Screening it here fixes the max, the JSON contract and the persisted baseline
+ * in one place, rather than papering over the last of the three.
+ */
+export function advanceRev(current: number, incoming: unknown): number {
+  return isRev(incoming) && incoming > current ? incoming : current;
 }
 
 // ---------------------------------------------------------------------------
@@ -1242,7 +1257,7 @@ export async function ingestFiles(
                 const chunkMs = Math.round(performance.now() - commitStart);
                 commitMsPerChunk[ci] += chunkMs;
                 timings.fallbackCommitMs += chunkMs;
-                if (result.rev > latestRev) latestRev = result.rev;
+                latestRev = advanceRev(latestRev, result.rev);
                 patchesApplied++;
                 opts?.onCommitted?.(item, result.rev);
               } catch (commitErr) {
@@ -1276,7 +1291,7 @@ export async function ingestFiles(
             const chunkMs = Math.round(performance.now() - commitStart);
             commitMsPerChunk[ci] = chunkMs;
             timings.bulkCommitMs += chunkMs;
-            if (result.rev > latestRev) latestRev = result.rev;
+            latestRev = advanceRev(latestRev, result.rev);
             patchesApplied += patches.length;
             for (const item of chunk) opts?.onCommitted?.(item, result.rev);
           } catch (err) {

--- a/ix-cli/src/cli/commands/view.ts
+++ b/ix-cli/src/cli/commands/view.ts
@@ -52,23 +52,47 @@ function parsePort(value: string): number | null {
 }
 
 /**
+ * Read a file, keeping "not there" and "there but unreadable" apart.
+ *
+ * Collapsing both to null is the tempting shape and the wrong one. An
+ * unreadable compass.pid — a directory left by a botched extract, a root-owned
+ * file after one `sudo ix` — would read as "no visualizer running", and the
+ * callers act on that: one deletes a live server's state files, the other goes
+ * on to spawn a second server it then cannot record or stop. Only ENOENT means
+ * absent. Anything else is a real problem and belongs to the caller.
+ *
+ * Reading straight out instead of checking existsSync first is what closes
+ * CodeQL js/file-system-race: the check could always go stale before the read,
+ * and it never told us the read would succeed anyway.
+ */
+function readTextIfPresent(path: string): string | null {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+/**
  * Read the persisted port, falling back to the server script written by older releases.
  *
- * No existsSync guard ahead of either read: a missing file throws into the same
- * catch that already handles unreadable content, so the check bought nothing and
- * only opened a window for the file to change between the two calls (CodeQL
- * js/file-system-race).
+ * Unlike the PID and scope reads, this one does swallow an unreadable file: it
+ * is a best-effort lookup for a URL to print, not a liveness check, so a corrupt
+ * compass.port should degrade to the legacy script rather than fail the command.
+ * That was already the behaviour; only the existsSync guards are gone.
  */
 function readRunningPort(): number | null {
   try {
-    const port = parsePort(readFileSync(PORT_FILE, "utf-8"));
+    const raw = readTextIfPresent(PORT_FILE);
+    const port = raw === null ? null : parsePort(raw);
     if (port !== null) return port;
   } catch {
     // Fall through to the legacy server script.
   }
 
   try {
-    const match = readFileSync(SERVER_SCRIPT_FILE, "utf-8").match(/^const PORT = (\d+);$/m);
+    const match = readTextIfPresent(SERVER_SCRIPT_FILE)?.match(/^const PORT = (\d+);$/m);
     const port = match?.[1] ? parsePort(match[1]) : null;
     if (port !== null) {
       // Best-effort migration for a visualizer started before compass.port existed.
@@ -112,18 +136,21 @@ export function runningInstanceLines(
   return lines;
 }
 
-/** Read PID from file and check if the process is alive. */
+/**
+ * Read PID from file and check if the process is alive.
+ *
+ * An unreadable PID file throws rather than reporting "not running". Both
+ * callers treat null as licence to act — `stop` wipes the state files, `start`
+ * launches a detached server — so answering null for a file we simply could not
+ * read would delete a live server's only record, or orphan a fresh one.
+ */
 function readAlivePid(): number | null {
-  let pid: number;
-  try {
-    pid = Number(readFileSync(PID_FILE, "utf-8").trim());
-  } catch {
-    // Absent or unreadable — same disposition either way. Reading straight out
-    // also fixes the old shape, where an existsSync pass followed by a failing
-    // read threw out of the command instead of clearing the stale state.
+  const raw = readTextIfPresent(PID_FILE);
+  if (raw === null) {
     removeCompassState();
     return null;
   }
+  const pid = Number(raw.trim());
   if (!Number.isInteger(pid) || pid <= 0) {
     removeCompassState();
     return null;
@@ -337,8 +364,11 @@ export function registerViewCommand(program: Command): void {
         }
         // The running instance has a fixed scope (baked at launch). If this directory
         // maps to a different workspace, say so rather than silently showing the old one.
-        let runningKey: string | null = null;
-        try { runningKey = readFileSync(SCOPE_FILE, "utf-8").trim(); } catch { /* no scope file */ }
+        // Unreadable must not read as "no scope": that would skip the check
+        // below and quietly hand back another workspace's graph, which is the
+        // exact confusion the scope file exists to prevent. Empty counts as
+        // unknown too, not as a scope literally named "".
+        const runningKey = readTextIfPresent(SCOPE_FILE)?.trim() || null;
         if (runningKey !== null && runningKey !== scopeKey) {
           const runningLabel = runningKey === "*all*"
             ? "all workspaces"

--- a/ix-cli/src/cli/commands/view.ts
+++ b/ix-cli/src/cli/commands/view.ts
@@ -51,18 +51,22 @@ function parsePort(value: string): number | null {
   return Number.isInteger(port) && port >= 1 && port <= 65535 ? port : null;
 }
 
-/** Read the persisted port, falling back to the server script written by older releases. */
+/**
+ * Read the persisted port, falling back to the server script written by older releases.
+ *
+ * No existsSync guard ahead of either read: a missing file throws into the same
+ * catch that already handles unreadable content, so the check bought nothing and
+ * only opened a window for the file to change between the two calls (CodeQL
+ * js/file-system-race).
+ */
 function readRunningPort(): number | null {
-  if (existsSync(PORT_FILE)) {
-    try {
-      const port = parsePort(readFileSync(PORT_FILE, "utf-8"));
-      if (port !== null) return port;
-    } catch {
-      // Fall through to the legacy server script.
-    }
+  try {
+    const port = parsePort(readFileSync(PORT_FILE, "utf-8"));
+    if (port !== null) return port;
+  } catch {
+    // Fall through to the legacy server script.
   }
 
-  if (!existsSync(SERVER_SCRIPT_FILE)) return null;
   try {
     const match = readFileSync(SERVER_SCRIPT_FILE, "utf-8").match(/^const PORT = (\d+);$/m);
     const port = match?.[1] ? parsePort(match[1]) : null;
@@ -110,11 +114,16 @@ export function runningInstanceLines(
 
 /** Read PID from file and check if the process is alive. */
 function readAlivePid(): number | null {
-  if (!existsSync(PID_FILE)) {
+  let pid: number;
+  try {
+    pid = Number(readFileSync(PID_FILE, "utf-8").trim());
+  } catch {
+    // Absent or unreadable — same disposition either way. Reading straight out
+    // also fixes the old shape, where an existsSync pass followed by a failing
+    // read threw out of the command instead of clearing the stale state.
     removeCompassState();
     return null;
   }
-  const pid = Number(readFileSync(PID_FILE, "utf-8").trim());
   if (!Number.isInteger(pid) || pid <= 0) {
     removeCompassState();
     return null;
@@ -328,7 +337,8 @@ export function registerViewCommand(program: Command): void {
         }
         // The running instance has a fixed scope (baked at launch). If this directory
         // maps to a different workspace, say so rather than silently showing the old one.
-        const runningKey = existsSync(SCOPE_FILE) ? readFileSync(SCOPE_FILE, "utf-8").trim() : null;
+        let runningKey: string | null = null;
+        try { runningKey = readFileSync(SCOPE_FILE, "utf-8").trim(); } catch { /* no scope file */ }
         if (runningKey !== null && runningKey !== scopeKey) {
           const runningLabel = runningKey === "*all*"
             ? "all workspaces"

--- a/ix-cli/src/cli/ingest-baseline.ts
+++ b/ix-cli/src/cli/ingest-baseline.ts
@@ -17,6 +17,19 @@ export interface IngestBaseline {
   lastIngestAt: string;
 }
 
+/**
+ * What counts as a revision, for both sides of this file.
+ *
+ * The rev arrives off the backend's commit response, so it is response data
+ * rather than anything this process computed, and `typeof` is not enough — the
+ * read side has always insisted on a non-negative integer. One predicate so the
+ * two sides cannot drift apart again; they were previously three lines apart
+ * and disagreed.
+ */
+export function isRev(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
 export function loadIngestBaseline(projectRoot: string): IngestBaseline | null {
   const cachePath = ingestMtimeCachePath(projectRoot);
   try {
@@ -40,12 +53,7 @@ export function loadIngestBaseline(projectRoot: string): IngestBaseline | null {
     const lastIngestAt = Number.isFinite(parsedTimestamp)
       ? new Date(parsedTimestamp).toISOString()
       : fs.statSync(cachePath).mtime.toISOString();
-    const currentRev =
-      typeof data.currentRev === "number" &&
-      Number.isInteger(data.currentRev) &&
-      data.currentRev >= 0
-        ? data.currentRev
-        : 0;
+    const currentRev = isRev(data.currentRev) ? data.currentRev : 0;
 
     return { files, deletedFiles, currentRev, lastIngestAt };
   } catch {
@@ -61,15 +69,16 @@ export function saveIngestBaseline(
   deletedFiles: Map<string, string[]> = new Map(),
 ): void {
   try {
-    const previousRev = loadIngestBaseline(projectRoot)?.currentRev ?? 0;
-    // The rev reaches us straight off the backend's commit response, and until
-    // now only the read side checked its shape. That asymmetry is a quiet trap:
-    // a non-integer rev (an older backend answering with a string, say) sails
-    // through a bare `> 0`, gets written, and is then rejected by
-    // loadIngestBaseline on the next run — which resets the rev to 0 and costs a
-    // full re-ingest, every run, with nothing said. Insist on the same shape
-    // both sides already agree on.
-    const rev = Number.isInteger(currentRev) && currentRev > 0 ? currentRev : previousRev;
+    // Keep the last good rev rather than writing a shape the read side will
+    // reject. `ix status` is the only thing that reads this number, so a bad one
+    // costs a wrong Revision line, not a re-ingest — incremental skipping runs
+    // off the mtime map below and is unaffected either way. The lookup is lazy
+    // because it parses the entire baseline for one integer, and the reject
+    // branch is the only one that wants it: onCommitted calls this once per
+    // deleted file, so an eager read would re-parse the whole map N times.
+    const rev = isRev(currentRev) && currentRev > 0
+      ? currentRev
+      : (loadIngestBaseline(projectRoot)?.currentRev ?? 0);
     const data: SerializedIngestBaseline = {
       root: projectRoot,
       files: Object.fromEntries(mtimes),

--- a/ix-cli/src/cli/ingest-baseline.ts
+++ b/ix-cli/src/cli/ingest-baseline.ts
@@ -62,11 +62,19 @@ export function saveIngestBaseline(
 ): void {
   try {
     const previousRev = loadIngestBaseline(projectRoot)?.currentRev ?? 0;
+    // The rev reaches us straight off the backend's commit response, and until
+    // now only the read side checked its shape. That asymmetry is a quiet trap:
+    // a non-integer rev (an older backend answering with a string, say) sails
+    // through a bare `> 0`, gets written, and is then rejected by
+    // loadIngestBaseline on the next run — which resets the rev to 0 and costs a
+    // full re-ingest, every run, with nothing said. Insist on the same shape
+    // both sides already agree on.
+    const rev = Number.isInteger(currentRev) && currentRev > 0 ? currentRev : previousRev;
     const data: SerializedIngestBaseline = {
       root: projectRoot,
       files: Object.fromEntries(mtimes),
       deletedFiles: Object.fromEntries(deletedFiles),
-      currentRev: currentRev > 0 ? currentRev : previousRev,
+      currentRev: rev,
       lastIngestAt: now.toISOString(),
     };
     fs.mkdirSync(path.dirname(ingestMtimeCachePath(projectRoot)), { recursive: true });


### PR DESCRIPTION
Three of the eight open code scanning alerts — the ones with a real fix behind them. The other five are dispositions rather than code changes; they are listed at the bottom so the whole set is accounted for in one place.

## #44 — `js/file-system-race` (high), `view.ts`

`readRunningPort` called `existsSync(PORT_FILE)` and then, fifteen lines later, wrote to that same path. That pair is what CodeQL flagged, and the check could always go stale before the operation — it never told us the read would succeed either.

The reads now go straight out through `readTextIfPresent`, which returns null **only** for ENOENT and rethrows everything else. That distinction is load-bearing: both callers of `readAlivePid` treat null as licence to act, so collapsing "unreadable" into "absent" means `ix view stop` deletes a live server's state and `ix view` spawns a second one it cannot record. `readRunningPort` keeps its swallow-all policy deliberately — it is looking up a URL to print, not liveness — and now says so. The scope read also stops reading a zero-length file as a workspace named `""`.

## #47 — `js/http-to-file-access` (medium), `ingest-baseline.ts`

The rev arrives off the backend's commit response and only the read side ever checked its shape, so a non-integer rev (an older backend answering `"9"` instead of `9`) cleared a bare `> 0` and was written, then rejected on the next read.

The save side is the *last* stop, though, not the first. The same value enters at the accumulator, where a bare `>` compares it as a string — `"9"` becomes the max, and `"10" > "9"` is then false, so the max walks backwards — and it ships to the user verbatim as the `latestRev` field of `ix ingest --format json`. `advanceRev` screens it where it enters, which fixes the max, the JSON contract and the persisted baseline in one place. `isRev` is now a single predicate both sides of the baseline share; they previously sat three lines apart and disagreed on whether 0 was valid.

To be accurate about the cost: `currentRev` is read only by `ix status`'s Revision line. Incremental skipping runs off the mtime map, which was always persisted correctly. A bad rev means a wrong Revision, **not** a re-ingest.

## #40 — Scorecard `Vulnerabilities` (high)

`nanoid` 3.3.16 → 3.3.18 and `brace-expansion` 5.0.7 → 5.0.9, clearing all three advisories behind the alert: GHSA-2v37-7h3g-55p8, GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895. Lockfiles only; both are dev-only transitive deps, and `npm audit` is clean in `ix-cli` and `core-ingestion`.

## Testing

`npm test` in `ix-cli`: 720 passed, 2 skipped. `npm run typecheck` clean; lint unchanged at 0 errors.

Every new assertion was checked against a restored mutant rather than assumed to be doing work. Swallowing all read errors brings back the orphan spawn (`spawn` called once, then EISDIR) and the silently-suppressed scope warning; `?? null` on the scope read brings back the bogus warning for an empty file; dropping the rev screen lets `"9"` win the max. Five mutants, five failures, then all pass.

The scope-mismatch branch previously had **no** coverage anywhere in the 713-test suite — every case seeded `compass.scope` as `"*all*"` and launched with `--all`, so the keys always matched and the warning never ran. It has a test now.

## Known leftovers

- `watch-utils.ts:readFileContent` still carries the same `existsSync`-then-read shape, plus an any-error-to-null contract that `watch` depends on. Left alone deliberately rather than widened into this PR.
- The temp-HOME test fixture is now duplicated in four test files and wants extracting into shared test support. Out of scope here.

## The other five alerts, for the record

- **#45, #46** (`js/http-to-file-access`, `view.ts`) — the same finding already dismissed as #28/#29. The flow is the `workspaceSystem` response reaching `systemId`; it is charset-constrained at `view.ts:309` and JSON-encoded at the sink, and the proxy has to embed its own scope. CodeQL keeps the taint because the guard tests the value rather than rebuilding it, which is correct of it and not worth laundering the code to satisfy.
- **#48** (Scorecard `PinnedDependencies`) — `skills/ix/scripts/bootstrap.sh` runs the official installer. Hash-pinning it would freeze bootstrap at one installer version and break on every release.
- **#39, #43** (Scorecard `SAST` / `CI-Tests`) — backward-looking scores over the last 30 merged PRs. CodeQL only began running on PR heads at #386; before that it ran on `main` pushes only, so the five uncovered PRs are already behind us. Both heal as PRs roll forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)