### PR TITLE
fix(cli): follow Ix-pro's `ix bugs` -> `ix bug list` collapse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ Only the first four work without Pro.
 | **[Pro]** List goals | `ix truth list` | `ix truth list --format json` |
 | **[Pro]** Bug tracking | `ix bug create` | `ix bug create "title" --severity high --affects Entity` |
 | **[Pro]** Update bug status | `ix bug update` | `ix bug update <id> --status resolved` |
-| **[Pro]** Bug listing | `ix bugs` | `ix bugs --status open --format json` |
+| **[Pro]** Bug listing | `ix bug list` | `ix bug list --status open --format json` |
 | **[Pro]** Bug details | `ix bug show` | `ix bug show <id> --format json` |
 
 ### Planning (Pro)

--- a/ix-cli/src/cli/__tests__/help-topics.test.ts
+++ b/ix-cli/src/cli/__tests__/help-topics.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
+import { Command } from "commander";
 import * as fs from "node:fs";
 import * as path from "node:path";
+
+import { registerProStubs } from "../register/oss.js";
+import { registerWorkflowsHelpCommand } from "../commands/workflows.js";
 
 /**
  * Verify that the help command properly routes topic arguments
@@ -37,5 +41,61 @@ describe("help topic routing", () => {
 
   it("help action handles unknown topics with an error", () => {
     expect(workflowsContent).toContain("Unknown help topic");
+  });
+});
+
+/**
+ * Behavioral coverage for the collapsed-plural forwarder. The assertions above
+ * are source-text greps, which is how `ix help bugs` broke unnoticed: @ix/pro
+ * collapsed `ix bugs` into `ix bug list` (Ix-pro#108) and dropping the `bugs`
+ * stub left the topic resolving to nothing. Run the real command instead.
+ */
+describe("collapsed plural help topics resolve", () => {
+  function runHelp(topic: string): { stdout: string; stderr: string; exitCode: number | string | undefined } {
+    const program = new Command();
+    program.name("ix").exitOverride();
+    registerProStubs(program);
+    registerWorkflowsHelpCommand(program);
+
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    const origErr = console.error;
+    const origExit = process.exitCode;
+    process.stdout.write = ((chunk: unknown) => {
+      stdout.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    console.error = (...a: unknown[]) => void stderr.push(a.join(" "));
+    process.exitCode = undefined;
+
+    let code: number | string | undefined;
+    try {
+      program.parse(["node", "ix", "help", topic]);
+    } catch (e) {
+      stderr.push(String((e as Error).message));
+    } finally {
+      code = process.exitCode;
+      process.stdout.write = origWrite;
+      console.error = origErr;
+      process.exitCode = origExit;
+    }
+    return { stdout: stdout.join(""), stderr: stderr.join("\n"), exitCode: code };
+  }
+
+  it.each([
+    ["bugs", "bug"],
+    ["goals", "goal"],
+  ])("ix help %s forwards to the %s command instead of erroring", (plural, singular) => {
+    const { stdout, stderr, exitCode } = runHelp(plural);
+    expect(stderr).not.toContain("Unknown help topic");
+    expect(exitCode).toBeUndefined();
+    expect(stdout).toContain(`Usage: ix ${singular}`);
+  });
+
+  it("still rejects a topic that was never a command", () => {
+    const { stderr, exitCode } = runHelp("nonsense");
+    expect(stderr).toContain('Unknown help topic: "nonsense"');
+    expect(exitCode).toBe(1);
   });
 });

--- a/ix-cli/src/cli/__tests__/help-topics.test.ts
+++ b/ix-cli/src/cli/__tests__/help-topics.test.ts
@@ -90,7 +90,11 @@ describe("collapsed plural help topics resolve", () => {
     const { stdout, stderr, exitCode } = runHelp(plural);
     expect(stderr).not.toContain("Unknown help topic");
     expect(exitCode).toBeUndefined();
-    expect(stdout).toContain(`Usage: ix ${singular}`);
+    // Anchored on a word boundary, not a prefix: `goals` is still a registered
+    // Pro stub, and its own help starts `Usage: ix goals` — which *contains*
+    // `Usage: ix goal`. Without the boundary this assertion passes with the
+    // forwarder deleted outright, which is exactly how it was first written.
+    expect(stdout).toMatch(new RegExp(`^Usage: ix ${singular}\\b`, "m"));
   });
 
   it("still rejects a topic that was never a command", () => {

--- a/ix-cli/src/cli/__tests__/pro-stub-message.test.ts
+++ b/ix-cli/src/cli/__tests__/pro-stub-message.test.ts
@@ -100,11 +100,17 @@ describe("Pro stubs", () => {
     expect(patches?.options.map(o => o.long)).toContain("--format");
   });
 
-  // @ix/pro registers a plural list command alongside some singular managers
-  // (`plan`/`plans`, `task`/`tasks`, `goal`/`goals`). Stubbing only the singular
-  // is the failure this pins: `ix goals` fell through to commander's "unknown
-  // command" instead of the sentinel above, so an agent told to stop on
+  // @ix/pro registers a plural list command alongside `plan` and `task`
+  // (register.ts: registerPlansCommand, registerTasksCommand). Stubbing only the
+  // singular is the failure this pins: the plural fell through to commander's
+  // "unknown command" instead of the sentinel above, so an agent told to stop on
   // `requires Ix Pro.` saw an unrecognized error and had nothing to match.
+  //
+  // `goals` is NOT in that category and is only still stubbed by oversight:
+  // Ix-pro#103 deleted the command, #327 correctly dropped the stub, and #384
+  // re-added it on the stated premise that Pro registers a plural for *every*
+  // singular — which was already false. Do not use this row as evidence that
+  // `ix goals` exists; removing it is a pending follow-up.
   it.each([
     ["plan", "plans"],
     ["task", "tasks"],

--- a/ix-cli/src/cli/__tests__/pro-stub-message.test.ts
+++ b/ix-cli/src/cli/__tests__/pro-stub-message.test.ts
@@ -53,7 +53,6 @@ describe("Pro stubs", () => {
     ["bug", ["bug", "create", "a title", "--affects", "Entity"]],
     ["bug", ["bug", "update", "abc123", "--status", "resolved"]],
     ["bug", ["bug", "show", "abc123", "--format", "json"]],
-    ["bugs", ["bugs", "--status", "open", "--format", "json"]],
     ["truth", ["truth", "add", "Support 100k file repos"]],
     ["truth", ["truth", "list", "--format", "json"]],
     ["goal", ["goal", "create", "Support GitHub", "--format", "json"]],
@@ -101,13 +100,12 @@ describe("Pro stubs", () => {
     expect(patches?.options.map(o => o.long)).toContain("--format");
   });
 
-  // @ix/pro registers a plural list command alongside each singular manager
-  // (`bug`/`bugs`, `plan`/`plans`, `task`/`tasks`, `goal`/`goals`). Stubbing only
-  // the singular is the failure this pins: `ix goals` fell through to commander's
-  // "unknown command" instead of the sentinel above, so an agent told to stop on
+  // @ix/pro registers a plural list command alongside some singular managers
+  // (`plan`/`plans`, `task`/`tasks`, `goal`/`goals`). Stubbing only the singular
+  // is the failure this pins: `ix goals` fell through to commander's "unknown
+  // command" instead of the sentinel above, so an agent told to stop on
   // `requires Ix Pro.` saw an unrecognized error and had nothing to match.
   it.each([
-    ["bug", "bugs"],
     ["plan", "plans"],
     ["task", "tasks"],
     ["goal", "goals"],
@@ -115,6 +113,17 @@ describe("Pro stubs", () => {
     for (const name of [singular, plural]) {
       expect(runStub([name]).err).toContain(`The '${name}' command requires Ix Pro.`);
     }
+  });
+
+  // `bugs` is deliberately absent from the pairs above: @ix/pro collapsed it into
+  // `ix bug list` (Ix-pro#108), so there is no plural command left to stub. The
+  // singular stub has to cover the subcommand form instead — it swallows operands,
+  // so `bug list` still reaches the sentinel rather than "unknown command".
+  it("stubs the collapsed 'bug list' subcommand, not a 'bugs' command", () => {
+    expect(runStub(["bug", "list", "--status", "open", "--format", "json"]).err).toContain(
+      "The 'bug' command requires Ix Pro.",
+    );
+    expect(runStub(["bugs"]).err).not.toContain("requires Ix Pro");
   });
 
   it("emits the message verbatim as CLAUDE.md quotes it", () => {

--- a/ix-cli/src/cli/commands/workflows.ts
+++ b/ix-cli/src/cli/commands/workflows.ts
@@ -29,7 +29,7 @@ Staged Workflows:
   ix workflow run task <id> --stage discover   Run one stage
 
 Bug Workflow:
-  ix bugs --status open                   See open bugs
+  ix bug list --status open               See open bugs
   ix bug show <id>                        Get bug details
   ix plan create "Fix X" --goal <id> --responds-to <bugId>
   ix plan task "Step 1" --plan <id> --resolves <bugId>

--- a/ix-cli/src/cli/commands/workflows.ts
+++ b/ix-cli/src/cli/commands/workflows.ts
@@ -59,6 +59,12 @@ Advanced (low-level graph commands):
 Use "ix <command> --help" for details on any command.
 `;
 
+/** Retired plural names -> the singular that absorbed them as a subcommand. */
+const COLLAPSED_HELP_TOPICS: Record<string, string> = {
+  goals: "goal",
+  bugs: "bug",
+};
+
 export function registerWorkflowsHelpCommand(program: Command): void {
   const help = program
     .command("help [topic]")
@@ -80,13 +86,18 @@ export function registerWorkflowsHelpCommand(program: Command): void {
         return;
       }
 
-      // "goals" → forward to "goal" command help
-      if (topic === "goals") {
-        const goalCmd = program.commands.find(
-          (c: Command) => c.name() === "goal"
+      // Plural commands @ix/pro collapsed into a subcommand of the singular
+      // (`ix goals` -> `ix goal list`, Ix-pro#103; `ix bugs` -> `ix bug list`,
+      // Ix-pro#108). The plural is no longer a command anywhere, so `ix help
+      // bugs` would fall through to "Unknown help topic". Forward it to the
+      // singular, whose help documents the new subcommand.
+      const collapsed = COLLAPSED_HELP_TOPICS[topic];
+      if (collapsed) {
+        const target = program.commands.find(
+          (c: Command) => c.name() === collapsed
         );
-        if (goalCmd) {
-          goalCmd.outputHelp();
+        if (target) {
+          target.outputHelp();
           return;
         }
       }

--- a/ix-cli/src/cli/register/oss.ts
+++ b/ix-cli/src/cli/register/oss.ts
@@ -39,7 +39,6 @@ import { registerPatchesCommand } from "../commands/patches.js";
 const PRO_COMMANDS: { name: string; desc: string }[] = [
   { name: "briefing", desc: "Session-resume briefing" },
   { name: "bug", desc: "Manage bugs" },
-  { name: "bugs", desc: "List all bugs" },
   { name: "decide", desc: "Record a design decision" },
   { name: "decisions", desc: "List recorded design decisions" },
   { name: "goal", desc: "Manage project goals" },

--- a/skills/ix/references/commands.md
+++ b/skills/ix/references/commands.md
@@ -125,9 +125,10 @@ ix inventory --kind function --path auth.py --format llm
   - `registerProCommands` is async (each Pro command is dynamically imported)
     and MUST be awaited; skipping the await makes every `ix <pro-cmd>` fail
     with "unknown command".
-  - Real example: `registerPatchesCommand` is defined but never called in
-    `oss.ts`, so `ix patches` errors as an unknown command today; wiring it in
-    would flip it to OSS.
+  - Real example: `registerPatchesCommand` was defined but never called in
+    `oss.ts`, so a `patches` entry in `PRO_COMMANDS` shadowed it and `ix
+    patches` answered "requires Ix Pro" (#371). #390 wired the call in and
+    dropped the stub, so `ix patches` is an OSS command today.
 
 ## Do NOT Use
 

--- a/skills/ix/references/output-formats.md
+++ b/skills/ix/references/output-formats.md
@@ -33,7 +33,7 @@ does not have them — skip that step, do not retry it, and do not mention it
 again for the rest of the session. Nothing outside those marks is Pro-gated.
 
 Pro-only surface: `plan`, `plans`, `task`, `tasks`, `workflow`, `decide`,
-`decisions`, `goal`, `truth`, `bug`, `bugs`, `briefing`, `patches`.
+`decisions`, `goal`, `truth`, `bug`, `briefing`, `patches`.
 
 ### Semantic boundaries (Pro record types)
 

--- a/skills/ix/references/output-formats.md
+++ b/skills/ix/references/output-formats.md
@@ -33,7 +33,7 @@ does not have them — skip that step, do not retry it, and do not mention it
 again for the rest of the session. Nothing outside those marks is Pro-gated.
 
 Pro-only surface: `plan`, `plans`, `task`, `tasks`, `workflow`, `decide`,
-`decisions`, `goal`, `truth`, `bug`, `briefing`, `patches`.
+`decisions`, `goal`, `truth`, `bug`, `briefing`.
 
 ### Semantic boundaries (Pro record types)
 


### PR DESCRIPTION
## Summary

[Ix-pro#108](https://github.com/ix-infrastructure/Ix-pro/pull/108) deletes the top-level `ix bugs` command and re-adds its behavior as `ix bug list`. Four places in this repo still point at the old name — the CLI help one is user-facing.

| File | Was |
|---|---|
| `ix-cli/src/cli/commands/workflows.ts:32` | `ix workflows` printed `ix bugs --status open` in its Bug Workflow section — shipped OSS help for a command that will not exist |
| `ix-cli/src/cli/register/oss.ts:42` | `PRO_COMMANDS` stubbed `bugs`, so OSS answered *"The 'bugs' command requires Ix Pro."* — an upsell for something installing Pro would not give you |
| `CLAUDE.md:183` | documented `ix bugs` |
| `skills/ix/references/output-formats.md:36` | listed `bugs` in the Pro-only surface |

## Notes

- Dropping the `bugs` stub means commander now answers `unknown command 'bugs' (Did you mean bug?)`, which is both honest and more useful than the Pro upsell.
- The singular `bug` stub already covers the new subcommand form — it calls `.argument("[args...]")` with `allowExcessArguments`, so `ix bug list --status open` still reaches the Pro sentinel rather than dying on "too many arguments". That is the behavior #390/#371 established; this change relies on it and now pins it.
- **`goals` is in this same broken state already** — Ix-pro removed the command but `PRO_COMMANDS` still stubs it, so `ix goals` promises Pro something Pro does not have. Left alone here to keep this scoped to the collapse; worth a follow-up.

## Test plan

- [x] `npx vitest run` in `ix-cli` — 752 passed, 2 skipped, 0 failed
- [x] The new guard is not vacuous: restoring the `bugs` entry in `PRO_COMMANDS` makes *only* `stubs the collapsed 'bug list' subcommand, not a 'bugs' command` fail, with `expected 'The 'bugs' command requires Ix Pro.…' not to contain 'requires Ix Pro'`
- [x] `git diff --check` silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)