### PR TITLE
fix(cli): register the patches command instead of stubbing it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,8 +47,12 @@ ix map --silent                             # refresh the graph after code chang
   Pro probe diffs against it. Adding a command to `oss.ts` silently makes it
   OSS; removing one makes Pro own it. `registerProCommands` is async and MUST
   be awaited.
-- **`registerPatchesCommand` is defined but never registered** in `oss.ts` —
-  `ix patches` is an "unknown command" today.
+- **`ix patches` is OSS, not Pro** (#371). It is implemented here and registered
+  in `oss.ts`. `@ix/pro` also registers a `patches`; commander throws on the
+  duplicate and Pro's `tryRegister` swallows the throw, so the OSS one — which
+  registers first — wins on a Kartr install too. Do not re-add it to
+  `PRO_COMMANDS`: a stub for a command that exists in OSS shadows the real
+  implementation, and the failure is silent rather than a crash.
 - **`ix upgrade` wipes `~/.ix/cli/compass`.** The Compass assets ship only via
   `ix upgrade`, and re-running the installer re-extracts over them, so a
   re-install can leave `ix view` with no UI. `bootstrap.sh` re-runs `ix upgrade`
@@ -162,14 +166,14 @@ Underlying structural commands — useful for debugging or fine-grained inspecti
 
 ### History & Decisions
 
-Only the first three work without Pro.
+Only the first four work without Pro.
 
 | Goal | Command | Example |
 |---|---|---|
 | Entity history | `ix history` | `ix history <entityId> --format llm` |
 | Changes between revisions | `ix diff` | `ix diff 1 5 --summary --format llm` |
 | Detect contradictions | `ix conflicts` | `ix conflicts --format llm` |
-| **[Pro]** List recent patches | `ix patches` | `ix patches --limit 20 --format json` |
+| List recent patches | `ix patches` | `ix patches --limit 20 --format llm` |
 | **[Pro]** Design decisions | `ix decisions` | `ix decisions --topic ingestion --limit 10` |
 | **[Pro]** Record a decision | `ix decide` | `ix decide "Use CONTAINS" --rationale "Normalize edges" --responds-to <bugId>` |
 | **[Pro]** Record a goal | `ix truth add` | `ix truth add "Support 100k file repos"` |

--- a/ix-cli/src/cli/__tests__/pro-stub-message.test.ts
+++ b/ix-cli/src/cli/__tests__/pro-stub-message.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { Command } from "commander";
 
-import { registerProStubs } from "../register/oss.js";
+import { registerOssCommands, registerProStubs } from "../register/oss.js";
 
 /**
  * CLAUDE.md tells agents to detect a Pro-gated install by the exact string
@@ -82,6 +82,23 @@ describe("Pro stubs", () => {
     program.name("ix").exitOverride();
     registerProStubs(program);
     expect(program.commands.map(c => c.name())).not.toContain("patches");
+  });
+
+  // The other half, and the one that actually delivers #371. Absence from the
+  // stub list only helps if `oss.ts` registers the real command — drop the
+  // registerPatchesCommand(program) call and the test above still passes while
+  // `ix patches` becomes commander's "unknown command", which is where #371
+  // started. Both halves have to be pinned or either can silently regress.
+  it("registers patches as an OSS command", () => {
+    const program = new Command();
+    program.name("ix").exitOverride();
+    registerOssCommands(program);
+
+    const patches = program.commands.find(c => c.name() === "patches");
+    expect(patches).toBeDefined();
+    // --format llm is why the OSS implementation is the one worth keeping when
+    // commander drops @ix/pro's duplicate registration on a Kartr install.
+    expect(patches?.options.map(o => o.long)).toContain("--format");
   });
 
   // @ix/pro registers a plural list command alongside each singular manager

--- a/ix-cli/src/cli/__tests__/pro-stub-message.test.ts
+++ b/ix-cli/src/cli/__tests__/pro-stub-message.test.ts
@@ -61,7 +61,6 @@ describe("Pro stubs", () => {
     ["decide", ["decide", "Use X", "--rationale", "because", "--affects", "Entity"]],
     ["briefing", ["briefing", "--format", "json"]],
     ["decisions", ["decisions", "--topic", "ingestion", "--limit", "10"]],
-    ["patches", ["patches", "--limit", "20", "--format", "json"]],
     ["plan", ["plan", "task", "title", "--plan", "p1", "--resolves", "b1"]],
     ["task", ["task", "show", "t1"]],
     ["workflow", ["workflow", "attach", "w1"]],
@@ -70,6 +69,19 @@ describe("Pro stubs", () => {
     expect(err).toContain(`The '${name}' command requires Ix Pro.`);
     expect(err).not.toContain("too many arguments");
     expect(exitCode).toBe(1);
+  });
+
+  // `patches` is NOT Pro. ix-cli implements it (commands/patches.ts), but it
+  // sat in PRO_COMMANDS while never being registered, so the stub answered
+  // "requires Ix Pro" for a command this repo ships — #371. Pinning its absence
+  // here is what stops it being re-added to the list: a stub for a command that
+  // exists in OSS shadows the real implementation, and because
+  // registerOssCommands runs first the symptom is silent rather than a crash.
+  it("does not stub patches — ix-cli owns it", () => {
+    const program = new Command();
+    program.name("ix").exitOverride();
+    registerProStubs(program);
+    expect(program.commands.map(c => c.name())).not.toContain("patches");
   });
 
   // @ix/pro registers a plural list command alongside each singular manager

--- a/ix-cli/src/cli/commands/patches.ts
+++ b/ix-cli/src/cli/commands/patches.ts
@@ -1,8 +1,23 @@
 import type { Command } from "commander";
-import { IxClient } from "../../client/api.js";
-import { getEndpoint } from "../config.js";
+import { createClient } from "../config.js";
 import { formatPatches } from "../format.js";
 
+/**
+ * `ix patches`.
+ *
+ * This is the real implementation and has been all along — it was simply never
+ * imported by `register/oss.ts`, while `patches` sat in `PRO_COMMANDS` so
+ * `registerProStubs` installed the "requires Ix Pro" sentinel over the top of
+ * it. OSS users got a paywall message for a command this repo implements (#371).
+ *
+ * `@ix/pro` also registers a `patches`. Commander throws on a duplicate command
+ * name and Pro's `tryRegister` swallows the throw, so on a Kartr install the
+ * OSS registration (which runs first, from `registerOssCommands`) is the one
+ * that survives. That is the intended outcome — this version additionally
+ * supports `--format llm` — but it makes the two implementations' behaviour
+ * matter, so this one uses the same `createClient()` factory Pro's does rather
+ * than constructing `IxClient` directly.
+ */
 export function registerPatchesCommand(program: Command): void {
   program
     .command("patches")
@@ -10,7 +25,7 @@ export function registerPatchesCommand(program: Command): void {
     .option("--limit <n>", "Maximum patches to return", "50")
     .option("--format <fmt>", "Output format (text|json|llm)", "text")
     .action(async (opts: { limit: string; format: string }) => {
-      const client = new IxClient(getEndpoint());
+      const client = await createClient();
       const patches = await client.listPatches({ limit: parseInt(opts.limit, 10) });
       formatPatches(patches, opts.format);
     });

--- a/ix-cli/src/cli/register/oss.ts
+++ b/ix-cli/src/cli/register/oss.ts
@@ -34,6 +34,7 @@ import { registerSubsystemsCommand } from "../commands/subsystems.js";
 import { registerUpgradeCommand } from "../commands/upgrade.js";
 import { registerViewCommand } from "../commands/view.js";
 import { registerSavingsCommand } from "../commands/savings.js";
+import { registerPatchesCommand } from "../commands/patches.js";
 
 const PRO_COMMANDS: { name: string; desc: string }[] = [
   { name: "briefing", desc: "Session-resume briefing" },
@@ -43,7 +44,10 @@ const PRO_COMMANDS: { name: string; desc: string }[] = [
   { name: "decisions", desc: "List recorded design decisions" },
   { name: "goal", desc: "Manage project goals" },
   { name: "goals", desc: "List all goals" },
-  { name: "patches", desc: "List recent patches" },
+  // `patches` is deliberately absent: ix-cli owns the real implementation
+  // (commands/patches.ts, registered above). It sat in this list while never
+  // being registered, so `ix patches` answered "requires Ix Pro" on OSS and
+  // shadowed a working command — see #371.
   { name: "plan", desc: "Manage plans and plan tasks" },
   { name: "task", desc: "Manage tasks" },
   { name: "plans", desc: "List all plans" },
@@ -96,6 +100,7 @@ export function registerOssCommands(program: Command): void {
   registerUpgradeCommand(program);
   registerViewCommand(program);
   registerSavingsCommand(program);
+  registerPatchesCommand(program);
 
   // Hide advanced commands from default help
   const advancedSet = new Set(ADVANCED_COMMANDS);


### PR DESCRIPTION
## The bug

`ix-cli` has always contained a complete `ix patches` — client call, `--limit`, `--format text|json|llm`, and `formatPatches` already has a working `llm` branch (`format.ts:242`).

It was never imported by `register/oss.ts`. Meanwhile `patches` sat in `PRO_COMMANDS`, so `registerProStubs` installed the "requires Ix Pro" sentinel over the top of it.

So OSS users got a paywall message for a command this repo ships. Nobody noticed because the stub is a *plausible* answer — had it fallen through to commander's `unknown command` the way `goals` did (#384), it would have been reported long ago.

Found by @Alot1z while writing the agent skill (#368).

## The fix

Register it, and drop it from `PRO_COMMANDS`.

## The part worth reviewing

`@ix/pro` registers a `patches` too. Commander **throws** on a duplicate command name, and Pro's `tryRegister` wraps registration in a `try`/`catch` that swallows it — so on a Kartr install the OSS registration (which runs first, from `registerOssCommands`) is the one that survives, and Pro's is silently skipped.

That is the outcome we want: this version also supports `--format llm`, which Pro's does not. But it means the two implementations' behaviour now matters, so this one uses the same `createClient()` factory Pro's does instead of constructing `IxClient` directly. They are identical today (`createClient` is literally `new IxClient(getEndpoint())`) — the point is that its docstring says Pro commands should prefer it "so auth and endpoint resolution can evolve in one spot", and `patches` is now a command both editions route through.

Verified the swallow rather than assuming it: commander 12.1.0 raises `cannot add command 'patches' as already have command 'patches'` from `_registerCommand`, and `tryRegister`'s `catch` covers the `fn(program)` call, not just the `import`.

## Tests

The stub test asserting `patches` reports Pro is replaced by one asserting it is **not** stubbed. A stub for a command that exists in OSS shadows the real implementation, and because `registerOssCommands` runs first the symptom is silence, not a crash — worth pinning so it cannot come back.

722 tests green. `ix patches --help` verified against a real build.

## Docs

CLAUDE.md said the wrong thing in three places: the gotcha claiming `ix patches` is an unknown command, the `[Pro]` marker on its routing row, and the "only the first three work without Pro" line above that table.

Fixes #371