### PR TITLE
chore(release): 0.9.3

### DIFF
--- a/ix-cli/package-lock.json
+++ b/ix-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ix/cli",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ix/cli",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
         "chalk": "^6.0.0",

--- a/ix-cli/package.json
+++ b/ix-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ix/cli",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "description": "Ix Memory — Persistent Memory for LLM Systems",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump for **v0.9.3**, matching what 0.9.2 did.

The release workflow derives the version from the tag name and rewrites
`ix-cli/package.json` at build time, so a released install is unaffected either
way — but this file feeds `getCurrentVersion()`, so without the bump a source
checkout reports the previous version.

That matters more than usual this release: two plugins gate on reading
`ix --version`.

- `ix-codex-plugin` — `MIN_IX_VERSION_FOR_MCP = (0, 9, 3)`
- `ix-cursor-plugin` — the same floor in `install.sh` / `install.ps1`

## What 0.9.3 contains

- **#397** — `ix mcp`: Ix's tools served over MCP from the CLI, with
  `ix mcp install` / `ix mcp doctor` covering seven hosts
- **#393** — a real `POST /__ix/remap` behind a loopback guard, scoped to the
  workspace the visualizer is showing
- #396, #392, #391, #390, #394, #389, #378, #375

814 tests pass on main with both features merged; typecheck, lint and knip clean.