### PR TITLE
ci(codeql): move to advanced setup so fork PRs get scanned before merge

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,21 +30,35 @@ permissions:
 
 concurrency:
   group: codeql-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # PRs only. For push and schedule, github.ref is refs/heads/main, so cancelling
+  # would put every merge in one group with the weekly cron and let a burst of
+  # merges kill main's analysis before it uploads — and a cancelled run renders
+  # grey, not red, on a check that is not required. Default setup analysed every
+  # commit on main to completion; that is the net that caught #44 after the fact,
+  # and it has to survive the switch.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
+    # Deliberately not "Analyze (<lang>)": that is byte-for-byte what default
+    # setup names its checks, and during the cutover both configurations report
+    # at once, so identical names would sit in the checks list with opposite
+    # results and no way to tell which is which.
+    name: CodeQL (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
       security-events: write # upload SARIF to code scanning
-      actions: read # CodeQL reads workflow run info for the `actions` language
 
     strategy:
       fail-fast: false
       matrix:
+        # Hand-maintained, and default setup's was not: it auto-detected new
+        # languages as they appeared. This repo already carries .py and .scala
+        # files, so adding a Python or Go component means adding it here too —
+        # nothing fails if you forget, the Security tab simply reads clean.
+        #
         # build-mode: none for all three — nothing here is a compiled language,
         # so there is no build to observe.
         language: [actions, javascript-typescript, ruby]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,71 @@
+name: CodeQL
+
+# Advanced setup, replacing default setup for one reason: default setup does not
+# analyze pull requests from forks. Measured on this repo before the switch —
+# 16/16 non-fork PRs scanned, 0/5 fork PRs — and it is not an approval problem,
+# since #380 and #382 ran the whole CI suite and still got no CodeQL. With 56
+# forks that means every external contribution was first scanned only once it
+# had already landed on main.
+#
+# Settings below mirror what default setup was configured with, so the switch
+# changes when analysis runs, not what it looks for:
+#   query_suite: extended  -> queries: security-extended
+#   languages: actions, javascript-typescript, ruby
+#   schedule: weekly
+#   threat_model: remote   -> no input needed; remote is CodeQL's default
+#     (there is no threat-models input on codeql-action v4).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, matching what default setup ran. Offset from the Scorecard job
+    # (Mon 05:27) so the two do not contend for runners.
+    - cron: "41 4 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write # upload SARIF to code scanning
+      actions: read # CodeQL reads workflow run info for the `actions` language
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # build-mode: none for all three — nothing here is a compiled language,
+        # so there is no build to observe.
+        language: [actions, javascript-typescript, ruby]
+
+    steps:
+      - uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Why

CodeQL **default setup does not analyze pull requests from forks.** Measured on this repo:

| | CodeQL ran |
|---|---|
| Non-fork PRs | **16 / 16** |
| Fork PRs | **0 / 5** |

It is not a workflow-approval problem. #380 and #382 ran the entire CI suite — Trivy, gitleaks, Dependency Review, the whole test matrix — and still got no CodeQL. With 56 forks, every external contribution was first scanned only after it had already landed on `main`.

To be precise about the risk: the code was never *unscanned*. The push-to-`main` analysis catches it, which is how #44 was found in the first place. But catching it after the merge is the wrong end of the process, and it is what dragged the Scorecard SAST check to 25/30 (alert #39).

## Why this fixes it

An advanced-setup workflow is an ordinary workflow, and ordinary workflows demonstrably do run on fork PRs here. Confirmed against `actions/runner`, a public repo whose `codeql.yml` triggers on `pull_request`: fork PRs 4551, 4550, 4546 and 4527 were all analyzed, identically to its own-branch PRs.

## What carries over

Settings mirror the previous default setup, so this changes *when* analysis runs, not what it looks for.

| Default setup | This workflow |
|---|---|
| `query_suite: extended` | `queries: security-extended` |
| `languages: actions, javascript-typescript, ruby` | matrix of the same three |
| `schedule: weekly` | `cron: "41 4 * * 1"`, offset from Scorecard's 05:27 so they do not contend |
| `threat_model: remote` | nothing — see below |

`threat_model` is the one that does not carry over: **codeql-action v4 has no `threat-models` input.** It happens not to matter, because `remote` is CodeQL's default and the setting was already a no-op. Worth knowing before anyone tries to set it to `local`, which would need a config file.

## Checks

- All four actions pinned to a SHA; `codeql-action` uses the same SHA the repo already pins in `scorecard.yml`, verified to be exactly what `v4.37.6` dereferences to.
- `zizmor` reports no findings at `--min-severity=low`; CI gates at medium.
- Least-privilege: `contents: read` at top level, elevated only in the job.

## Sequencing

Default setup and advanced setup are mutually exclusive, so the CodeQL check on this PR fails until default setup is switched off. That switch happens immediately before merge, deliberately — it keeps the repo scanned right up to the cutover instead of leaving a gap while the PR sits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)