### PR TITLE
feat(mcp): serve Ix's tools over MCP as `ix mcp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,28 @@ The graph lives on your machine, and it persists — so context survives between
 sessions, and your assistant can navigate a real map of your system instead of
 re-deriving it from whatever fits in a prompt.
 
+### Use Ix from any MCP client
+
+The CLI includes a canonical stdio MCP server with the same graph tools used by
+the editor integrations:
+
+```bash
+ix mcp
+```
+
+Configure an MCP client to launch `ix` with the argument `mcp`. For Codex:
+
+```bash
+codex mcp add ix-memory -- ix mcp
+```
+
+The client launches the server in the active workspace, so every Ix tool uses
+that repository's graph and configuration.
+
+Tool calls run inside the server process. Set `IX_MCP_SUBPROCESS=1` to run each
+one as a separate `ix` child process instead — slower by roughly the CLI's
+startup time per call, but fully isolated.
+
 ## Sign up for Kartr
 
 We built Kartr on top of this technology.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,27 @@ the editor integrations:
 ix mcp
 ```
 
-Configure an MCP client to launch `ix` with the argument `mcp`. For Codex:
+To register it with every AI client on the machine at once:
+
+```bash
+ix mcp install            # detect clients and register `ix mcp` with each
+ix mcp install --dry-run  # show what would change, write nothing
+ix mcp doctor             # check each client's registration
+```
+
+`install` knows Claude Code, Codex, Cursor, VS Code, Gemini CLI, OpenClaw and
+opencode. It writes through each client's own MCP command where one exists
+(`claude mcp add`, `codex mcp add`, `gemini mcp add`, `openclaw mcp set`,
+`code --add-mcp`), so the client owns its config format; only Cursor and
+opencode are edited directly, and both are merged in place with a `.bak` kept
+alongside.
+
+**It never overwrites.** If the name `ix-memory` already belongs to a different
+server — an earlier Ix plugin, say — that client is reported and left exactly as
+it was. Pass `--force` to replace it, or `--host <id>` to limit the run.
+
+To register a single client by hand instead, point it at `ix` with the argument
+`mcp`. For Codex:
 
 ```bash
 codex mcp add ix-memory -- ix mcp

--- a/docs/mcp-plugin-consolidation.md
+++ b/docs/mcp-plugin-consolidation.md
@@ -1,0 +1,68 @@
+# Consolidating the per-host plugins onto `ix mcp`
+
+Ix ships six per-host plugin repos, each with its own tool implementation:
+`ix-claude-plugin`, `ix-codex-plugin`, `ix-cursor-plugin`, `ix-gemini-plugin`,
+`ix-openclaw-plugin`, `ix-opencode-plugin`. `ix mcp` serves the same graph tools
+from the CLI, so those implementations can be retired in favour of one server.
+
+This is what that costs and in what order it can happen.
+
+## What MCP can and cannot absorb
+
+Measured across the six repos (source only, excluding `node_modules` and `dist`):
+
+| Layer | Lines | Absorbed by `ix mcp`? |
+|---|---:|---|
+| Tool implementations (`mcp/`, `tools/`, `runtime/`) | ~15,300 | **Yes** |
+| Agents, hooks, skills, commands, rules | ~10,600 | **No** |
+
+MCP standardizes tools, resources and prompts. It has no concept of a hook, a
+skill, a slash command or a host instruction file, so roughly 40% of what the
+plugins do has no MCP equivalent and stays host-specific whatever else happens.
+Consolidation retires the tool layer; it does not retire the plugins.
+
+## Tool-surface parity
+
+The plugins never shared one tool surface. Measured against `ix mcp`:
+
+| Plugin | Tools | Tools `ix mcp` lacked |
+|---|---:|---|
+| ix-codex-plugin | 23 | — |
+| ix-cursor-plugin | 23 | — |
+| ix-gemini-plugin | 23 | `ix_decide`, `ix_ingest`, `ix_query`, `ix_status` |
+| ix-openclaw-plugin | 17 | `ix_decide`, `ix_docs_tool`, `ix_ingest`, `ix_neighbors`, `ix_query` |
+| ix-opencode-plugin | 17 | `ix_decide`, `ix_docs_tool`, `ix_ingest`, `ix_neighbors`, `ix_query` |
+| ix-claude-plugin | 0 (skills only) | — |
+
+`ix mcp` now closes that gap, with three deliberate exclusions:
+
+- **`ix_query`** — the deprecated command the CLI docs tell agents not to use
+  ("produces oversized low-signal responses"). Dropped on purpose.
+- **`ix_neighbors`** — a composite of `ix_callers` + `ix_callees` + `ix_depends`,
+  all served individually. Callers lose one round-trip, not a capability.
+- **`ix_docs_tool`** — a composite over `ix_overview`, likewise served.
+
+And `ix_status` is Gemini's name for what `ix mcp` calls `ix_health`; both run
+`ix status`.
+
+`ix_decide` and `ix_ingest` were real gaps and are now served. `ix_decide` is a
+write and needs Pro, so it is advertised only when `@ix/pro` resolves — as are
+`ix_briefing` and `ix_decisions`, which this server previously offered to every
+install even though every call answered "requires Ix Pro".
+
+**Net:** codex and cursor can delegate with no change in what an agent can do.
+gemini, openclaw and opencode lose only `ix_query` and the two composites.
+
+## Order of work
+
+1. **Ship `ix mcp` in a released `@ix/cli`.** Nothing downstream can depend on it
+   until then. The plugins already gate features on CLI version floors, so this
+   becomes a new floor.
+2. **Point each plugin's registration at `ix mcp`** instead of its own server,
+   and delete that server. Start with codex and cursor — those two are lossless.
+3. **Leave agents, hooks, skills and commands where they are.** They are the
+   plugins' remaining reason to exist.
+
+Step 2 is one PR per repo and each is independently revertible; a plugin that has
+not migrated keeps working, because `ix mcp install` refuses to take a name that
+another server already holds.

--- a/ix-cli/package-lock.json
+++ b/ix-cli/package-lock.json
@@ -8,9 +8,11 @@
       "name": "@ix/cli",
       "version": "0.9.2",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "chalk": "^6.0.0",
         "commander": "^15.0.0",
-        "yaml": "^2.4.0"
+        "yaml": "^2.4.0",
+        "zod": "^3.25.76"
       },
       "bin": {
         "ix": "dist/cli/main.js"
@@ -697,6 +699,18 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -790,6 +804,68 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -937,9 +1013,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -957,9 +1030,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -977,9 +1047,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -997,9 +1064,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1017,9 +1081,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1037,9 +1098,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1057,9 +1115,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1077,9 +1132,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1292,9 +1344,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1309,9 +1358,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1326,9 +1372,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1343,9 +1386,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1360,9 +1400,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1377,9 +1414,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1394,9 +1428,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1411,9 +1442,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1573,9 +1601,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1590,9 +1615,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1607,9 +1629,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1624,9 +1643,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1641,9 +1657,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1658,9 +1671,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1675,9 +1685,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1692,9 +1699,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1709,9 +1713,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1726,9 +1727,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1743,9 +1741,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1760,9 +1755,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1777,9 +1769,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2311,6 +2300,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2351,6 +2353,45 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2383,6 +2424,43 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
@@ -2394,6 +2472,44 @@
       },
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chai": {
@@ -2427,6 +2543,28 @@
         "node": ">=22.12.0"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2434,11 +2572,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2453,7 +2625,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2474,12 +2645,80 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -2522,6 +2761,12 @@
         "@esbuild/win32-ia32": "0.28.1",
         "@esbuild/win32-x64": "0.28.1"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2733,6 +2978,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2743,11 +3018,72 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -2763,6 +3099,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fd-package-json": {
       "version": "2.0.0",
@@ -2803,6 +3155,27 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -2859,6 +3232,24 @@
         "node": ">=18.3.0"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2872,6 +3263,52 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -2900,6 +3337,18 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2910,12 +3359,81 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -2935,6 +3453,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-extglob": {
@@ -2960,11 +3502,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -3016,6 +3563,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
@@ -3036,6 +3592,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -3091,6 +3653,16 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/knip/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/levn": {
@@ -3161,6 +3733,65 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -3181,7 +3812,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3210,6 +3840,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
@@ -3222,6 +3882,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/optionator": {
@@ -3343,6 +4024,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3357,10 +4047,19 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -3388,6 +4087,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/postcss": {
@@ -3445,6 +4153,19 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3453,6 +4174,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -3510,6 +4284,28 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
@@ -3523,11 +4319,61 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3540,10 +4386,81 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -3582,6 +4499,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "4.1.0",
@@ -3660,6 +4586,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -3711,6 +4646,37 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -3768,6 +4734,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3776,6 +4751,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -3957,7 +4941,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -3996,6 +4979,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
@@ -4025,13 +5014,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/ix-cli/package.json
+++ b/ix-cli/package.json
@@ -30,9 +30,11 @@
     "dev": "node scripts/build-core-ingestion.mjs && tsx src/cli/main.ts"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "chalk": "^6.0.0",
     "commander": "^15.0.0",
-    "yaml": "^2.4.0"
+    "yaml": "^2.4.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/ix-cli/src/cli/__tests__/help-coverage.test.ts
+++ b/ix-cli/src/cli/__tests__/help-coverage.test.ts
@@ -16,6 +16,7 @@ const REQUIRED_COMMANDS = [
   "search", "locate", "explain", "impact", "overview", "watch",
   "read", "inventory", "rank", "history", "diff", "smells", "subsystems",
   "map", "trace", "status", "stats", "doctor", "docker",
+  "mcp",
 ];
 
 describe("help coverage", () => {

--- a/ix-cli/src/cli/__tests__/mcp-install.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-install.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { classifyDefinition, classifyListing, type McpHost, type Registration } from "../../mcp/hosts.js";
+import { IX_MCP_OSS_TOOL_NAMES, IX_MCP_PRO_TOOL_NAMES } from "../../mcp/server.js";
 import { runDoctor, runInstall, writeJsonConfig } from "../../mcp/install.js";
 
 const scratch: string[] = [];
@@ -142,7 +143,12 @@ describe("ix mcp doctor", () => {
       "conflict",
       "already-registered",
     ]);
-    expect(report.toolCount).toBe(23);
+    // Pro is resolvable on some machines and not others, so the count is one
+    // of exactly two values rather than a fixed number.
+    expect([
+      IX_MCP_OSS_TOOL_NAMES.length,
+      IX_MCP_OSS_TOOL_NAMES.length + IX_MCP_PRO_TOOL_NAMES.length,
+    ]).toContain(report.toolCount);
   });
 });
 

--- a/ix-cli/src/cli/__tests__/mcp-install.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-install.test.ts
@@ -1,0 +1,239 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { classifyDefinition, classifyListing, type McpHost, type Registration } from "../../mcp/hosts.js";
+import { runDoctor, runInstall, writeJsonConfig } from "../../mcp/install.js";
+
+const scratch: string[] = [];
+
+afterEach(() => {
+  for (const dir of scratch.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "ix-mcp-install-"));
+  scratch.push(dir);
+  return dir;
+}
+
+/**
+ * `node` stands in for an installed host and a name that cannot exist stands in
+ * for a missing one, so the PATH probe runs for real rather than being stubbed.
+ */
+function fakeHost(
+  id: string,
+  registration: Registration,
+  options: { installed?: boolean; fails?: boolean } = {},
+): McpHost & { registerCalls: number } {
+  const host = {
+    id,
+    label: id,
+    bin: options.installed === false ? "definitely-not-a-real-binary-xyz" : "node",
+    target: `${id}-config`,
+    registerCalls: 0,
+    async inspect() {
+      return { registration };
+    },
+    async register() {
+      host.registerCalls += 1;
+      if (options.fails) throw new Error("host CLI said no");
+    },
+  };
+  return host;
+}
+
+describe("ix mcp install", () => {
+  it("registers a host whose name is free", async () => {
+    const host = fakeHost("free", "none");
+
+    const report = await runInstall({ hosts: [host] });
+
+    expect(host.registerCalls).toBe(1);
+    expect(report.hosts[0]).toMatchObject({ outcome: "registered", installed: true });
+    expect(report.registered).toBe(1);
+  });
+
+  it("never overwrites a name held by a different server", async () => {
+    const host = fakeHost("taken", "other");
+
+    const report = await runInstall({ hosts: [host] });
+
+    expect(host.registerCalls).toBe(0);
+    expect(report.hosts[0]?.outcome).toBe("conflict");
+    expect(report.conflicts).toBe(1);
+  });
+
+  it("treats an unreadable registration as occupied rather than free", async () => {
+    const host = fakeHost("murky", "unknown");
+
+    const report = await runInstall({ hosts: [host] });
+
+    // Guessing "free" here is the one wrong guess that destroys a config.
+    expect(host.registerCalls).toBe(0);
+    expect(report.hosts[0]?.outcome).toBe("conflict");
+  });
+
+  it("replaces a conflicting registration only when --force is given", async () => {
+    const host = fakeHost("taken", "other");
+
+    const report = await runInstall({ hosts: [host], force: true });
+
+    expect(host.registerCalls).toBe(1);
+    expect(report.hosts[0]?.outcome).toBe("registered");
+  });
+
+  it("is idempotent when the name already points at ix mcp", async () => {
+    const host = fakeHost("ours", "ours");
+
+    const report = await runInstall({ hosts: [host] });
+
+    expect(host.registerCalls).toBe(0);
+    expect(report.hosts[0]?.outcome).toBe("already-registered");
+  });
+
+  it("writes nothing under --dry-run", async () => {
+    const hosts = [fakeHost("a", "none"), fakeHost("b", "other")];
+
+    const report = await runInstall({ hosts, dryRun: true });
+
+    expect(hosts.map((h) => h.registerCalls)).toEqual([0, 0]);
+    expect(report.hosts.map((h) => h.outcome)).toEqual(["would-register", "conflict"]);
+  });
+
+  it("skips hosts that are not installed", async () => {
+    const host = fakeHost("absent", "none", { installed: false });
+
+    const report = await runInstall({ hosts: [host] });
+
+    expect(host.registerCalls).toBe(0);
+    expect(report.hosts[0]).toMatchObject({ outcome: "not-installed", installed: false });
+  });
+
+  it("reports a failing host without aborting the rest", async () => {
+    const hosts = [fakeHost("broken", "none", { fails: true }), fakeHost("fine", "none")];
+
+    const report = await runInstall({ hosts });
+
+    expect(report.hosts.map((h) => h.outcome)).toEqual(["failed", "registered"]);
+    expect(report.hosts[0]?.note).toContain("host CLI said no");
+  });
+
+  it("honours the host filter", async () => {
+    const hosts = [fakeHost("a", "none"), fakeHost("b", "none")];
+
+    const report = await runInstall({ hosts, only: ["b"] });
+
+    expect(report.hosts.map((h) => h.id)).toEqual(["b"]);
+    expect(hosts[0]!.registerCalls).toBe(0);
+  });
+});
+
+describe("ix mcp doctor", () => {
+  it("separates a free name from one held by someone else", async () => {
+    const report = await runDoctor({
+      hosts: [fakeHost("free", "none"), fakeHost("taken", "other"), fakeHost("ours", "ours")],
+    });
+
+    expect(report.hosts.map((h) => h.outcome)).toEqual([
+      "not-registered",
+      "conflict",
+      "already-registered",
+    ]);
+    expect(report.toolCount).toBe(23);
+  });
+});
+
+describe("writeJsonConfig", () => {
+  it("keeps every unrelated key and backs up what was there", () => {
+    const dir = tempDir();
+    const path = join(dir, "opencode.json");
+    writeFileSync(path, JSON.stringify({ $schema: "x", plugin: ["./p.ts"] }, null, 2));
+
+    writeJsonConfig(path, (config) => {
+      (config.mcp as unknown) = { "ix-memory": { type: "local", command: ["ix", "mcp"] } };
+    });
+
+    const written = JSON.parse(readFileSync(path, "utf8"));
+    expect(written.$schema).toBe("x");
+    expect(written.plugin).toEqual(["./p.ts"]);
+    expect(written.mcp["ix-memory"].command).toEqual(["ix", "mcp"]);
+    expect(JSON.parse(readFileSync(`${path}.bak`, "utf8"))).toEqual({ $schema: "x", plugin: ["./p.ts"] });
+  });
+
+  it("creates the file and its directory when absent", () => {
+    const path = join(tempDir(), "nested", "mcp.json");
+
+    writeJsonConfig(path, (config) => {
+      (config.mcpServers as unknown) = { "ix-memory": { command: "ix", args: ["mcp"] } };
+    });
+
+    expect(JSON.parse(readFileSync(path, "utf8")).mcpServers["ix-memory"].command).toBe("ix");
+    // Nothing was replaced, so there is nothing to back up.
+    expect(existsSync(`${path}.bak`)).toBe(false);
+  });
+
+  it("treats a zero-byte file as empty rather than corrupt", () => {
+    const path = join(tempDir(), "mcp.json");
+    // The state VS Code ships this file in until something writes it.
+    writeFileSync(path, "");
+
+    writeJsonConfig(path, (config) => {
+      (config.servers as unknown) = { "ix-memory": { command: "ix" } };
+    });
+
+    expect(JSON.parse(readFileSync(path, "utf8")).servers["ix-memory"].command).toBe("ix");
+  });
+
+  it("refuses to overwrite a file it cannot parse", () => {
+    const path = join(tempDir(), "mcp.json");
+    writeFileSync(path, "{ this is not json");
+
+    expect(() => writeJsonConfig(path, () => {})).toThrow(/not valid JSON/);
+    // The user's content must still be there after the refusal.
+    expect(readFileSync(path, "utf8")).toBe("{ this is not json");
+  });
+});
+
+describe("registration classification", () => {
+  it("reads a codex table row pointing at ix mcp as ours", () => {
+    expect(classifyListing("ix-memory  ix  mcp  -  -  enabled").registration).toBe("ours");
+  });
+
+  it("reads the bespoke python server under the same name as someone else's", () => {
+    const listing = "ix-memory  python3  /home/u/.codex/mcp/server.py  -  -  enabled";
+
+    expect(classifyListing(listing).registration).toBe("other");
+  });
+
+  it("ignores loader diagnostics that happen to name the server", () => {
+    // Gemini prints ~28 lines of these before the listing, and its extension is
+    // itself called ix-memory.
+    const listing = [
+      "[ExtensionManager] Error loading agent from ix-memory: Failed to load agent",
+      "tools.0: Invalid tool name",
+      "Configured MCP servers:",
+      "✗ ix-memory (from ix-memory): node dist/server.js (stdio) - Disconnected",
+    ].join("\n");
+
+    expect(classifyListing(listing)).toMatchObject({
+      registration: "other",
+      detail: expect.stringContaining("node dist/server.js"),
+    });
+  });
+
+  it("reports nothing registered when the name never appears", () => {
+    expect(classifyListing("some-other-server: npx thing").registration).toBe("none");
+  });
+
+  it("recognises a pretty-printed definition split across lines", () => {
+    // `openclaw mcp show` puts "ix" and "mcp" on separate lines; matching one
+    // line at a time reads our own entry as a stranger's.
+    const shown = 'MCP server "ix-memory":\n{\n  "command": "ix",\n  "args": [\n    "mcp"\n  ]\n}';
+
+    expect(classifyDefinition(shown).registration).toBe("ours");
+    expect(classifyListing(shown).registration).toBe("other");
+  });
+});

--- a/ix-cli/src/cli/__tests__/mcp-install.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-install.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -200,6 +200,32 @@ describe("writeJsonConfig", () => {
     expect(() => writeJsonConfig(path, () => {})).toThrow(/not valid JSON/);
     // The user's content must still be there after the refusal.
     expect(readFileSync(path, "utf8")).toBe("{ this is not json");
+  });
+
+  // Needs a read to fail where the write would have succeeded. Permission bits
+  // give that only on POSIX and only for a non-root caller: root bypasses them,
+  // and on Windows chmod moves the read-only flag, which blocks the write too.
+  const readCanFailAlone =
+    process.platform !== "win32" && typeof process.getuid === "function" && process.getuid() !== 0;
+
+  it.skipIf(!readCanFailAlone)("surfaces an unreadable config instead of overwriting it", () => {
+    // Write-only: the read fails, the write would go through. That is the one
+    // shape where collapsing "unreadable" into "absent" is destructive — the
+    // mkdir-and-write branch replaces a config we never managed to read, and
+    // leaves no `.bak`, because the copy only runs on the branch that read one.
+    const path = join(tempDir(), "mcp.json");
+    writeFileSync(path, JSON.stringify({ mcpServers: { theirs: { command: "other" } } }));
+    chmodSync(path, 0o200);
+
+    expect(() =>
+      writeJsonConfig(path, (config) => {
+        (config.mcpServers as unknown) = { "ix-memory": { command: "ix" } };
+      }),
+    ).toThrow(/EACCES/);
+
+    chmodSync(path, 0o600);
+    expect(JSON.parse(readFileSync(path, "utf8")).mcpServers.theirs.command).toBe("other");
+    expect(existsSync(`${path}.bak`)).toBe(false);
   });
 });
 

--- a/ix-cli/src/cli/__tests__/mcp-runner.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-runner.test.ts
@@ -1,0 +1,198 @@
+import { Command } from "commander";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createInProcessRunner, resolveDefaultRunner, runCurrentIx } from "../../mcp/runner.js";
+
+/**
+ * A stand-in command tree. The capture machinery is what is under test here,
+ * not the Ix commands, and a real one would need a backend.
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program.name("ix").version("test-version").exitOverride();
+
+  program
+    .command("say")
+    .argument("<text>")
+    .option("--path <path>", "optional scope")
+    .action((text: string, opts: { path?: string }) => {
+      console.log(`out:${text}${opts.path ? ` path:${opts.path}` : ""}`);
+    });
+
+  program
+    .command("boom")
+    .action(() => {
+      console.error("fatal detail");
+      // The shape `ix status` and `ix text` use on their error paths.
+      process.exit(1);
+    });
+
+  program
+    .command("soft-fail")
+    .action(() => {
+      console.log("error code=backend_error message=offline");
+      // The shape most commands use: report on stdout, flag via exitCode.
+      process.exitCode = 1;
+    });
+
+  program
+    .command("slow")
+    .option("--delay <ms>", "how long to run past the caller's patience", "5000")
+    .option("--tag <tag>", "marker identifying which invocation printed", "slow")
+    .action(async (opts: { delay: string; tag: string }) => {
+      await new Promise((resolve) => setTimeout(resolve, Number(opts.delay)));
+      console.log(`done:${opts.tag}`);
+    });
+
+  program
+    .command("flood")
+    .action(() => {
+      for (let i = 0; i < 20; i += 1) console.log("x".repeat(100));
+    });
+
+  return program;
+}
+
+function testRunner() {
+  return createInProcessRunner({ version: "test-version", createProgram: createTestProgram });
+}
+
+const originalSubprocessFlag = process.env.IX_MCP_SUBPROCESS;
+
+afterEach(() => {
+  if (originalSubprocessFlag === undefined) delete process.env.IX_MCP_SUBPROCESS;
+  else process.env.IX_MCP_SUBPROCESS = originalSubprocessFlag;
+});
+
+describe("in-process ix runner", () => {
+  it("captures command stdout instead of writing it to the process", async () => {
+    const run = testRunner();
+
+    const result = await run(["say", "hello"]);
+
+    expect(result).toEqual({ ok: true, stdout: "out:hello\n", stderr: "" });
+  });
+
+  it("turns a command's process.exit into a failed result without exiting", async () => {
+    const run = testRunner();
+
+    const result = await run(["boom"]);
+
+    expect(result.ok).toBe(false);
+    expect(result.stderr).toContain("fatal detail");
+    // Reaching this line at all is the assertion that matters: a real
+    // process.exit here would have taken the MCP server down.
+    expect(await run(["say", "still alive"])).toMatchObject({ ok: true });
+  });
+
+  it("reports process.exitCode failures and leaves the host exit code alone", async () => {
+    const run = testRunner();
+    process.exitCode = undefined;
+
+    const result = await run(["soft-fail"]);
+
+    expect(result.ok).toBe(false);
+    expect(result.stdout).toBe("error code=backend_error message=offline\n");
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("does not leak option values from one run into the next", async () => {
+    const run = testRunner();
+
+    const scoped = await run(["say", "a", "--path", "src/mcp"]);
+    const unscoped = await run(["say", "b"]);
+
+    expect(scoped.stdout).toBe("out:a path:src/mcp\n");
+    // Commander keeps parsed values on the Command object, so a cached program
+    // would answer "out:b path:src/mcp" here.
+    expect(unscoped.stdout).toBe("out:b\n");
+  });
+
+  it("keeps concurrent calls' output and exit status separate", async () => {
+    const run = testRunner();
+
+    const [first, second, third] = await Promise.all([
+      run(["say", "one"]),
+      run(["soft-fail"]),
+      run(["say", "three"]),
+    ]);
+
+    expect(first).toEqual({ ok: true, stdout: "out:one\n", stderr: "" });
+    expect(second.ok).toBe(false);
+    expect(third).toEqual({ ok: true, stdout: "out:three\n", stderr: "" });
+  });
+
+  it("fails a run that outlives its timeout", async () => {
+    const run = testRunner();
+
+    const result = await run(["slow"], 50);
+
+    expect(result.ok).toBe(false);
+    expect(result.stderr).toContain("timed out after 50ms");
+  });
+
+  it("stays usable after a timeout rather than stranding the queue", async () => {
+    const run = testRunner();
+
+    await run(["slow"], 50);
+
+    expect(await run(["say", "after"])).toMatchObject({ ok: true, stdout: "out:after\n" });
+  });
+
+  it("keeps a timed-out command's late output out of the next call's result", async () => {
+    const run = testRunner();
+
+    // Abandoned at 50ms but still printing at ~150ms.
+    const timedOut = await run(["slow", "--delay", "150", "--tag", "orphan"], 50);
+    // Starts once the queue advances (~50ms) and is still running at ~150ms,
+    // so it is the call the orphan's write would otherwise be misfiled into.
+    const covering = await run(["slow", "--delay", "250", "--tag", "covering"], 5_000);
+
+    expect(timedOut.ok).toBe(false);
+    expect(covering).toEqual({ ok: true, stdout: "done:covering\n", stderr: "" });
+  });
+
+  it("truncates output instead of growing the server heap without bound", async () => {
+    const run = createInProcessRunner({
+      createProgram: createTestProgram,
+      maxOutputBytes: 500,
+    });
+
+    const result = await run(["flood"]);
+
+    expect(result.stdout.length).toBeLessThanOrEqual(500);
+    expect(result.stderr).toContain("exceeded 500 bytes and was truncated");
+  });
+
+  it("reports an unknown command as a failure with commander's message", async () => {
+    const run = testRunner();
+
+    const result = await run(["not-a-command"]);
+
+    expect(result.ok).toBe(false);
+    expect(result.stderr).toContain("not-a-command");
+  });
+
+  it("treats --version as a success rather than a usage error", async () => {
+    const run = testRunner();
+
+    const result = await run(["--version"]);
+
+    expect(result.ok).toBe(true);
+    expect(result.stdout).toContain("test-version");
+  });
+});
+
+describe("resolveDefaultRunner", () => {
+  it("runs in-process by default", () => {
+    delete process.env.IX_MCP_SUBPROCESS;
+
+    expect(resolveDefaultRunner({ createProgram: createTestProgram })).not.toBe(runCurrentIx);
+  });
+
+  it("falls back to the child process when IX_MCP_SUBPROCESS=1", () => {
+    process.env.IX_MCP_SUBPROCESS = "1";
+
+    expect(resolveDefaultRunner({ createProgram: createTestProgram })).toBe(runCurrentIx);
+  });
+});

--- a/ix-cli/src/cli/__tests__/mcp.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp.test.ts
@@ -1,0 +1,131 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createIxMcpServer, IX_MCP_TOOL_NAMES, type IxRunner } from "../../mcp/server.js";
+
+const clients: Client[] = [];
+
+afterEach(async () => {
+  await Promise.all(clients.splice(0).map((client) => client.close()));
+});
+
+async function connect(runIx: IxRunner): Promise<Client> {
+  const server = createIxMcpServer({ version: "test", runIx });
+  const client = new Client({ name: "ix-mcp-test", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  clients.push(client);
+  return client;
+}
+
+describe("ix mcp", () => {
+  it("exposes one canonical tool catalog", async () => {
+    const client = await connect(async () => ({ ok: true, stdout: "ok", stderr: "" }));
+
+    const result = await client.listTools();
+
+    expect(result.tools.map((tool) => tool.name)).toEqual(IX_MCP_TOOL_NAMES);
+  });
+
+  it("maps tool input to the matching Ix command with compact output", async () => {
+    const calls: string[][] = [];
+    const client = await connect(async (args) => {
+      calls.push(args);
+      return { ok: true, stdout: "match name=Widget", stderr: "" };
+    });
+
+    const result = await client.callTool({
+      name: "ix_locate",
+      arguments: { symbol: "Widget" },
+    });
+
+    expect(calls).toEqual([["locate", "Widget", "--format", "llm"]]);
+    expect(result.content).toEqual([{ type: "text", text: "match name=Widget" }]);
+  });
+
+  it("marks Ix command failures as MCP errors", async () => {
+    const client = await connect(async () => ({
+      ok: false,
+      stdout: "",
+      stderr: "Session expired",
+    }));
+
+    const result = await client.callTool({ name: "ix_stats", arguments: {} });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: JSON.stringify({ error: "Session expired", tool: "ix_stats" }),
+      },
+    ]);
+  });
+
+  it("preserves structured CLI errors written to stdout", async () => {
+    const client = await connect(async () => ({
+      ok: false,
+      stdout: "error code=backend_unreachable message=offline",
+      stderr: "",
+    }));
+
+    const result = await client.callTool({ name: "ix_health", arguments: {} });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: JSON.stringify({
+          error: "error code=backend_unreachable message=offline",
+          tool: "ix_health",
+        }),
+      },
+    ]);
+  });
+
+  it("keeps the existing ix_map file argument contract", async () => {
+    const calls: string[][] = [];
+    const client = await connect(async (args) => {
+      calls.push(args);
+      return { ok: true, stdout: "{}", stderr: "" };
+    });
+
+    await client.callTool({ name: "ix_map", arguments: { file: "src/service.ts" } });
+
+    expect(calls).toEqual([["map", "src/service.ts", "--format", "json"]]);
+  });
+
+  it("applies ix_smells path and limit compatibility without unsupported CLI flags", async () => {
+    const calls: string[][] = [];
+    const client = await connect(async (args) => {
+      calls.push(args);
+      return {
+        ok: true,
+        stdout: JSON.stringify({
+          count: 3,
+          candidates: [
+            { file: "src/a.ts", smell: "orphan" },
+            { file: "src/nested/b.ts", smell: "orphan" },
+            { file: "test/c.ts", smell: "orphan" },
+          ],
+        }),
+        stderr: "",
+      };
+    });
+
+    const result = await client.callTool({
+      name: "ix_smells",
+      arguments: { path: "src", limit: 1 },
+    });
+
+    expect(calls).toEqual([["smells", "--format", "json"]]);
+    const content = (result as CallToolResult).content[0];
+    expect(content?.type).toBe("text");
+    const parsed = JSON.parse(content?.type === "text" ? content.text : "{}");
+    expect(parsed.count).toBe(1);
+    expect(parsed.candidates).toEqual([{ file: "src/a.ts", smell: "orphan" }]);
+  });
+});

--- a/ix-cli/src/cli/__tests__/mcp.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp.test.ts
@@ -3,7 +3,13 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { createIxMcpServer, IX_MCP_TOOL_NAMES, type IxRunner } from "../../mcp/server.js";
+import {
+  createIxMcpServer,
+  IX_MCP_OSS_TOOL_NAMES,
+  IX_MCP_PRO_TOOL_NAMES,
+  IX_MCP_TOOL_NAMES,
+  type IxRunner,
+} from "../../mcp/server.js";
 
 const clients: Client[] = [];
 
@@ -11,8 +17,8 @@ afterEach(async () => {
   await Promise.all(clients.splice(0).map((client) => client.close()));
 });
 
-async function connect(runIx: IxRunner): Promise<Client> {
-  const server = createIxMcpServer({ version: "test", runIx });
+async function connect(runIx: IxRunner, proAvailable = false): Promise<Client> {
+  const server = createIxMcpServer({ version: "test", runIx, proAvailable });
   const client = new Client({ name: "ix-mcp-test", version: "1.0.0" });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
@@ -23,12 +29,38 @@ async function connect(runIx: IxRunner): Promise<Client> {
 }
 
 describe("ix mcp", () => {
-  it("exposes one canonical tool catalog", async () => {
+  it("exposes only the OSS catalog when Pro is not installed", async () => {
     const client = await connect(async () => ({ ok: true, stdout: "ok", stderr: "" }));
 
     const result = await client.listTools();
 
+    // Advertising a Pro tool on an OSS install hands the agent something whose
+    // every call answers "requires Ix Pro" — indistinguishable from a failure.
+    expect(result.tools.map((tool) => tool.name)).toEqual(IX_MCP_OSS_TOOL_NAMES);
+    for (const pro of IX_MCP_PRO_TOOL_NAMES) {
+      expect(result.tools.map((tool) => tool.name)).not.toContain(pro);
+    }
+  });
+
+  it("adds the Pro catalog when Pro is installed", async () => {
+    const client = await connect(async () => ({ ok: true, stdout: "ok", stderr: "" }), true);
+
+    const result = await client.listTools();
+
     expect(result.tools.map((tool) => tool.name)).toEqual(IX_MCP_TOOL_NAMES);
+  });
+
+  it("covers every plugin tool that is not a composite or deprecated", async () => {
+    const client = await connect(async () => ({ ok: true, stdout: "ok", stderr: "" }), true);
+    const names = (await client.listTools()).tools.map((tool) => tool.name);
+
+    // The union exposed by ix-codex/cursor/gemini/openclaw/opencode-plugin,
+    // less ix_query (deprecated), ix_neighbors and ix_docs_tool (composites of
+    // callers/callees/depends and of overview), and ix_status (gemini's name
+    // for ix_health).
+    for (const tool of ["ix_decide", "ix_ingest", "ix_health", "ix_locate", "ix_impact"]) {
+      expect(names).toContain(tool);
+    }
   });
 
   it("maps tool input to the matching Ix command with compact output", async () => {
@@ -127,5 +159,47 @@ describe("ix mcp", () => {
     const parsed = JSON.parse(content?.type === "text" ? content.text : "{}");
     expect(parsed.count).toBe(1);
     expect(parsed.candidates).toEqual([{ file: "src/a.ts", smell: "orphan" }]);
+  });
+
+  it("maps ix_ingest onto the github form the plugins used", async () => {
+    const calls: string[][] = [];
+    const client = await connect(async (args) => {
+      calls.push(args);
+      return { ok: true, stdout: "{}", stderr: "" };
+    });
+
+    await client.callTool({ name: "ix_ingest", arguments: { github: "owner/repo", limit: 25 } });
+
+    expect(calls).toEqual([["ingest", "--github", "owner/repo", "--limit", "25", "--format", "json"]]);
+  });
+
+  it("does not pass --limit when ingesting a local path", async () => {
+    const calls: string[][] = [];
+    const client = await connect(async (args) => {
+      calls.push(args);
+      return { ok: true, stdout: "{}", stderr: "" };
+    });
+
+    await client.callTool({ name: "ix_ingest", arguments: { path: "src" } });
+
+    // --limit is a GitHub paging cap; on a path ingest it is meaningless.
+    expect(calls).toEqual([["ingest", "src", "--format", "json"]]);
+  });
+
+  it("maps ix_decide onto the decide command", async () => {
+    const calls: string[][] = [];
+    const client = await connect(async (args) => {
+      calls.push(args);
+      return { ok: true, stdout: "{}", stderr: "" };
+    }, true);
+
+    await client.callTool({
+      name: "ix_decide",
+      arguments: { title: "Use CONTAINS", rationale: "Normalize edges", affects: "Ingestion" },
+    });
+
+    expect(calls).toEqual([
+      ["decide", "Use CONTAINS", "--rationale", "Normalize edges", "--affects", "Ingestion", "--format", "json"],
+    ]);
   });
 });

--- a/ix-cli/src/cli/commands/mcp.ts
+++ b/ix-cli/src/cli/commands/mcp.ts
@@ -1,0 +1,12 @@
+import type { Command } from "commander";
+
+export function registerMcpCommand(program: Command): void {
+  program
+    .command("mcp")
+    .description("Serve Ix tools over the Model Context Protocol (stdio)")
+    .action(async () => {
+      // Keep the SDK off the startup path for ordinary CLI commands.
+      const { startIxMcpServer } = await import("../../mcp/server.js");
+      await startIxMcpServer(program.version());
+    });
+}

--- a/ix-cli/src/cli/commands/mcp.ts
+++ b/ix-cli/src/cli/commands/mcp.ts
@@ -1,12 +1,131 @@
 import type { Command } from "commander";
+import chalk from "chalk";
+
+import { llmLine, type LlmValue } from "../llm.js";
+import type { DoctorReport, HostReport, InstallReport, Outcome } from "../../mcp/install.js";
+
+/** Symbol and colour per outcome, shared by install and doctor. */
+const OUTCOME_STYLE: Record<Outcome, { mark: string; paint: (text: string) => string }> = {
+  registered: { mark: "+", paint: chalk.green },
+  "would-register": { mark: "+", paint: chalk.cyan },
+  "already-registered": { mark: "=", paint: chalk.dim },
+  conflict: { mark: "!", paint: chalk.yellow },
+  failed: { mark: "x", paint: chalk.red },
+  "not-registered": { mark: "o", paint: chalk.yellow },
+  "not-installed": { mark: "-", paint: chalk.dim },
+};
+
+const OUTCOME_TEXT: Record<Outcome, string> = {
+  registered: "registered",
+  "would-register": "would register",
+  "already-registered": "already registered",
+  conflict: "conflict — left alone",
+  failed: "failed",
+  "not-registered": "not registered",
+  "not-installed": "not installed",
+};
+
+function renderHostLine(host: HostReport): string {
+  const style = OUTCOME_STYLE[host.outcome];
+  const label = host.label.padEnd(13);
+  const line = `  ${style.mark} ${label} ${OUTCOME_TEXT[host.outcome]}`;
+  return style.paint(line) + (host.note ? chalk.dim(`\n      ${host.note}`) : "");
+}
+
+function hostFields(host: HostReport): Array<[string, LlmValue]> {
+  return [
+    ["host", host.id],
+    ["outcome", host.outcome],
+    ["installed", host.installed],
+    ["registration", host.registration],
+    ["note", host.note],
+  ];
+}
+
+function renderInstall(report: InstallReport, format: string, dryRun: boolean): void {
+  if (format === "json") {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+  if (format === "llm") {
+    for (const host of report.hosts) console.log(llmLine("host", hostFields(host)));
+    console.log(llmLine("summary", [["registered", report.registered], ["conflicts", report.conflicts]]));
+    return;
+  }
+
+  console.log(chalk.bold(dryRun ? "\nix mcp install --dry-run" : "\nix mcp install"));
+  for (const host of report.hosts) console.log(renderHostLine(host));
+
+  const conflicts = report.hosts.filter((host) => host.outcome === "conflict");
+  if (conflicts.length > 0) {
+    console.log(
+      chalk.dim(
+        `\n  ${conflicts.length} host(s) already use the name '${chalk.bold("ix-memory")}' for a different server.` +
+          `\n  Nothing was changed there. Re-run with --force to replace them.`,
+      ),
+    );
+  }
+  console.log();
+}
+
+function renderDoctor(report: DoctorReport, format: string): void {
+  if (format === "json") {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+  if (format === "llm") {
+    console.log(llmLine("server", [["ix_on_path", report.ixOnPath], ["tools", report.toolCount]]));
+    for (const host of report.hosts) console.log(llmLine("host", hostFields(host)));
+    return;
+  }
+
+  console.log(chalk.bold("\nix mcp doctor"));
+  console.log(
+    report.ixOnPath
+      ? chalk.green(`  + ix on PATH`) + chalk.dim(`  (hosts launch the bare command \`ix\`)`)
+      : chalk.red(`  x ix is NOT on PATH`) +
+          chalk.dim(`\n      Every registration launches \`ix mcp\` and will fail until it resolves.`),
+  );
+  console.log(chalk.dim(`  ${report.toolCount} tools advertised`));
+  console.log();
+  for (const host of report.hosts) console.log(renderHostLine(host));
+  console.log();
+}
 
 export function registerMcpCommand(program: Command): void {
-  program
+  const mcp = program
     .command("mcp")
     .description("Serve Ix tools over the Model Context Protocol (stdio)")
     .action(async () => {
       // Keep the SDK off the startup path for ordinary CLI commands.
       const { startIxMcpServer } = await import("../../mcp/server.js");
       await startIxMcpServer(program.version());
+    });
+
+  mcp
+    .command("install")
+    .description("Register `ix mcp` with the AI clients installed on this machine")
+    .option("--host <ids...>", "Only these hosts (claude, codex, cursor, vscode, gemini, openclaw, opencode)")
+    .option("--dry-run", "Report what would change without writing anything", false)
+    .option("--force", "Replace a registration held by a different server", false)
+    .option("--format <fmt>", "Output format (text|json|llm)", "text")
+    .action(async (opts: { host?: string[]; dryRun: boolean; force: boolean; format: string }) => {
+      const { runInstall } = await import("../../mcp/install.js");
+      const report = await runInstall({ only: opts.host, dryRun: opts.dryRun, force: opts.force });
+      renderInstall(report, opts.format, opts.dryRun);
+      if (report.hosts.some((host) => host.outcome === "failed")) process.exitCode = 1;
+    });
+
+  mcp
+    .command("doctor")
+    .description("Check that `ix mcp` is registered and launchable from each client")
+    .option("--host <ids...>", "Only these hosts")
+    .option("--format <fmt>", "Output format (text|json|llm)", "text")
+    .action(async (opts: { host?: string[]; format: string }) => {
+      const { runDoctor } = await import("../../mcp/install.js");
+      const report = await runDoctor({ only: opts.host });
+      renderDoctor(report, opts.format);
+      const broken = report.hosts.some((host) => host.outcome === "conflict" || host.outcome === "not-registered");
+      if (!report.ixOnPath || broken) process.exitCode = 1;
     });
 }

--- a/ix-cli/src/cli/help-text.ts
+++ b/ix-cli/src/cli/help-text.ts
@@ -29,6 +29,7 @@ const OSS_HELP = [
   `  status                Check status`,
   `  stats                 Show stats`,
   `  doctor                Diagnose issues`,
+  `  mcp                   Serve agent tools`,
   `  docker <action>       Manage backend`,
   `  view                  Open visualizer`,
   `  reset                 Reset map`,

--- a/ix-cli/src/cli/help-text.ts
+++ b/ix-cli/src/cli/help-text.ts
@@ -29,7 +29,7 @@ const OSS_HELP = [
   `  status                Check status`,
   `  stats                 Show stats`,
   `  doctor                Diagnose issues`,
-  `  mcp                   Serve agent tools`,
+  `  mcp [install|doctor]  Serve agent tools over MCP`,
   `  docker <action>       Manage backend`,
   `  view                  Open visualizer`,
   `  reset                 Reset map`,

--- a/ix-cli/src/cli/main.ts
+++ b/ix-cli/src/cli/main.ts
@@ -85,7 +85,7 @@ registerOssCommands(program);
 
   // Check for updates (non-blocking, cached 1hr) — skip for upgrade command itself
   const args = process.argv.slice(2);
-  if (args[0] !== "upgrade") {
+  if (args[0] !== "upgrade" && args[0] !== "mcp" && process.env.IX_MCP_CHILD !== "1") {
     // Deliberately not awaited — but it must still be caught here. The catch
     // inside checkForUpdate only guards its inner fetch chain; the function's
     // own promise covers the synchronous cached-read path, and a corrupt

--- a/ix-cli/src/cli/register/oss.ts
+++ b/ix-cli/src/cli/register/oss.ts
@@ -35,6 +35,7 @@ import { registerUpgradeCommand } from "../commands/upgrade.js";
 import { registerViewCommand } from "../commands/view.js";
 import { registerSavingsCommand } from "../commands/savings.js";
 import { registerPatchesCommand } from "../commands/patches.js";
+import { registerMcpCommand } from "../commands/mcp.js";
 
 const PRO_COMMANDS: { name: string; desc: string }[] = [
   { name: "briefing", desc: "Session-resume briefing" },
@@ -100,6 +101,7 @@ export function registerOssCommands(program: Command): void {
   registerViewCommand(program);
   registerSavingsCommand(program);
   registerPatchesCommand(program);
+  registerMcpCommand(program);
 
   // Hide advanced commands from default help
   const advancedSet = new Set(ADVANCED_COMMANDS);

--- a/ix-cli/src/mcp/hosts.ts
+++ b/ix-cli/src/mcp/hosts.ts
@@ -1,0 +1,357 @@
+import { execFile } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/** The name `ix mcp` registers itself under in every host. */
+export const SERVER_NAME = "ix-memory";
+
+/**
+ * How long a host's own CLI gets to answer. `claude mcp list` health-checks
+ * every configured server before printing, which measured ~1.8s here, so this
+ * is generous enough for the slowest of them without hanging `ix mcp doctor`
+ * on a host that is wedged.
+ */
+const HOST_CLI_TIMEOUT_MS = 20_000;
+
+/** What a host currently has registered under {@link SERVER_NAME}. */
+export type Registration =
+  | "none" // nothing under our name; safe to add
+  | "ours" // already points at `ix mcp`; nothing to do
+  | "other" // a different server holds the name — never overwrite without --force
+  | "unknown"; // could not tell, so treat it as occupied
+
+export interface HostStatus {
+  id: string;
+  label: string;
+  installed: boolean;
+  registration: Registration;
+  /** What was found, for the human-readable report. */
+  detail?: string;
+}
+
+export interface McpHost {
+  id: string;
+  label: string;
+  /** Executable whose presence on PATH means the host is installed. */
+  bin: string;
+  /** Read-only look at what holds {@link SERVER_NAME} today. */
+  inspect(): Promise<Pick<HostStatus, "registration" | "detail">>;
+  /** Register `ix mcp`. Only called once inspect reports it is safe. */
+  register(): Promise<void>;
+  /** Where the registration lands, shown in the report. */
+  target: string;
+}
+
+interface RunResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+async function run(bin: string, args: string[]): Promise<RunResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync(bin, args, {
+      encoding: "utf8",
+      timeout: HOST_CLI_TIMEOUT_MS,
+      windowsHide: true,
+    });
+    return { ok: true, stdout, stderr };
+  } catch (error) {
+    const failure = error as Error & { stdout?: string; stderr?: string };
+    return { ok: false, stdout: failure.stdout ?? "", stderr: failure.stderr ?? failure.message };
+  }
+}
+
+export async function isOnPath(bin: string): Promise<boolean> {
+  const probe = platform() === "win32" ? "where" : "which";
+  return (await run(probe, [bin])).ok;
+}
+
+/**
+ * Lines that mention a server name only because something went wrong.
+ *
+ * Gemini writes its whole listing to stderr behind ~28 lines of extension
+ * loader errors, several of which name the extension — and the extension here
+ * is itself called `ix-memory`. Matching one of those instead of the listing
+ * row reports a diagnostic as though it were the registration.
+ */
+const LOG_LINE = /^\[|^\s*(error|warning|warn|failed|validation)\b|Error:|Failed to|Validation failed/i;
+
+/**
+ * Decide what a host's own listing says about our name.
+ *
+ * Whether the matching line is ours is judged by whether it invokes the `ix`
+ * binary — the bespoke integrations register this same name against
+ * `python3 .../server.py` or `node dist/server.js`, and those must read as
+ * `other` so they are reported rather than replaced.
+ */
+export function classifyListing(listing: string): Pick<HostStatus, "registration" | "detail"> {
+  const matches = listing
+    .split("\n")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.includes(SERVER_NAME));
+
+  if (matches.length === 0) return { registration: "none" };
+
+  // The listing is printed after any warm-up noise, so among the lines that are
+  // not obviously diagnostics the last is the real row.
+  const candidates = matches.filter((entry) => !LOG_LINE.test(entry));
+  const line = candidates.at(-1) ?? matches[0]!;
+
+  return judge(line);
+}
+
+/**
+ * Classify a multi-line server definition.
+ *
+ * `openclaw mcp show` pretty-prints JSON, which puts `"command": "ix"` and
+ * `"mcp"` on separate lines — line-at-a-time matching reads our own
+ * registration as a stranger's and reports a false conflict on every re-run.
+ */
+export function classifyDefinition(blob: string): Pick<HostStatus, "registration" | "detail"> {
+  return judge(blob.replace(/\s+/g, " ").trim());
+}
+
+/** Ours iff the entry invokes the `ix` binary with the `mcp` subcommand. */
+function judge(text: string): Pick<HostStatus, "registration" | "detail"> {
+  if (/(^|[\s"'/\\])ix(\.\w+)?([\s"',\]]|$)/.test(text) && /\bmcp\b/.test(text)) {
+    return { registration: "ours", detail: truncate(text) };
+  }
+  return { registration: "other", detail: truncate(text) };
+}
+
+function truncate(line: string, max = 120): string {
+  return line.length <= max ? line : `${line.slice(0, max - 1)}…`;
+}
+
+/** A host that answers both questions through its own CLI. */
+function cliHost(spec: {
+  id: string;
+  label: string;
+  bin: string;
+  target: string;
+  listArgs: string[];
+  addArgs: string[];
+  /**
+   * Preferred over `listArgs` where the host can print one server's full
+   * definition. A listing that shows only names cannot say whether the entry
+   * is ours.
+   */
+  showArgs?: string[];
+}): McpHost {
+  return {
+    id: spec.id,
+    label: spec.label,
+    bin: spec.bin,
+    target: spec.target,
+    async inspect() {
+      if (spec.showArgs) {
+        const shown = await run(spec.bin, spec.showArgs);
+        const blob = `${shown.stdout}\n${shown.stderr}`;
+        // "No MCP server named X" also mentions the name and also exits 0, so
+        // presence of a definition body is what distinguishes the two.
+        if (!blob.includes(SERVER_NAME) || !blob.includes("{")) return { registration: "none" };
+        return classifyDefinition(blob);
+      }
+
+      const result = await run(spec.bin, spec.listArgs);
+      // A host that cannot answer is treated as occupied rather than empty:
+      // guessing "none" here is the one wrong guess that overwrites something.
+      if (!result.ok && !result.stdout.includes(SERVER_NAME)) {
+        return { registration: "unknown", detail: firstLine(result.stderr) };
+      }
+      return classifyListing(`${result.stdout}\n${result.stderr}`);
+    },
+    async register() {
+      const result = await run(spec.bin, spec.addArgs);
+      if (!result.ok) {
+        throw new Error(firstLine(result.stderr) || firstLine(result.stdout) || "registration failed");
+      }
+    },
+  };
+}
+
+function firstLine(text: string): string {
+  return text.trim().split("\n", 1)[0]?.trim() ?? "";
+}
+
+function readJsonFile(path: string): { value: Record<string, unknown> | null; missing: boolean } {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return { value: null, missing: true };
+  }
+  // VS Code ships this file as zero bytes until something writes it, and an
+  // empty file is not parseable JSON.
+  if (raw.trim() === "") return { value: {}, missing: false };
+  try {
+    const parsed = JSON.parse(stripJsonComments(raw));
+    return { value: typeof parsed === "object" && parsed !== null ? (parsed as Record<string, unknown>) : {}, missing: false };
+  } catch {
+    return { value: null, missing: false };
+  }
+}
+
+/**
+ * Strip `//` and block comments.
+ *
+ * VS Code and Cursor both accept JSON-with-comments in these files, and a user
+ * who has hand-annotated theirs must not read as corrupt.
+ */
+function stripJsonComments(raw: string): string {
+  let out = "";
+  let inString = false;
+  let inLine = false;
+  let inBlock = false;
+  for (let i = 0; i < raw.length; i += 1) {
+    const ch = raw[i];
+    const next = raw[i + 1];
+    if (inLine) {
+      if (ch === "\n") { inLine = false; out += ch; }
+      continue;
+    }
+    if (inBlock) {
+      if (ch === "*" && next === "/") { inBlock = false; i += 1; }
+      continue;
+    }
+    if (inString) {
+      out += ch;
+      if (ch === "\\") { out += next ?? ""; i += 1; } else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') { inString = true; out += ch; continue; }
+    if (ch === "/" && next === "/") { inLine = true; i += 1; continue; }
+    if (ch === "/" && next === "*") { inBlock = true; i += 1; continue; }
+    out += ch;
+  }
+  return out;
+}
+
+/** Inspect a host by reading the JSON file its servers live in. */
+function inspectJsonFile(path: string, key: string): Pick<HostStatus, "registration" | "detail"> {
+  const { value, missing } = readJsonFile(path);
+  if (missing) return { registration: "none" };
+  if (value === null) return { registration: "unknown", detail: `${path} is not valid JSON` };
+
+  const servers = value[key];
+  if (typeof servers !== "object" || servers === null) return { registration: "none" };
+
+  const entry = (servers as Record<string, unknown>)[SERVER_NAME];
+  if (entry === undefined) return { registration: "none" };
+  return classifyListing(`${SERVER_NAME} ${JSON.stringify(entry)}`);
+}
+
+function vsCodeUserConfig(): string {
+  const home = homedir();
+  if (platform() === "darwin") return join(home, "Library", "Application Support", "Code", "User", "mcp.json");
+  if (platform() === "win32") return join(process.env.APPDATA ?? join(home, "AppData", "Roaming"), "Code", "User", "mcp.json");
+  return join(home, ".config", "Code", "User", "mcp.json");
+}
+
+export function cursorConfigPath(): string {
+  return join(homedir(), ".cursor", "mcp.json");
+}
+
+export function opencodeConfigPath(): string {
+  return join(homedir(), ".config", "opencode", "opencode.json");
+}
+
+/**
+ * The hosts `ix mcp install` knows about.
+ *
+ * Writes go through each host's own CLI wherever one exists, so the host owns
+ * its config format and a format change upstream cannot corrupt a file here.
+ * Only Cursor (no MCP CLI) and opencode (`opencode mcp add` is interactive and
+ * takes no arguments) are written directly, and both are plain JSON.
+ */
+export function createHosts(writeJson: (path: string, mutate: (config: Record<string, unknown>) => void) => void): McpHost[] {
+  return [
+    cliHost({
+      id: "claude",
+      label: "Claude Code",
+      bin: "claude",
+      target: "user scope",
+      listArgs: ["mcp", "list"],
+      addArgs: ["mcp", "add", "--scope", "user", SERVER_NAME, "ix", "mcp"],
+    }),
+    cliHost({
+      id: "codex",
+      label: "Codex CLI",
+      bin: "codex",
+      target: "~/.codex/config.toml",
+      listArgs: ["mcp", "list"],
+      addArgs: ["mcp", "add", SERVER_NAME, "--", "ix", "mcp"],
+    }),
+    cliHost({
+      id: "gemini",
+      label: "Gemini CLI",
+      bin: "gemini",
+      target: "~/.gemini/settings.json",
+      listArgs: ["mcp", "list"],
+      addArgs: ["mcp", "add", SERVER_NAME, "ix", "mcp"],
+    }),
+    cliHost({
+      id: "openclaw",
+      label: "OpenClaw",
+      bin: "openclaw",
+      target: "~/.openclaw/openclaw.json",
+      listArgs: ["mcp", "list"],
+      // `openclaw mcp list` prints names only ("- ix-memory"), so the command
+      // behind the name is invisible there.
+      showArgs: ["mcp", "show", SERVER_NAME],
+      addArgs: ["mcp", "set", SERVER_NAME, JSON.stringify({ command: "ix", args: ["mcp"] })],
+    }),
+    {
+      id: "vscode",
+      label: "VS Code",
+      bin: "code",
+      target: vsCodeUserConfig(),
+      // No list subcommand, so the user-profile file is the only read path.
+      async inspect() {
+        return inspectJsonFile(vsCodeUserConfig(), "servers");
+      },
+      async register() {
+        const definition = JSON.stringify({ name: SERVER_NAME, command: "ix", args: ["mcp"] });
+        const result = await run("code", ["--add-mcp", definition]);
+        if (!result.ok) throw new Error(firstLine(result.stderr) || "code --add-mcp failed");
+      },
+    },
+    {
+      id: "cursor",
+      label: "Cursor",
+      bin: "cursor",
+      target: cursorConfigPath(),
+      async inspect() {
+        return inspectJsonFile(cursorConfigPath(), "mcpServers");
+      },
+      async register() {
+        writeJson(cursorConfigPath(), (config) => {
+          const servers = (config.mcpServers ??= {}) as Record<string, unknown>;
+          servers[SERVER_NAME] = { command: "ix", args: ["mcp"] };
+        });
+      },
+    },
+    {
+      id: "opencode",
+      label: "opencode",
+      bin: "opencode",
+      target: opencodeConfigPath(),
+      async inspect() {
+        return inspectJsonFile(opencodeConfigPath(), "mcp");
+      },
+      async register() {
+        writeJson(opencodeConfigPath(), (config) => {
+          const servers = (config.mcp ??= {}) as Record<string, unknown>;
+          // Shape per https://opencode.ai/config.json — `type` and `command`
+          // are required and the schema forbids extra properties.
+          servers[SERVER_NAME] = { type: "local", command: ["ix", "mcp"], enabled: true };
+        });
+      },
+    },
+  ];
+}

--- a/ix-cli/src/mcp/hosts.ts
+++ b/ix-cli/src/mcp/hosts.ts
@@ -82,7 +82,7 @@ export async function isOnPath(bin: string): Promise<boolean> {
  * that fix instead of handing the same problem to seven hosts. Falls back to
  * the bare name, which is no worse than not trying.
  */
-export async function resolveLauncher(): Promise<{ command: string; args: string[] }> {
+async function resolveLauncher(): Promise<{ command: string; args: string[] }> {
   if (platform() !== "win32") return { command: "ix", args: ["mcp"] };
 
   const found = await run("where", ["ix"]);
@@ -277,11 +277,11 @@ function vsCodeUserConfig(): string {
   return join(home, ".config", "Code", "User", "mcp.json");
 }
 
-export function cursorConfigPath(): string {
+function cursorConfigPath(): string {
   return join(homedir(), ".cursor", "mcp.json");
 }
 
-export function opencodeConfigPath(): string {
+function opencodeConfigPath(): string {
   return join(homedir(), ".config", "opencode", "opencode.json");
 }
 

--- a/ix-cli/src/mcp/hosts.ts
+++ b/ix-cli/src/mcp/hosts.ts
@@ -72,6 +72,29 @@ export async function isOnPath(bin: string): Promise<boolean> {
 }
 
 /**
+ * The command a host should launch to reach `ix mcp`.
+ *
+ * On Unix the bare name is right: it survives an upgrade that moves the
+ * install. On Windows it is not — npm ships no `ix.exe`, only `ix.CMD`, and a
+ * host spawning the bare name through CreateProcess never consults PATHEXT, so
+ * it fails however well-formed the rest of the argv is. `ix-codex-plugin` hit
+ * exactly this (its #13) and resolved the path itself; resolving it here keeps
+ * that fix instead of handing the same problem to seven hosts. Falls back to
+ * the bare name, which is no worse than not trying.
+ */
+export async function resolveLauncher(): Promise<{ command: string; args: string[] }> {
+  if (platform() !== "win32") return { command: "ix", args: ["mcp"] };
+
+  const found = await run("where", ["ix"]);
+  const resolved = found.stdout
+    .split(/\r?\n/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)[0];
+
+  return { command: resolved || "ix", args: ["mcp"] };
+}
+
+/**
  * Lines that mention a server name only because something went wrong.
  *
  * Gemini writes its whole listing to stderr behind ~28 lines of extension
@@ -135,7 +158,8 @@ function cliHost(spec: {
   bin: string;
   target: string;
   listArgs: string[];
-  addArgs: string[];
+  /** Built from the resolved launcher, so Windows gets the real path. */
+  addArgs: (launcher: { command: string; args: string[] }) => string[];
   /**
    * Preferred over `listArgs` where the host can print one server's full
    * definition. A listing that shows only names cannot say whether the entry
@@ -167,7 +191,7 @@ function cliHost(spec: {
       return classifyListing(`${result.stdout}\n${result.stderr}`);
     },
     async register() {
-      const result = await run(spec.bin, spec.addArgs);
+      const result = await run(spec.bin, spec.addArgs(await resolveLauncher()));
       if (!result.ok) {
         throw new Error(firstLine(result.stderr) || firstLine(result.stdout) || "registration failed");
       }
@@ -277,7 +301,7 @@ export function createHosts(writeJson: (path: string, mutate: (config: Record<st
       bin: "claude",
       target: "user scope",
       listArgs: ["mcp", "list"],
-      addArgs: ["mcp", "add", "--scope", "user", SERVER_NAME, "ix", "mcp"],
+      addArgs: (ix) => ["mcp", "add", "--scope", "user", SERVER_NAME, ix.command, ...ix.args],
     }),
     cliHost({
       id: "codex",
@@ -285,7 +309,7 @@ export function createHosts(writeJson: (path: string, mutate: (config: Record<st
       bin: "codex",
       target: "~/.codex/config.toml",
       listArgs: ["mcp", "list"],
-      addArgs: ["mcp", "add", SERVER_NAME, "--", "ix", "mcp"],
+      addArgs: (ix) => ["mcp", "add", SERVER_NAME, "--", ix.command, ...ix.args],
     }),
     cliHost({
       id: "gemini",
@@ -293,7 +317,7 @@ export function createHosts(writeJson: (path: string, mutate: (config: Record<st
       bin: "gemini",
       target: "~/.gemini/settings.json",
       listArgs: ["mcp", "list"],
-      addArgs: ["mcp", "add", SERVER_NAME, "ix", "mcp"],
+      addArgs: (ix) => ["mcp", "add", SERVER_NAME, ix.command, ...ix.args],
     }),
     cliHost({
       id: "openclaw",
@@ -304,7 +328,7 @@ export function createHosts(writeJson: (path: string, mutate: (config: Record<st
       // `openclaw mcp list` prints names only ("- ix-memory"), so the command
       // behind the name is invisible there.
       showArgs: ["mcp", "show", SERVER_NAME],
-      addArgs: ["mcp", "set", SERVER_NAME, JSON.stringify({ command: "ix", args: ["mcp"] })],
+      addArgs: (ix) => ["mcp", "set", SERVER_NAME, JSON.stringify({ command: ix.command, args: ix.args })],
     }),
     {
       id: "vscode",
@@ -316,7 +340,8 @@ export function createHosts(writeJson: (path: string, mutate: (config: Record<st
         return inspectJsonFile(vsCodeUserConfig(), "servers");
       },
       async register() {
-        const definition = JSON.stringify({ name: SERVER_NAME, command: "ix", args: ["mcp"] });
+        const ix = await resolveLauncher();
+        const definition = JSON.stringify({ name: SERVER_NAME, command: ix.command, args: ix.args });
         const result = await run("code", ["--add-mcp", definition]);
         if (!result.ok) throw new Error(firstLine(result.stderr) || "code --add-mcp failed");
       },
@@ -330,9 +355,10 @@ export function createHosts(writeJson: (path: string, mutate: (config: Record<st
         return inspectJsonFile(cursorConfigPath(), "mcpServers");
       },
       async register() {
+        const ix = await resolveLauncher();
         writeJson(cursorConfigPath(), (config) => {
           const servers = (config.mcpServers ??= {}) as Record<string, unknown>;
-          servers[SERVER_NAME] = { command: "ix", args: ["mcp"] };
+          servers[SERVER_NAME] = { command: ix.command, args: ix.args };
         });
       },
     },
@@ -345,11 +371,12 @@ export function createHosts(writeJson: (path: string, mutate: (config: Record<st
         return inspectJsonFile(opencodeConfigPath(), "mcp");
       },
       async register() {
+        const ix = await resolveLauncher();
         writeJson(opencodeConfigPath(), (config) => {
           const servers = (config.mcp ??= {}) as Record<string, unknown>;
           // Shape per https://opencode.ai/config.json — `type` and `command`
           // are required and the schema forbids extra properties.
-          servers[SERVER_NAME] = { type: "local", command: ["ix", "mcp"], enabled: true };
+          servers[SERVER_NAME] = { type: "local", command: [ix.command, ...ix.args], enabled: true };
         });
       },
     },

--- a/ix-cli/src/mcp/install.ts
+++ b/ix-cli/src/mcp/install.ts
@@ -9,7 +9,8 @@ import {
   type McpHost,
   type Registration,
 } from "./hosts.js";
-import { IX_MCP_TOOL_NAMES } from "./server.js";
+import { IX_MCP_OSS_TOOL_NAMES, IX_MCP_PRO_TOOL_NAMES } from "./server.js";
+import { detectPro } from "./runner.js";
 
 /** What install decided to do about one host. */
 export type Outcome =
@@ -178,7 +179,8 @@ export async function runDoctor(options: { hosts?: McpHost[]; only?: string[] } 
 
   return {
     ixOnPath: await isOnPath("ix"),
-    toolCount: IX_MCP_TOOL_NAMES.length,
+    // What this install actually advertises, not the theoretical maximum.
+    toolCount: IX_MCP_OSS_TOOL_NAMES.length + (await detectPro() ? IX_MCP_PRO_TOOL_NAMES.length : 0),
     hosts: reports,
   };
 }

--- a/ix-cli/src/mcp/install.ts
+++ b/ix-cli/src/mcp/install.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 import {
@@ -53,6 +53,28 @@ export interface InstallOptions {
 }
 
 /**
+ * Read a config file, distinguishing "absent" from "unreadable".
+ *
+ * Reading straight out instead of checking existsSync first is what closes
+ * CodeQL js/file-system-race — the same fix view.ts carries for the same rule.
+ * The check could always go stale before the read, and it never told us the
+ * read would succeed anyway.
+ *
+ * Only ENOENT means absent. Anything else has to surface: collapsing
+ * "unreadable" into "absent" here would take the mkdir-and-write branch and
+ * overwrite a config we merely failed to read — with no `.bak`, since the copy
+ * only happens on the branch that read something.
+ */
+function readTextIfPresent(path: string): string | null {
+  try {
+    return readFileSync(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+/**
  * Merge into a JSON config in place, keeping a `.bak` of what was there.
  *
  * Only used for the two hosts with no usable CLI. Everything the user already
@@ -61,10 +83,9 @@ export interface InstallOptions {
  */
 export function writeJsonConfig(path: string, mutate: (config: Record<string, unknown>) => void): void {
   let config: Record<string, unknown> = {};
-  const exists = existsSync(path);
+  const raw = readTextIfPresent(path);
 
-  if (exists) {
-    const raw = readFileSync(path, "utf8");
+  if (raw !== null) {
     if (raw.trim() !== "") {
       let parsed: unknown;
       try {

--- a/ix-cli/src/mcp/install.ts
+++ b/ix-cli/src/mcp/install.ts
@@ -1,0 +1,184 @@
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+import {
+  createHosts,
+  isOnPath,
+  SERVER_NAME,
+  type HostStatus,
+  type McpHost,
+  type Registration,
+} from "./hosts.js";
+import { IX_MCP_TOOL_NAMES } from "./server.js";
+
+/** What install decided to do about one host. */
+export type Outcome =
+  | "registered"
+  | "already-registered"
+  | "conflict"
+  | "not-installed"
+  | "failed"
+  | "would-register"
+  /** Doctor only: host is present and the name is free, but nothing points at us. */
+  | "not-registered";
+
+export interface HostReport extends HostStatus {
+  outcome: Outcome;
+  target: string;
+  /** Why it was skipped, or how it failed. */
+  note?: string;
+}
+
+export interface InstallReport {
+  hosts: HostReport[];
+  registered: number;
+  conflicts: number;
+}
+
+export interface DoctorReport {
+  /** Hosts launch the bare command `ix`; if that does not resolve, every registration is dead. */
+  ixOnPath: boolean;
+  toolCount: number;
+  hosts: HostReport[];
+}
+
+export interface InstallOptions {
+  hosts?: McpHost[];
+  /** Restrict to these host ids. */
+  only?: string[];
+  dryRun?: boolean;
+  /** Replace a name held by something else. Off by default: never clobber. */
+  force?: boolean;
+}
+
+/**
+ * Merge into a JSON config in place, keeping a `.bak` of what was there.
+ *
+ * Only used for the two hosts with no usable CLI. Everything the user already
+ * had is preserved: the file is parsed, mutated, and re-serialised, so an
+ * unrelated key cannot be dropped, and the backup makes a bad merge reversible.
+ */
+export function writeJsonConfig(path: string, mutate: (config: Record<string, unknown>) => void): void {
+  let config: Record<string, unknown> = {};
+  const exists = existsSync(path);
+
+  if (exists) {
+    const raw = readFileSync(path, "utf8");
+    if (raw.trim() !== "") {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        // Refuse rather than overwrite: a file we cannot parse is a file whose
+        // contents we would be destroying.
+        throw new Error(`${path} is not valid JSON — fix or move it, then re-run`);
+      }
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        throw new Error(`${path} is not a JSON object`);
+      }
+      config = parsed as Record<string, unknown>;
+    }
+    copyFileSync(path, `${path}.bak`);
+  } else {
+    mkdirSync(dirname(path), { recursive: true });
+  }
+
+  mutate(config);
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+}
+
+function outcomeFor(registration: Registration, force: boolean): Exclude<Outcome, "not-installed" | "failed"> | null {
+  if (registration === "none") return null; // proceed
+  if (registration === "ours") return "already-registered";
+  return force ? null : "conflict";
+}
+
+function noteFor(registration: Registration, detail?: string): string | undefined {
+  if (registration === "other") {
+    return detail
+      ? `'${SERVER_NAME}' already points at something else: ${detail}`
+      : `'${SERVER_NAME}' is already registered to a different server`;
+  }
+  if (registration === "unknown") {
+    return detail ? `could not read current registration (${detail})` : "could not read current registration";
+  }
+  return detail;
+}
+
+export async function runInstall(options: InstallOptions = {}): Promise<InstallReport> {
+  const hosts = (options.hosts ?? createHosts(writeJsonConfig)).filter(
+    (host) => !options.only?.length || options.only.includes(host.id),
+  );
+
+  const reports: HostReport[] = [];
+
+  for (const host of hosts) {
+    const base = { id: host.id, label: host.label, target: host.target };
+
+    if (!(await isOnPath(host.bin))) {
+      reports.push({ ...base, installed: false, registration: "none", outcome: "not-installed" });
+      continue;
+    }
+
+    const { registration, detail } = await host.inspect();
+    const blocked = outcomeFor(registration, options.force === true);
+    if (blocked) {
+      reports.push({ ...base, installed: true, registration, outcome: blocked, note: noteFor(registration, detail) });
+      continue;
+    }
+
+    if (options.dryRun) {
+      reports.push({ ...base, installed: true, registration, outcome: "would-register" });
+      continue;
+    }
+
+    try {
+      await host.register();
+      reports.push({ ...base, installed: true, registration, outcome: "registered" });
+    } catch (error) {
+      reports.push({
+        ...base,
+        installed: true,
+        registration,
+        outcome: "failed",
+        note: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return {
+    hosts: reports,
+    registered: reports.filter((r) => r.outcome === "registered").length,
+    conflicts: reports.filter((r) => r.outcome === "conflict").length,
+  };
+}
+
+export async function runDoctor(options: { hosts?: McpHost[]; only?: string[] } = {}): Promise<DoctorReport> {
+  const hosts = (options.hosts ?? createHosts(writeJsonConfig)).filter(
+    (host) => !options.only?.length || options.only.includes(host.id),
+  );
+
+  const reports: HostReport[] = [];
+  for (const host of hosts) {
+    const base = { id: host.id, label: host.label, target: host.target };
+    if (!(await isOnPath(host.bin))) {
+      reports.push({ ...base, installed: false, registration: "none", outcome: "not-installed" });
+      continue;
+    }
+    const { registration, detail } = await host.inspect();
+    reports.push({
+      ...base,
+      installed: true,
+      registration,
+      outcome:
+        registration === "ours" ? "already-registered" : registration === "none" ? "not-registered" : "conflict",
+      note: noteFor(registration, detail),
+    });
+  }
+
+  return {
+    ixOnPath: await isOnPath("ix"),
+    toolCount: IX_MCP_TOOL_NAMES.length,
+    hosts: reports,
+  };
+}

--- a/ix-cli/src/mcp/runner.ts
+++ b/ix-cli/src/mcp/runner.ts
@@ -22,7 +22,7 @@ export const DEFAULT_TIMEOUT_MS = 30_000;
  * unbounded `ix text` on a large repo would otherwise grow the long-lived
  * server's heap instead of a short-lived child's.
  */
-export const MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
+const MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
 
 export interface IxRunResult {
   ok: boolean;

--- a/ix-cli/src/mcp/runner.ts
+++ b/ix-cli/src/mcp/runner.ts
@@ -1,0 +1,381 @@
+import { execFile } from "node:child_process";
+import { Writable } from "node:stream";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import { format } from "node:util";
+
+import { Command, CommanderError } from "commander";
+
+import { registerOssCommands, registerProStubs } from "../cli/register/oss.js";
+import { tryLoadProCommands } from "../cli/register/pro-loader.js";
+
+const execFileAsync = promisify(execFile);
+const CLI_ENTRYPOINT = fileURLToPath(new URL("../cli/main.js", import.meta.url));
+
+export const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Cap on a single command's captured output. The subprocess runner got this
+ * for free from `execFile`'s `maxBuffer`; in-process nothing bounds it, and an
+ * unbounded `ix text` on a large repo would otherwise grow the long-lived
+ * server's heap instead of a short-lived child's.
+ */
+export const MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
+
+export interface IxRunResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+export type IxRunner = (args: string[], timeoutMs?: number) => Promise<IxRunResult>;
+
+/**
+ * The write functions as they were before any capture patch. Captured at module
+ * load so both the patch (which forwards to them when idle) and the MCP
+ * transport (which must never be captured) share one pristine reference.
+ */
+const pristineStdoutWrite = process.stdout.write.bind(process.stdout);
+const pristineStderrWrite = process.stderr.write.bind(process.stderr);
+const pristineExit = process.exit.bind(process);
+
+interface ActiveRun {
+  stdout: string[];
+  stderr: string[];
+  bytes: number;
+  maxBytes: number;
+  truncated: boolean;
+  /**
+   * Set once the result has been returned. Output arriving afterwards is from a
+   * command that outlived its timeout and is dropped, so a hung command cannot
+   * grow a buffer nobody will ever read.
+   */
+  closed: boolean;
+}
+
+/**
+ * The run currently owning the process globals, or null when idle.
+ *
+ * One slot, because runs are serialized. Running them concurrently would need
+ * every global they touch to be context-local, and `process.exitCode` — the
+ * signal commands use to report failure — is a non-configurable property on
+ * Node 22, so it cannot be. Isolating output per async context while the exit
+ * code stayed global would attribute a call's output to the right result and
+ * its success to the wrong one. See `createInProcessRunner`.
+ */
+let activeRun: ActiveRun | null = null;
+let captureInstalled = false;
+let redirectIdleStdout = false;
+
+/**
+ * Which run a write belongs to, tracked so a command that outlived its timeout
+ * still resolves to its own (already-returned) run. The queue advances on
+ * timeout, so without this a timed-out `ix map` would dribble progress into
+ * whichever tool call is running by then. Attribution falls back to
+ * {@link activeRun} wherever the context does not propagate, so this can only
+ * narrow the damage, never widen it.
+ */
+const runContext = new AsyncLocalStorage<ActiveRun>();
+
+/** The run a write belongs to: its own context first, else whoever holds the globals. */
+function resolveRun(): ActiveRun | null {
+  return runContext.getStore() ?? activeRun;
+}
+
+/** Which buffer each console method feeds, mirroring Node's own routing. */
+const CONSOLE_SINKS = [
+  ["log", "stdout"],
+  ["info", "stdout"],
+  ["debug", "stdout"],
+  ["warn", "stderr"],
+  ["error", "stderr"],
+] as const satisfies ReadonlyArray<readonly [keyof Console, "stdout" | "stderr"]>;
+
+/** Thrown in place of a real `process.exit()` while a run owns the globals. */
+class ProcessExitSignal extends Error {
+  constructor(readonly code: number) {
+    super(`process.exit(${code})`);
+    this.name = "ProcessExitSignal";
+  }
+}
+
+function appendChunk(run: ActiveRun, sink: "stdout" | "stderr", chunk: unknown, encoding?: string): void {
+  if (run.truncated) return;
+
+  const text =
+    typeof chunk === "string"
+      ? chunk
+      : Buffer.from(chunk as Uint8Array).toString((encoding as BufferEncoding) ?? "utf8");
+
+  run.bytes += Buffer.byteLength(text);
+  if (run.bytes > run.maxBytes) {
+    run.truncated = true;
+    run.stderr.push(`\n[ix mcp] output exceeded ${run.maxBytes} bytes and was truncated\n`);
+    return;
+  }
+  run[sink].push(text);
+}
+
+/**
+ * Replace a stream's `write` with one that diverts into the active run.
+ *
+ * Covers direct stream writes such as `cli/stderr.ts`, and — in a plain Node
+ * process — `console.log`, which bottoms out here. The console methods are
+ * patched separately because that is not true everywhere: a harness that
+ * substitutes its own `console` (vitest does) never reaches this.
+ */
+function patchWrite(
+  stream: NodeJS.WriteStream,
+  sink: "stdout" | "stderr",
+  idleWrite: (chunk: unknown, encoding?: unknown, cb?: unknown) => boolean,
+): void {
+  stream.write = function patched(chunk: unknown, encodingOrCb?: unknown, maybeCb?: unknown): boolean {
+    const run = resolveRun();
+    if (!run) return idleWrite(chunk, encodingOrCb, maybeCb);
+
+    const callback = typeof encodingOrCb === "function" ? encodingOrCb : maybeCb;
+    const encoding = typeof encodingOrCb === "string" ? encodingOrCb : undefined;
+    if (!run.closed) appendChunk(run, sink, chunk, encoding);
+    if (typeof callback === "function") (callback as () => void)();
+    return true;
+  } as typeof stream.write;
+}
+
+/**
+ * Take ownership of the process globals that CLI commands write through.
+ *
+ * Idempotent, and transparent while no run is active: writes fall through to
+ * the pristine stream functions unless `redirectIdleStdout` is set.
+ */
+function installCapture(options: { redirectIdleStdout?: boolean } = {}): void {
+  redirectIdleStdout = redirectIdleStdout || options.redirectIdleStdout === true;
+  if (captureInstalled) return;
+  captureInstalled = true;
+
+  // When serving MCP over stdio, fd 1 carries the JSON-RPC framing and nothing
+  // else — the transport gets its own handle via createProtocolStdout. Any
+  // stdout write that cannot be attributed to a run is therefore a stray one,
+  // and letting it reach fd 1 would desync the protocol for the rest of the
+  // session; it goes to stderr instead, where it is merely noise.
+  patchWrite(process.stdout, "stdout", (chunk, encoding, cb) =>
+    redirectIdleStdout
+      ? (pristineStderrWrite as Function)(chunk, encoding, cb)
+      : (pristineStdoutWrite as Function)(chunk, encoding, cb),
+  );
+  patchWrite(process.stderr, "stderr", (chunk, encoding, cb) =>
+    (pristineStderrWrite as Function)(chunk, encoding, cb),
+  );
+
+  for (const [method, sink] of CONSOLE_SINKS) {
+    const original = console[method].bind(console);
+    console[method] = (...parts: unknown[]): void => {
+      const run = resolveRun();
+      if (!run) return original(...parts);
+      if (!run.closed) appendChunk(run, sink, `${format(...parts)}\n`);
+    };
+  }
+
+  // `ix status` and `ix text` call `process.exit(1)` on their error paths. In a
+  // child process that ends one command; in-process it would take the whole MCP
+  // server down mid-session, so it becomes a throw the runner turns into a
+  // failed tool result.
+  process.exit = ((code?: number) => {
+    if (!resolveRun()) return pristineExit(code);
+    throw new ProcessExitSignal(code ?? 0);
+  }) as typeof process.exit;
+}
+
+/**
+ * A stdout stream for the MCP transport that bypasses the capture patch.
+ *
+ * The transport holds this instead of `process.stdout`, so protocol framing
+ * cannot be swallowed by a run or reordered behind command output.
+ */
+export function createProtocolStdout(): Writable {
+  return new Writable({
+    write(chunk, encoding, callback) {
+      // Writable hands Buffer chunks the pseudo-encoding "buffer", which is not
+      // a value process.stdout.write accepts.
+      if (Buffer.isBuffer(chunk)) pristineStdoutWrite(chunk, callback);
+      else pristineStdoutWrite(chunk, encoding, callback);
+    },
+  });
+}
+
+/**
+ * Build a fresh command tree.
+ *
+ * Rebuilt per run rather than cached: commander stores parsed option values on
+ * the `Command` objects and does not clear them between parses, so a reused
+ * program would leak `--path` from one `ix_text` call into the next call that
+ * omitted it.
+ */
+async function buildProgram(version: string): Promise<Command> {
+  const program = new Command();
+  program.name("ix").version(version);
+  registerOssCommands(program);
+
+  if (!(await tryLoadProCommands(program))) registerProStubs(program);
+
+  return program;
+}
+
+/**
+ * Make commander report usage errors by throwing rather than exiting.
+ *
+ * Without this it calls process.exit, which the patch above turns into a bare
+ * ProcessExitSignal carrying no explanation; a CommanderError carries the
+ * actual message. Applied per run so an injected program gets it too.
+ */
+function throwOnUsageError(program: Command): Command {
+  program.exitOverride();
+  for (const command of program.commands) command.exitOverride();
+  return program;
+}
+
+function withTimeout<T>(work: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: NodeJS.Timeout;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+  });
+  return Promise.race([work, deadline]).finally(() => clearTimeout(timer)) as Promise<T>;
+}
+
+export interface InProcessRunnerOptions {
+  version?: string;
+  redirectIdleStdout?: boolean;
+  /**
+   * Command-tree factory, called once per run. Defaults to the real Ix tree;
+   * tests substitute a small one to exercise the capture machinery without a
+   * backend.
+   */
+  createProgram?: (version: string) => Command | Promise<Command>;
+  /** Output cap for a single run. Defaults to {@link MAX_OUTPUT_BYTES}. */
+  maxOutputBytes?: number;
+}
+
+async function executeInProcess(
+  args: string[],
+  timeoutMs: number,
+  version: string,
+  createProgram: (version: string) => Command | Promise<Command>,
+  maxBytes: number,
+): Promise<IxRunResult> {
+  const program = throwOnUsageError(await createProgram(version));
+  const run: ActiveRun = {
+    stdout: [],
+    stderr: [],
+    bytes: 0,
+    maxBytes,
+    truncated: false,
+    closed: false,
+  };
+
+  const callerExitCode = process.exitCode;
+  process.exitCode = undefined;
+  activeRun = run;
+
+  let failure: string | null = null;
+  let commandExitCode: number | string | undefined;
+
+  try {
+    await withTimeout(
+      runContext.run(run, () => program.parseAsync(args, { from: "user" })),
+      timeoutMs,
+      args[0] ?? "ix",
+    );
+  } catch (error) {
+    if (error instanceof ProcessExitSignal) {
+      // An explicit exit; the command already explained itself on stdout/stderr.
+      if (error.code !== 0) commandExitCode = error.code;
+    } else if (error instanceof CommanderError) {
+      // exitOverride fires for `--help` and `--version` too, which are successes.
+      if (error.exitCode !== 0) failure = error.message;
+    } else {
+      failure = error instanceof Error ? error.message : String(error);
+    }
+  } finally {
+    commandExitCode = commandExitCode ?? process.exitCode;
+    process.exitCode = callerExitCode;
+    run.closed = true;
+    activeRun = null;
+  }
+
+  const ok = failure === null && (commandExitCode === undefined || commandExitCode === 0);
+  return {
+    ok,
+    stdout: run.stdout.join(""),
+    stderr: run.stderr.join("") + (failure ?? ""),
+  };
+}
+
+/**
+ * Run Ix commands inside this process instead of spawning the CLI per call.
+ *
+ * Booting `main.js` costs ~0.58s before any query runs, which a tool-calling
+ * agent pays on every hop of a `locate → callers → read` chain. Running the
+ * same command tree here removes that entirely and lets `cli/resolve.ts`'s
+ * per-cwd scope cache survive between calls.
+ *
+ * Runs are serialized. Commands report failure through `process.exitCode` and
+ * print through `process.stdout`, both of which are process-wide, so two
+ * commands in flight together would cross their output and their exit status.
+ * The queue costs parallelism on hosts that batch tool calls and still comes
+ * out ahead of per-call process boot; `IX_MCP_SUBPROCESS=1` restores the old
+ * isolated behaviour for anything pathological.
+ */
+export function createInProcessRunner(options: InProcessRunnerOptions = {}): IxRunner {
+  installCapture({ redirectIdleStdout: options.redirectIdleStdout });
+  const version = options.version ?? "0.0.0";
+  const createProgram = options.createProgram ?? buildProgram;
+  const maxBytes = options.maxOutputBytes ?? MAX_OUTPUT_BYTES;
+
+  let queue: Promise<unknown> = Promise.resolve();
+
+  return (args, timeoutMs = DEFAULT_TIMEOUT_MS) => {
+    const result = queue.then(() =>
+      executeInProcess(args, timeoutMs, version, createProgram, maxBytes),
+    );
+    // The chain must survive a rejection, or one failed run would strand every
+    // later call behind it. executeInProcess resolves rather than throws for
+    // command failures, so this only catches genuine runner faults.
+    queue = result.catch(() => undefined);
+    return result;
+  };
+}
+
+/** Spawn the CLI as a child process — one command per process, fully isolated. */
+export async function runCurrentIx(
+  args: string[],
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<IxRunResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync(process.execPath, [CLI_ENTRYPOINT, ...args], {
+      cwd: process.cwd(),
+      env: { ...process.env, IX_MCP_CHILD: "1" },
+      encoding: "utf8",
+      maxBuffer: MAX_OUTPUT_BYTES,
+      timeout: timeoutMs,
+      windowsHide: true,
+    });
+    return { ok: true, stdout, stderr };
+  } catch (error) {
+    const failure = error as Error & { stdout?: string; stderr?: string };
+    return {
+      ok: false,
+      stdout: failure.stdout ?? "",
+      stderr: failure.stderr ?? failure.message,
+    };
+  }
+}
+
+/**
+ * The runner `ix mcp` uses unless `IX_MCP_SUBPROCESS=1` asks for the child
+ * process path.
+ */
+export function resolveDefaultRunner(options: InProcessRunnerOptions = {}): IxRunner {
+  if (process.env.IX_MCP_SUBPROCESS === "1") return runCurrentIx;
+  return createInProcessRunner(options);
+}

--- a/ix-cli/src/mcp/runner.ts
+++ b/ix-cli/src/mcp/runner.ts
@@ -346,6 +346,18 @@ export function createInProcessRunner(options: InProcessRunnerOptions = {}): IxR
   };
 }
 
+let proProbe: Promise<boolean> | undefined;
+
+/**
+ * Whether `@ix/pro` is installed, probed once per process.
+ *
+ * The MCP server uses this to decide whether to advertise the Pro tools at all,
+ * rather than offering tools whose every call answers "requires Ix Pro".
+ */
+export function detectPro(): Promise<boolean> {
+  return (proProbe ??= tryLoadProCommands(new Command()));
+}
+
 /** Spawn the CLI as a child process — one command per process, fully isolated. */
 export async function runCurrentIx(
   args: string[],

--- a/ix-cli/src/mcp/server.ts
+++ b/ix-cli/src/mcp/server.ts
@@ -11,7 +11,7 @@ import {
   type IxRunner,
 } from "./runner.js";
 
-export { runCurrentIx, type IxRunner, type IxRunResult } from "./runner.js";
+export type { IxRunner } from "./runner.js";
 
 /**
  * Tools every install can run.

--- a/ix-cli/src/mcp/server.ts
+++ b/ix-cli/src/mcp/server.ts
@@ -6,15 +6,24 @@ import { z } from "zod";
 import {
   createProtocolStdout,
   DEFAULT_TIMEOUT_MS,
+  detectPro,
   resolveDefaultRunner,
   type IxRunner,
 } from "./runner.js";
 
 export { runCurrentIx, type IxRunner, type IxRunResult } from "./runner.js";
 
-export const IX_MCP_TOOL_NAMES = [
+/**
+ * Tools every install can run.
+ *
+ * This set is the union of what the per-host Ix plugins expose, minus three
+ * deliberate drops: `ix_query` is the deprecated command the CLI docs tell
+ * agents not to use, and `ix_neighbors` / `ix_docs_tool` are convenience
+ * composites of `ix_callers` + `ix_callees` + `ix_depends` and of
+ * `ix_overview`, all of which are here individually.
+ */
+export const IX_MCP_OSS_TOOL_NAMES = [
   "ix_health",
-  "ix_briefing",
   "ix_locate",
   "ix_text",
   "ix_impact",
@@ -34,13 +43,28 @@ export const IX_MCP_TOOL_NAMES = [
   "ix_smells",
   "ix_stats",
   "ix_subsystems",
-  "ix_decisions",
   "ix_history",
+  "ix_ingest",
 ] as const;
+
+/**
+ * Tools that need Ix Pro.
+ *
+ * Advertised only when the Pro package actually loads. Listing them
+ * unconditionally — as this server did for `ix_briefing` and `ix_decisions` —
+ * hands an OSS agent tools whose every call returns "requires Ix Pro", which it
+ * cannot tell apart from a real failure.
+ */
+export const IX_MCP_PRO_TOOL_NAMES = ["ix_briefing", "ix_decisions", "ix_decide"] as const;
+
+/** Every tool this server can serve, across both tiers. */
+export const IX_MCP_TOOL_NAMES = [...IX_MCP_OSS_TOOL_NAMES, ...IX_MCP_PRO_TOOL_NAMES] as const;
 
 interface CreateServerOptions {
   version?: string;
   runIx?: IxRunner;
+  /** Advertise the Pro tools. Resolved by {@link detectPro} at startup. */
+  proAvailable?: boolean;
 }
 
 type ToolInput = Record<string, unknown>;
@@ -64,9 +88,6 @@ export function createIxMcpServer(options: CreateServerOptions = {}): McpServer 
 
   registerTool(server, "ix_health", "Check Ix backend and graph readiness", {}, async () =>
     runFormatted(runIx, "ix_health", ["status"]),
-  );
-  registerTool(server, "ix_briefing", "Load the Ix Pro session briefing", {}, async () =>
-    runJson(runIx, "ix_briefing", ["briefing"]),
   );
   registerTool(
     server,
@@ -250,28 +271,70 @@ export function createIxMcpServer(options: CreateServerOptions = {}): McpServer 
   );
   registerTool(
     server,
-    "ix_decisions",
-    "List Ix Pro architecture decisions, optionally scoped to a path",
-    { path: z.string().min(1).optional() },
-    async (input) => {
-      const args = ["decisions"];
-      pushOption(args, "--path", input.path);
-      return runJson(runIx, "ix_decisions", args);
-    },
-  );
-  registerTool(
-    server,
     "ix_history",
     "Show provenance and patch history for a file or symbol",
     { target: z.string().min(1) },
     async (input) => runFormatted(runIx, "ix_history", ["history", stringArg(input, "target")]),
   );
+  registerTool(
+    server,
+    "ix_ingest",
+    "Ingest a path, or issues/PRs/commits from a GitHub repository, into the graph",
+    {
+      path: z.string().min(1).optional(),
+      github: z.string().min(1).optional().describe("owner/repo"),
+      limit: z.number().int().min(1).max(500).default(50),
+      since: z.string().min(1).optional().describe("ISO 8601 date"),
+    },
+    async (input) => {
+      const args = ["ingest"];
+      if (typeof input.path === "string") args.push(input.path);
+      pushOption(args, "--github", input.github);
+      pushOption(args, "--since", input.since);
+      if (typeof input.github === "string") args.push("--limit", numberArg(input, "limit").toString());
+      // Ingestion walks the tree or pages a GitHub API, so it gets the same
+      // headroom as ix_map rather than the default read timeout.
+      return runJson(runIx, "ix_ingest", args, 120_000);
+    },
+  );
+
+  if (options.proAvailable) {
+    registerTool(server, "ix_briefing", "Load the Ix Pro session briefing", {}, async () =>
+      runJson(runIx, "ix_briefing", ["briefing"]),
+    );
+    registerTool(
+      server,
+      "ix_decisions",
+      "List Ix Pro architecture decisions, optionally scoped to a path",
+      { path: z.string().min(1).optional() },
+      async (input) => {
+        const args = ["decisions"];
+        pushOption(args, "--path", input.path);
+        return runJson(runIx, "ix_decisions", args);
+      },
+    );
+    registerTool(
+      server,
+      "ix_decide",
+      "Record an architecture decision with its rationale",
+      {
+        title: z.string().min(1),
+        rationale: z.string().min(1),
+        affects: z.string().min(1).optional().describe("entity the decision affects"),
+      },
+      async (input) => {
+        const args = ["decide", stringArg(input, "title"), "--rationale", stringArg(input, "rationale")];
+        pushOption(args, "--affects", input.affects);
+        return runJson(runIx, "ix_decide", args);
+      },
+    );
+  }
 
   return server;
 }
 
 export async function startIxMcpServer(version = "0.0.0"): Promise<void> {
-  const server = createIxMcpServer({ version });
+  const server = createIxMcpServer({ version, proAvailable: await detectPro() });
   // A dedicated handle on fd 1 rather than process.stdout, which the in-process
   // runner patches to capture command output.
   await server.connect(new StdioServerTransport(process.stdin, createProtocolStdout()));

--- a/ix-cli/src/mcp/server.ts
+++ b/ix-cli/src/mcp/server.ts
@@ -1,0 +1,407 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+
+import {
+  createProtocolStdout,
+  DEFAULT_TIMEOUT_MS,
+  resolveDefaultRunner,
+  type IxRunner,
+} from "./runner.js";
+
+export { runCurrentIx, type IxRunner, type IxRunResult } from "./runner.js";
+
+export const IX_MCP_TOOL_NAMES = [
+  "ix_health",
+  "ix_briefing",
+  "ix_locate",
+  "ix_text",
+  "ix_impact",
+  "ix_map",
+  "ix_overview",
+  "ix_read",
+  "ix_diff",
+  "ix_callers",
+  "ix_callees",
+  "ix_imported_by",
+  "ix_imports",
+  "ix_depends",
+  "ix_trace",
+  "ix_explain",
+  "ix_rank",
+  "ix_inventory",
+  "ix_smells",
+  "ix_stats",
+  "ix_subsystems",
+  "ix_decisions",
+  "ix_history",
+] as const;
+
+interface CreateServerOptions {
+  version?: string;
+  runIx?: IxRunner;
+}
+
+type ToolInput = Record<string, unknown>;
+
+export function createIxMcpServer(options: CreateServerOptions = {}): McpServer {
+  const version = options.version ?? "0.0.0";
+
+  // Built on first use, not here: constructing the default runner takes over
+  // process.stdout and process.exit, which a caller supplying its own runner
+  // (every test, and any embedder) must not have done to it.
+  let fallback: IxRunner | undefined;
+  const runIx: IxRunner =
+    options.runIx ??
+    ((args, timeoutMs) =>
+      (fallback ??= resolveDefaultRunner({ version, redirectIdleStdout: true }))(args, timeoutMs));
+
+  const server = new McpServer({
+    name: "ix-memory",
+    version,
+  });
+
+  registerTool(server, "ix_health", "Check Ix backend and graph readiness", {}, async () =>
+    runFormatted(runIx, "ix_health", ["status"]),
+  );
+  registerTool(server, "ix_briefing", "Load the Ix Pro session briefing", {}, async () =>
+    runJson(runIx, "ix_briefing", ["briefing"]),
+  );
+  registerTool(
+    server,
+    "ix_locate",
+    "Resolve a symbol to its canonical graph-backed target",
+    { symbol: z.string().min(1) },
+    async (input) => runFormatted(runIx, "ix_locate", ["locate", stringArg(input, "symbol")]),
+  );
+  registerTool(
+    server,
+    "ix_text",
+    "Search text across the indexed repository and return ranked hits",
+    {
+      pattern: z.string().min(1),
+      limit: z.number().int().min(1).max(100).default(20),
+      path: z.string().min(1).optional(),
+      language: z.string().min(1).optional(),
+    },
+    async (input) => {
+      const args = [
+        "text",
+        stringArg(input, "pattern"),
+        "--limit",
+        numberArg(input, "limit").toString(),
+      ];
+      pushOption(args, "--path", input.path);
+      pushOption(args, "--language", input.language);
+      return runFormatted(runIx, "ix_text", args);
+    },
+  );
+  registerTool(
+    server,
+    "ix_impact",
+    "Analyze the blast radius and risk of changing a symbol or file",
+    { target: z.string().min(1) },
+    async (input) => runFormatted(runIx, "ix_impact", ["impact", stringArg(input, "target")]),
+  );
+  registerTool(
+    server,
+    "ix_map",
+    "Ingest one path or refresh the full workspace architecture map",
+    { file: z.string().min(1).optional() },
+    async (input) => {
+      const args = ["map"];
+      if (typeof input.file === "string") args.push(input.file);
+      return runJson(runIx, "ix_map", args, 120_000);
+    },
+  );
+  registerTool(
+    server,
+    "ix_overview",
+    "Return the structural overview of a symbol, file, or subsystem",
+    { target: z.string().min(1) },
+    async (input) => runFormatted(runIx, "ix_overview", ["overview", stringArg(input, "target")]),
+  );
+  registerTool(
+    server,
+    "ix_read",
+    "Read graph-bounded source for a symbol or indexed file",
+    { symbol: z.string().min(1) },
+    async (input) => runFormatted(runIx, "ix_read", ["read", stringArg(input, "symbol")]),
+  );
+  registerTool(
+    server,
+    "ix_diff",
+    "Show the structural diff between two graph revisions",
+    {
+      from_rev: z.number().int().nonnegative(),
+      to_rev: z.number().int().nonnegative(),
+      target: z.string().min(1).optional(),
+      summary: z.boolean().default(false),
+    },
+    async (input) => {
+      const args = [
+        "diff",
+        numberArg(input, "from_rev").toString(),
+        numberArg(input, "to_rev").toString(),
+      ];
+      if (typeof input.target === "string") args.push(input.target);
+      if (input.summary === true) args.push("--summary");
+      return runFormatted(runIx, "ix_diff", args);
+    },
+  );
+  registerSymbolTool(server, runIx, "ix_callers", "List incoming call edges", "callers");
+  registerSymbolTool(server, runIx, "ix_callees", "List outgoing call edges", "callees");
+  registerSymbolTool(server, runIx, "ix_imported_by", "List incoming import edges", "imported-by");
+  registerSymbolTool(server, runIx, "ix_imports", "List outgoing import edges", "imports");
+  registerTool(
+    server,
+    "ix_depends",
+    "Show downstream dependencies to a bounded depth",
+    {
+      symbol: z.string().min(1),
+      depth: z.number().int().min(1).max(5).default(2),
+    },
+    async (input) =>
+      runFormatted(runIx, "ix_depends", [
+        "depends",
+        stringArg(input, "symbol"),
+        "--depth",
+        numberArg(input, "depth").toString(),
+      ]),
+  );
+  registerTool(
+    server,
+    "ix_trace",
+    "Trace execution paths through a symbol",
+    {
+      symbol: z.string().min(1),
+      to: z.string().min(1).optional(),
+    },
+    async (input) => {
+      const args = ["trace", stringArg(input, "symbol")];
+      pushOption(args, "--to", input.to);
+      return runFormatted(runIx, "ix_trace", args);
+    },
+  );
+  registerSymbolTool(
+    server,
+    runIx,
+    "ix_explain",
+    "Explain a symbol using graph evidence",
+    "explain",
+  );
+  registerTool(
+    server,
+    "ix_rank",
+    "Rank graph entities by importance or connectivity",
+    {
+      by: z.string().min(1).default("dependents"),
+      kind: z.string().min(1).default("class"),
+      top: z.number().int().min(1).max(100).default(10),
+      path: z.string().min(1).optional(),
+    },
+    async (input) => {
+      const args = [
+        "rank",
+        "--by",
+        stringArg(input, "by"),
+        "--kind",
+        stringArg(input, "kind"),
+        "--top",
+        numberArg(input, "top").toString(),
+      ];
+      pushOption(args, "--path", input.path);
+      return runFormatted(runIx, "ix_rank", args);
+    },
+  );
+  registerTool(
+    server,
+    "ix_inventory",
+    "List graph entities within a repository path",
+    {
+      path: z.string().min(1),
+      kind: z.string().min(1).default("file"),
+    },
+    async (input) =>
+      runFormatted(runIx, "ix_inventory", [
+        "inventory",
+        "--kind",
+        stringArg(input, "kind"),
+        "--path",
+        stringArg(input, "path"),
+      ]),
+  );
+  registerTool(
+    server,
+    "ix_smells",
+    "Detect graph-backed architecture smells",
+    {
+      path: z.string().min(1).optional(),
+      limit: z.number().int().min(1).max(500).default(50),
+    },
+    async (input) => runSmells(runIx, input),
+  );
+  registerTool(server, "ix_stats", "Return graph-wide statistics", {}, async () =>
+    runFormatted(runIx, "ix_stats", ["stats"]),
+  );
+  registerTool(server, "ix_subsystems", "List graph-derived subsystems", {}, async () =>
+    runFormatted(runIx, "ix_subsystems", ["subsystems"]),
+  );
+  registerTool(
+    server,
+    "ix_decisions",
+    "List Ix Pro architecture decisions, optionally scoped to a path",
+    { path: z.string().min(1).optional() },
+    async (input) => {
+      const args = ["decisions"];
+      pushOption(args, "--path", input.path);
+      return runJson(runIx, "ix_decisions", args);
+    },
+  );
+  registerTool(
+    server,
+    "ix_history",
+    "Show provenance and patch history for a file or symbol",
+    { target: z.string().min(1) },
+    async (input) => runFormatted(runIx, "ix_history", ["history", stringArg(input, "target")]),
+  );
+
+  return server;
+}
+
+export async function startIxMcpServer(version = "0.0.0"): Promise<void> {
+  const server = createIxMcpServer({ version });
+  // A dedicated handle on fd 1 rather than process.stdout, which the in-process
+  // runner patches to capture command output.
+  await server.connect(new StdioServerTransport(process.stdin, createProtocolStdout()));
+}
+
+function registerSymbolTool(
+  server: McpServer,
+  runIx: IxRunner,
+  name: string,
+  description: string,
+  command: string,
+): void {
+  registerTool(server, name, description, { symbol: z.string().min(1) }, async (input) =>
+    runFormatted(runIx, name, [command, stringArg(input, "symbol")]),
+  );
+}
+
+function registerTool(
+  server: McpServer,
+  name: string,
+  description: string,
+  inputSchema: z.ZodRawShape,
+  handler: (input: ToolInput) => Promise<CallToolResult>,
+): void {
+  server.registerTool(name, { description, inputSchema }, async (input) =>
+    handler(input as ToolInput),
+  );
+}
+
+async function runFormatted(
+  runIx: IxRunner,
+  tool: string,
+  args: string[],
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<CallToolResult> {
+  return runCommand(runIx, tool, [...args, "--format", "llm"], timeoutMs);
+}
+
+async function runJson(
+  runIx: IxRunner,
+  tool: string,
+  args: string[],
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<CallToolResult> {
+  return runCommand(runIx, tool, [...args, "--format", "json"], timeoutMs);
+}
+
+async function runCommand(
+  runIx: IxRunner,
+  tool: string,
+  args: string[],
+  timeoutMs: number,
+): Promise<CallToolResult> {
+  const result = await runIx(args, timeoutMs);
+  if (!result.ok) {
+    const detail =
+      result.stderr.trim() ||
+      result.stdout.trim() ||
+      `${args.slice(0, 2).join(" ")} failed without output`;
+    return textResult(JSON.stringify({ error: detail, tool }), true);
+  }
+
+  return textResult(result.stdout.trim() || "{}");
+}
+
+async function runSmells(runIx: IxRunner, input: ToolInput): Promise<CallToolResult> {
+  const result = await runIx(["smells", "--format", "json"], DEFAULT_TIMEOUT_MS);
+  if (!result.ok) {
+    const detail = result.stderr.trim() || result.stdout.trim() || "smells failed without output";
+    return textResult(JSON.stringify({ error: detail, tool: "ix_smells" }), true);
+  }
+
+  const parsed = parseJsonOutput(result.stdout);
+  if (!isRecord(parsed) || !Array.isArray(parsed.candidates)) {
+    return textResult(result.stdout.trim() || "{}");
+  }
+
+  const path = typeof input.path === "string" ? normalizePath(input.path) : null;
+  const limit = numberArg(input, "limit");
+  const candidates = parsed.candidates
+    .filter((candidate) => {
+      if (path === null || !isRecord(candidate) || typeof candidate.file !== "string") {
+        return path === null;
+      }
+      const file = normalizePath(candidate.file);
+      return file === path || file.startsWith(`${path}/`);
+    })
+    .slice(0, limit);
+
+  return textResult(JSON.stringify({ ...parsed, count: candidates.length, candidates }, null, 2));
+}
+
+function textResult(text: string, isError = false): CallToolResult {
+  return {
+    content: [{ type: "text", text }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+function stringArg(input: ToolInput, key: string): string {
+  return input[key] as string;
+}
+
+function numberArg(input: ToolInput, key: string): number {
+  return input[key] as number;
+}
+
+function pushOption(args: string[], flag: string, value: unknown): void {
+  if (typeof value === "string" && value.length > 0) {
+    args.push(flag, value);
+  }
+}
+
+function parseJsonOutput(output: string): unknown {
+  const text = output.trim();
+  for (let index = 0; index < text.length; index += 1) {
+    if (text[index] !== "{" && text[index] !== "[") continue;
+    try {
+      return JSON.parse(text.slice(index));
+    } catch {
+      // A startup notice can contain punctuation before the actual JSON body.
+    }
+  }
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizePath(value: string): string {
+  return value.replaceAll("\\", "/").replace(/^\.\//, "").replace(/\/$/, "");
+}


### PR DESCRIPTION
Closes #219.

Serves Ix's graph tools over MCP from the CLI itself, so a host talks to `ix mcp`
instead of to one of six separately-maintained plugin servers.

## What this adds

| Command | Does |
|---|---|
| `ix mcp` | Serves the tools over stdio |
| `ix mcp install` | Registers that server with the AI clients on the machine |
| `ix mcp doctor` | Reports what each client currently points at |

Seven hosts are covered: Claude Code, Codex, Cursor, VS Code, Gemini CLI,
OpenClaw and opencode.

Commands run **in-process**, not by shelling back out to `ix` — one CLI startup
per server, not one per tool call.

## Why it is a superset

The six plugins never shared one tool surface, so delegating to `ix mcp` as it
first stood would have *removed* tools from three of them:

| Plugin | Tools | Not served before this |
|---|---:|---|
| codex, cursor | 23 | — |
| gemini | 23 | `ix_decide`, `ix_ingest`, `ix_query`, `ix_status` |
| openclaw, opencode | 17 | + `ix_docs_tool`, `ix_neighbors` |
| claude | 0 (skills only) | — |

`ix_decide` and `ix_ingest` were real gaps and are now served. Three exclusions
are deliberate: `ix_query` is the deprecated command our own docs tell agents not
to use; `ix_neighbors` and `ix_docs_tool` are composites of tools served
individually. `ix_status` is gemini's name for `ix_health`.

Pro tools are advertised only when `@ix/pro` resolves. `ix_briefing` and
`ix_decisions` were previously offered to every install while answering "requires
Ix Pro" on every call — which an agent cannot tell apart from a real failure.
OSS installs see 22 tools, Pro 25.

## install never overwrites

The six plugins register their own server under the same `ix-memory` name, so a
name held by anything that is not `ix mcp` is reported and left alone. `--force`
replaces, `--host` narrows, `--dry-run` writes nothing. A registration that
cannot be read is treated as occupied rather than free — guessing "free" is the
one wrong guess that destroys someone's config.

Writes go through each client's own MCP command where one exists (`claude`/
`codex`/`gemini mcp add`, `openclaw mcp set`, `code --add-mcp`), so the client
owns its config format. Only Cursor (no MCP CLI) and opencode (`opencode mcp add`
is interactive) are written directly — JSON, merged in place, every existing key
preserved, `.bak` kept, and a file that does not parse is refused.

Two detection bugs found against real installs are fixed: Gemini prints its
listing to stderr behind ~28 extension-loader errors, several naming the
extension `ix-memory` — matching the first line containing the name reported a
diagnostic as the registration. And `openclaw mcp show` pretty-prints JSON across
lines, so line-at-a-time matching read our own entry as a stranger's and raised a
false conflict on every re-run.

## Windows

`install` wrote `command: "ix"` for all seven hosts. npm ships no `ix.exe`, only
`ix.CMD`, and a host spawning the bare name through CreateProcess never consults
PATHEXT — so the registration resolved to nothing however well-formed the rest
was. ix-codex-plugin already hit this (its #13); consolidating would have
discarded that fix and handed the problem to every host. The launcher is now
resolved once here and each host records what `where ix` returned. Unix keeps the
bare name, which survives an upgrade that moves the install.

## Testing

798 → **800 tests pass** (59 files), lint clean, build clean. 648 lines of new
tests across `mcp.test.ts`, `mcp-install.test.ts` and `mcp-runner.test.ts`.

Driven end-to-end through a real MCP client. `ix mcp install` was run for real
against cursor, opencode and openclaw and then fully reverted; **the other four
hosts are dry-run only**, and the Windows launcher path is untested on Windows
from this machine — the Unix path is unchanged and resolution falls back to the
bare name.

## What this unblocks

`docs/mcp-plugin-consolidation.md` records the migration order. Two plugin PRs
are already open, green, and gated on `ix >= 0.9.3`:
ix-codex-plugin#24 and ix-cursor-plugin#24 — both lossless.

MCP absorbs the ~15.3k-line tool layer. It has no concept of a hook, skill or
slash command, so ~10.6k lines of agents/hooks/skills stay host-specific and the
plugins do not go away.
