### PR TITLE
fix(mcp): repair the orphan bookkeeping and the Windows quoting from #400

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ opencode. It writes through each client's own MCP command where one exists
 everywhere but Windows), so the client owns its config format. Cursor, VS Code
 and opencode are edited directly instead, as is OpenClaw on Windows — its
 registration is passed as a JSON argument, which cmd cannot carry intact. Every
-direct write is merged in place with a `.bak` kept alongside, and those clients
-are detected by their config directory rather than by a shell command, since
-`cursor` and `code` are opt-in shims a GUI install may not have.
+direct write is merged in place with a `.bak` kept alongside. Cursor, VS Code
+and opencode are also detected by their config directory rather than by a shell
+command, since `cursor` and `code` are opt-in shims a GUI install may not have.
 
 **It never overwrites.** If the name `ix-memory` already belongs to a different
 server — an earlier Ix plugin, say — that client is reported and left exactly as

--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ command, since `cursor` and `code` are opt-in shims a GUI install may not have.
 **It never overwrites.** If the name `ix-memory` already belongs to a different
 server — an earlier Ix plugin, say — that client is reported and left exactly as
 it was. Pass `--force` to replace it, or `--host <id>` to limit the run; an
-unrecognised id is an error rather than a silent no-op. `doctor` additionally
-reports a registration of ours whose recorded launcher path has since
-disappeared, which `install` then repairs without `--force`.
+unrecognised id is an error rather than a silent no-op. For the clients written
+directly, `doctor` also reports a registration of ours whose recorded launcher
+path has since disappeared, and `install` repairs it without `--force`; the
+clients written through their own CLI print a table rather than their stored
+command, so a launcher that has moved there needs `ix mcp install --force`.
 
 To register a single client by hand instead, point it at `ix` with the argument
 `mcp`. For Codex:

--- a/README.md
+++ b/README.md
@@ -71,11 +71,13 @@ ix mcp doctor             # check each client's registration
 
 `install` knows Claude Code, Codex, Cursor, VS Code, Gemini CLI, OpenClaw and
 opencode. It writes through each client's own MCP command where one exists
-(`claude mcp add`, `codex mcp add`, `gemini mcp add`, `openclaw mcp set`), so
-the client owns its config format; Cursor, VS Code and opencode are edited
-directly, and each is merged in place with a `.bak` kept alongside. Those three
-are also detected by their config directory rather than by a shell command,
-since `cursor` and `code` are opt-in shims a GUI install may not have.
+(`claude mcp add`, `codex mcp add`, `gemini mcp add`, and `openclaw mcp set`
+everywhere but Windows), so the client owns its config format. Cursor, VS Code
+and opencode are edited directly instead, as is OpenClaw on Windows — its
+registration is passed as a JSON argument, which cmd cannot carry intact. Every
+direct write is merged in place with a `.bak` kept alongside, and those clients
+are detected by their config directory rather than by a shell command, since
+`cursor` and `code` are opt-in shims a GUI install may not have.
 
 **It never overwrites.** If the name `ix-memory` already belongs to a different
 server — an earlier Ix plugin, say — that client is reported and left exactly as

--- a/README.md
+++ b/README.md
@@ -82,11 +82,13 @@ command, since `cursor` and `code` are opt-in shims a GUI install may not have.
 **It never overwrites.** If the name `ix-memory` already belongs to a different
 server — an earlier Ix plugin, say — that client is reported and left exactly as
 it was. Pass `--force` to replace it, or `--host <id>` to limit the run; an
-unrecognised id is an error rather than a silent no-op. For the clients written
-directly, `doctor` also reports a registration of ours whose recorded launcher
-path has since disappeared, and `install` repairs it without `--force`; the
-clients written through their own CLI print a table rather than their stored
-command, so a launcher that has moved there needs `ix mcp install --force`.
+unrecognised id is an error rather than a silent no-op. Where a client's own
+config can be read back — Cursor, VS Code, opencode, and OpenClaw off Windows —
+`doctor` also reports a registration of ours whose recorded launcher path has
+since disappeared, and `install` repairs it. The clients that answer with a
+rendered table instead expose no stored command, so a launcher that has moved
+there is not detected: clear the name with that client's own command
+(`claude mcp remove ix-memory`) and re-run `ix mcp install`.
 
 To register a single client by hand instead, point it at `ix` with the argument
 `mcp`. For Codex:

--- a/ix-cli/src/cli/__tests__/mcp-install.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-install.test.ts
@@ -404,6 +404,26 @@ describe("registration classification", () => {
     expect(classifyListing(`ix-memory  ${rendered}  mcp  -  enabled`).registration).toBe("ours");
   });
 
+  it.each([
+    ["a cmd wrapper", (p: string) => `ix-memory: cmd /c ${p} mcp - Connected`],
+    ["a flag before the path", (p: string) => `ix-memory: wrapper /q ${p} mcp`],
+    ["a path earlier in the row", (p: string) => `ix-memory (from /home/j/.gemini/settings.json): ${p} mcp`],
+    ["quotes", (p: string) => `ix-memory: "${p}" mcp`],
+  ])("does not mistake %s for the launcher", (_case, render) => {
+    // Reading the row left-to-right, whatever bound the match had was applied
+    // from the wrong end: it started at the first absolute-looking token and
+    // swallowed everything up to the launcher, so `cmd /c C:\...\ix.cmd` — the
+    // documented Windows wrapper form — yielded `/c C:\...\ix.cmd`, stat'd
+    // nothing, and reported a live launcher dead. `stale` re-registers with no
+    // --force, so this silently rewrites a working config.
+    const dir = join(tempDir(), "Program Files", "npm");
+    mkdirSync(dir, { recursive: true });
+    const launcher = join(dir, "ix.cmd");
+    writeFileSync(launcher, "@echo off");
+
+    expect(classifyListing(render(launcher)).registration).toBe("ours");
+  });
+
   // The three hosts that answer with a rendered table rather than JSON, so
   // there is no entry to parse — and the three that record an absolute
   // `ix.cmd` on Windows, which is where staleness matters at all. Reading the

--- a/ix-cli/src/cli/__tests__/mcp-install.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-install.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   ADD_ARGS,
+  REMOVE_ARGS,
   classifyDefinition,
   classifyListing,
   classifyShown,
@@ -37,7 +38,7 @@ function fakeHost(
   id: string,
   registration: Registration,
   options: { installed?: boolean; fails?: boolean; detectInstalled?: () => Promise<boolean> } = {},
-): McpHost & { registerCalls: number } {
+): McpHost & { registerCalls: number; replacedWith: boolean[] } {
   const host = {
     id,
     label: id,
@@ -48,10 +49,12 @@ function fakeHost(
     async inspect() {
       return { registration };
     },
-    async register() {
+    async register(replacing: boolean) {
       host.registerCalls += 1;
+      host.replacedWith.push(replacing);
       if (options.fails) throw new Error("host CLI said no");
     },
+    replacedWith: [] as boolean[],
   };
   return host;
 }
@@ -161,6 +164,24 @@ describe("ix mcp install", () => {
     // skipped the one host it should have rewritten.
     expect(host.registerCalls).toBe(1);
     expect(report.hosts[0]?.outcome).toBe("registered");
+  });
+
+  it("tells the host when it is replacing an existing entry", async () => {
+    const free = fakeHost("free", "none");
+    const taken = fakeHost("taken", "other");
+    const moved = fakeHost("moved", "stale");
+
+    await runInstall({ hosts: [free] });
+    await runInstall({ hosts: [taken], force: true });
+    await runInstall({ hosts: [moved] });
+
+    // `claude mcp add` refuses a name that already exists and has no force
+    // flag, so a host that is not told it is replacing something reports
+    // `failed` and leaves the entry it was asked to overwrite exactly where it
+    // was — which made --force inert there.
+    expect(free.replacedWith).toEqual([false]);
+    expect(taken.replacedWith).toEqual([true]);
+    expect(moved.replacedWith).toEqual([true]);
   });
 
   it("consults a host's own installed check before falling back to PATH", async () => {
@@ -404,58 +425,23 @@ describe("registration classification", () => {
     expect(classifyListing(`ix-memory  ${rendered}  mcp  -  enabled`).registration).toBe("ours");
   });
 
-  // Every row format a host actually prints, and every launcher shape that has
-  // broken one attempt or another at recovering the path back out of the row:
-  // a space, parentheses, brackets, a comma, a wrapper prefix, quotes. All of
-  // them name the launcher we would write today, so all of them are healthy —
-  // and each was reported `stale` by some iteration of the parsing approach,
-  // which re-registers with no --force over a config that was working.
-  const HOST_ROWS: Array<[string, (p: string) => string]> = [
-    ["claude mcp list", (p) => `ix-memory: ${p} mcp - ✓ Connected`],
-    ["codex mcp list", (p) => `ix-memory  ${p}  mcp  -  -  enabled`],
-    ["gemini mcp list", (p) => `✓ ix-memory (from ix-memory): ${p} mcp (stdio) - Connected`],
-    ["a cmd wrapper", (p) => `ix-memory: cmd /c ${p} mcp - Connected`],
-    ["a quoted path", (p) => `ix-memory: "${p}" mcp`],
-  ];
+  it("does not guess at staleness from a rendered listing row", () => {
+    // Five attempts at establishing it from the row alone each produced the
+    // same class of failure — a *working* registration reported stale, which
+    // re-registers with no --force. Parsing the path back out broke on a
+    // different shape every time; comparing the row against the launcher we
+    // would write today instead broke when `where`'s console output, decoded as
+    // UTF-8, mangled a non-ASCII npm prefix and overwrote a hand-repaired
+    // config with an unstartable path. A moved prefix on these hosts is now a
+    // manual `ix mcp install --force` — a real gap, and a smaller one.
+    const rows = [
+      String.raw`ix-memory: C:\Users\gone\AppData\Roaming\npm\ix.cmd mcp - Connected`,
+      String.raw`ix-memory  C:\Program Files (x86)\nodejs\ix.cmd  mcp  -  -  enabled`,
+      String.raw`ix-memory: cmd /c C:\Users\Jane Doe\npm\ix.cmd mcp`,
+      String.raw`ix-memory: C:\Users\José Müller\npm\ix.cmd mcp`,
+    ];
 
-  const LAUNCHER_SHAPES = [
-    String.raw`C:\Users\Jane Doe\AppData\Roaming\npm\ix.cmd`,
-    String.raw`C:\Program Files (x86)\nodejs\ix.cmd`,
-    String.raw`C:\Users\J [work]\npm\ix.cmd`,
-    String.raw`C:\Users\A, B\npm\ix.cmd`,
-    "/opt/my tools/bin/ix",
-  ];
-
-  for (const [host, render] of HOST_ROWS) {
-    it.each(LAUNCHER_SHAPES)(`reads %s in a ${host} row as ours`, (launcher) => {
-      expect(classifyListing(render(launcher), null, launcher).registration).toBe("ours");
-    });
-  }
-
-  it.each(HOST_ROWS)("spots a launcher that is no longer the current one in a %s row", (_host, render) => {
-    // The npm prefix moved — an nvm switch, a reinstall elsewhere. The row
-    // still names the old path, which is what makes every client fail to start
-    // while install skips the repair and doctor calls it healthy.
-    const recorded = String.raw`C:\Users\gone\AppData\Roaming\npm\ix.cmd`;
-    const current = String.raw`C:\Users\now\AppData\Roaming\npm\ix.cmd`;
-
-    expect(classifyListing(render(recorded), null, current)).toMatchObject({
-      registration: "stale",
-      detail: expect.stringContaining(current),
-    });
-  });
-
-  it("ignores separator and case differences in how a host renders the path", () => {
-    const current = String.raw`C:\Users\Me\AppData\Roaming\npm\ix.cmd`;
-
-    expect(
-      classifyListing("ix-memory: c:/users/me/appdata/roaming/npm/ix.cmd mcp", null, current).registration,
-    ).toBe("ours");
-  });
-
-  it("does not judge staleness at all when the launcher is the bare name", () => {
-    // Unix registers `ix`, which survives the install moving. Nothing to check.
-    expect(classifyListing("ix-memory: ix mcp - Connected", null, "ix").registration).toBe("ours");
+    for (const row of rows) expect(classifyListing(row).registration).toBe("ours");
   });
 
   it("recognises a pretty-printed definition split across lines", () => {
@@ -545,6 +531,17 @@ describe("classifyShown", () => {
 });
 
 describe("host registration arguments", () => {
+  it("clears an occupied name with the host's own removal command", () => {
+    // `claude mcp add` refuses a name that already exists and offers no force
+    // flag, so without a removal first `--force` was inert there: install
+    // reported `failed` and left the foreign entry exactly where it was.
+    // Verified end-to-end against the real binary; pinned here because CI has
+    // no host CLI to run.
+    expect(REMOVE_ARGS.claude).toEqual(["mcp", "remove", "--scope", "user", "ix-memory"]);
+    expect(REMOVE_ARGS.codex).toEqual(["mcp", "remove", "ix-memory"]);
+    expect(REMOVE_ARGS.openclaw).toEqual(["mcp", "unset", "ix-memory"]);
+  });
+
   it("pins gemini to user scope", () => {
     // `gemini mcp add` defaults to project scope, writing `<cwd>/.gemini/` —
     // invisible from every other directory, while the report named the

--- a/ix-cli/src/cli/__tests__/mcp-install.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-install.test.ts
@@ -6,7 +6,6 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   ADD_ARGS,
-  REMOVE_ARGS,
   classifyDefinition,
   classifyListing,
   classifyShown,
@@ -38,7 +37,7 @@ function fakeHost(
   id: string,
   registration: Registration,
   options: { installed?: boolean; fails?: boolean; detectInstalled?: () => Promise<boolean> } = {},
-): McpHost & { registerCalls: number; replacedWith: boolean[] } {
+): McpHost & { registerCalls: number } {
   const host = {
     id,
     label: id,
@@ -49,12 +48,10 @@ function fakeHost(
     async inspect() {
       return { registration };
     },
-    async register(replacing: boolean) {
+    async register() {
       host.registerCalls += 1;
-      host.replacedWith.push(replacing);
       if (options.fails) throw new Error("host CLI said no");
     },
-    replacedWith: [] as boolean[],
   };
   return host;
 }
@@ -164,24 +161,6 @@ describe("ix mcp install", () => {
     // skipped the one host it should have rewritten.
     expect(host.registerCalls).toBe(1);
     expect(report.hosts[0]?.outcome).toBe("registered");
-  });
-
-  it("tells the host when it is replacing an existing entry", async () => {
-    const free = fakeHost("free", "none");
-    const taken = fakeHost("taken", "other");
-    const moved = fakeHost("moved", "stale");
-
-    await runInstall({ hosts: [free] });
-    await runInstall({ hosts: [taken], force: true });
-    await runInstall({ hosts: [moved] });
-
-    // `claude mcp add` refuses a name that already exists and has no force
-    // flag, so a host that is not told it is replacing something reports
-    // `failed` and leaves the entry it was asked to overwrite exactly where it
-    // was — which made --force inert there.
-    expect(free.replacedWith).toEqual([false]);
-    expect(taken.replacedWith).toEqual([true]);
-    expect(moved.replacedWith).toEqual([true]);
   });
 
   it("consults a host's own installed check before falling back to PATH", async () => {
@@ -425,25 +404,6 @@ describe("registration classification", () => {
     expect(classifyListing(`ix-memory  ${rendered}  mcp  -  enabled`).registration).toBe("ours");
   });
 
-  it("does not guess at staleness from a rendered listing row", () => {
-    // Five attempts at establishing it from the row alone each produced the
-    // same class of failure — a *working* registration reported stale, which
-    // re-registers with no --force. Parsing the path back out broke on a
-    // different shape every time; comparing the row against the launcher we
-    // would write today instead broke when `where`'s console output, decoded as
-    // UTF-8, mangled a non-ASCII npm prefix and overwrote a hand-repaired
-    // config with an unstartable path. A moved prefix on these hosts is now a
-    // manual `ix mcp install --force` — a real gap, and a smaller one.
-    const rows = [
-      String.raw`ix-memory: C:\Users\gone\AppData\Roaming\npm\ix.cmd mcp - Connected`,
-      String.raw`ix-memory  C:\Program Files (x86)\nodejs\ix.cmd  mcp  -  -  enabled`,
-      String.raw`ix-memory: cmd /c C:\Users\Jane Doe\npm\ix.cmd mcp`,
-      String.raw`ix-memory: C:\Users\José Müller\npm\ix.cmd mcp`,
-    ];
-
-    for (const row of rows) expect(classifyListing(row).registration).toBe("ours");
-  });
-
   it("recognises a pretty-printed definition split across lines", () => {
     // `openclaw mcp show` puts "ix" and "mcp" on separate lines; matching one
     // line at a time reads our own entry as a stranger's.
@@ -531,17 +491,6 @@ describe("classifyShown", () => {
 });
 
 describe("host registration arguments", () => {
-  it("clears an occupied name with the host's own removal command", () => {
-    // `claude mcp add` refuses a name that already exists and offers no force
-    // flag, so without a removal first `--force` was inert there: install
-    // reported `failed` and left the foreign entry exactly where it was.
-    // Verified end-to-end against the real binary; pinned here because CI has
-    // no host CLI to run.
-    expect(REMOVE_ARGS.claude).toEqual(["mcp", "remove", "--scope", "user", "ix-memory"]);
-    expect(REMOVE_ARGS.codex).toEqual(["mcp", "remove", "ix-memory"]);
-    expect(REMOVE_ARGS.openclaw).toEqual(["mcp", "unset", "ix-memory"]);
-  });
-
   it("pins gemini to user scope", () => {
     // `gemini mcp add` defaults to project scope, writing `<cwd>/.gemini/` —
     // invisible from every other directory, while the report named the

--- a/ix-cli/src/cli/__tests__/mcp-install.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-install.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -339,26 +339,55 @@ describe("registration classification", () => {
     expect(classifyListing("some-other-server: npx thing").registration).toBe("none");
   });
 
-  it("reports an absolute launcher path that no longer resolves as stale", () => {
-    // What a Windows registration looks like after an nvm switch or a reinstall
-    // to a different prefix. Judged from the command string alone this reads as
-    // healthy, so install skipped it and doctor called it registered while every
-    // client failed to start a single Ix tool.
-    const entry = JSON.stringify({ command: "C:\\Users\\gone\\AppData\\Roaming\\npm\\ix.cmd", args: ["mcp"] });
-
-    expect(classifyListing(`ix-memory ${entry}`)).toMatchObject({
+  it.each([
+    String.raw`C:\Users\gone\AppData\Roaming\npm\ix.cmd`,
+    // A Windows username with a space is the common case, not the edge one; a
+    // first attempt that recovered the path by regex stopped at the space and
+    // read this as healthy — for most of the users the check was written for.
+    String.raw`C:\Users\Jane Doe\AppData\Roaming\npm\ix.cmd`,
+    String.raw`C:\Program Files\nodejs\ix.cmd`,
+    "/opt/my tools/bin/ix",
+  ])("reports %s as stale once it no longer resolves", (command) => {
+    // What a registration looks like after an nvm switch or a reinstall to a
+    // different prefix. Read as healthy, install skipped the one host it should
+    // have repaired while doctor agreed it was fine.
+    expect(classifyListing(`ix-memory ${JSON.stringify({ command, args: ["mcp"] })}`, command)).toMatchObject({
       registration: "stale",
       detail: expect.stringContaining("no longer exists"),
     });
   });
 
   it("keeps an absolute launcher that does resolve as ours", () => {
-    const launcher = join(tempDir(), "ix.cmd");
+    // Written under a directory with a space in it, so this cannot pass merely
+    // by failing to recognise the path as a path.
+    const dir = join(tempDir(), "my tools");
+    mkdirSync(dir, { recursive: true });
+    const launcher = join(dir, "ix.cmd");
     writeFileSync(launcher, "@echo off");
 
-    expect(classifyListing(`ix-memory ${JSON.stringify({ command: launcher, args: ["mcp"] })}`).registration).toBe(
+    expect(
+      classifyListing(`ix-memory ${JSON.stringify({ command: launcher, args: ["mcp"] })}`, launcher).registration,
+    ).toBe("ours");
+  });
+
+  it("leaves a launcher it cannot conclusively stat alone", () => {
+    // An unreachable UNC path fails to stat with something other than ENOENT.
+    // A file server being offline is not evidence the launcher is gone, and
+    // `stale` triggers a rewrite with no --force, so only ENOENT counts.
+    const unc = String.raw`\\server-that-does-not-exist\share\npm\ix.cmd`;
+
+    expect(classifyListing(`ix-memory ${JSON.stringify({ command: unc, args: ["mcp"] })}`, unc).registration).toBe(
       "ours",
     );
+  });
+
+  it("does not invent a stale launcher out of a path that is merely rendered", () => {
+    // The recovered-by-regex version latched onto the `/npm/ix.cmd` suffix of a
+    // live path and stat'd that instead, so `install` rewrote a working
+    // registration with no --force and `doctor` exited 1 on a healthy machine.
+    const rendered = "ix-memory  C:/Users/jane/Program Files/npm/ix.cmd  mcp  -  enabled";
+
+    expect(classifyListing(rendered).registration).toBe("ours");
   });
 
   it("recognises a pretty-printed definition split across lines", () => {
@@ -399,6 +428,21 @@ describe("quoteForCmd", () => {
     );
   });
 
+  it.each([
+    String.raw`C:\Users\R&D\npm\ix.cmd`,
+    String.raw`C:\a^b\ix.cmd`,
+    String.raw`C:\a|b\ix.cmd`,
+  ])("quotes %s, which carries a metacharacter but no space", (path) => {
+    // The case the test above cannot reach, because its fixture has a space and
+    // so takes the quoting branch either way. A "does this need quoting?" check
+    // that asks only about whitespace lets these through bare: verified by
+    // round-trip that `C:\Users\R&D\npm\ix.cmd` then arrives as `C:\Users\R`
+    // with cmd running `D\npm\ix.cmd` as a second command, and that
+    // `C:\a^b\ix.cmd` arrives silently as `C:\ab\ix.cmd` — a wrong launcher
+    // path written into every host config and reported as a success.
+    expect(quoteForCmd(path)).toBe(`"${path}"`);
+  });
+
   it("leaves an ordinary argument alone", () => {
     expect(quoteForCmd("--scope")).toBe("--scope");
   });
@@ -416,6 +460,13 @@ describe("classifyShown", () => {
 
   it("still reads an explicit 'no such server' as free", () => {
     expect(classifyShown("No MCP server named ix-memory\n", false).registration).toBe("none");
+  });
+
+  it("does not read an unrelated 'not found' as free", () => {
+    // A missing plugin, or the host's own loader failing. Neither says anything
+    // about our name, and reading one as an empty slot writes over whatever the
+    // user had — the very thing this function exists to prevent.
+    expect(classifyShown("Error: plugin 'foo' not found\n", false).registration).toBe("unknown");
   });
 
   it("reads a definition body as ours", () => {

--- a/ix-cli/src/cli/__tests__/mcp-install.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-install.test.ts
@@ -370,8 +370,11 @@ describe("registration classification", () => {
     ).toBe("ours");
   });
 
-  it("leaves a launcher it cannot conclusively stat alone", () => {
-    // An unreachable UNC path fails to stat with something other than ENOENT.
+  // Windows-only by nature: a UNC path is a network location there, and stat
+  // fails on it with something other than ENOENT. Everywhere else those
+  // backslashes are ordinary filename characters, so the path really is absent
+  // and `stale` is the right answer.
+  it.skipIf(process.platform !== "win32")("leaves a launcher it cannot conclusively stat alone", () => {
     // A file server being offline is not evidence the launcher is gone, and
     // `stale` triggers a rewrite with no --force, so only ENOENT counts.
     const unc = String.raw`\\server-that-does-not-exist\share\npm\ix.cmd`;

--- a/ix-cli/src/cli/__tests__/mcp-install.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-install.test.ts
@@ -384,13 +384,41 @@ describe("registration classification", () => {
     );
   });
 
-  it("does not invent a stale launcher out of a path that is merely rendered", () => {
-    // The recovered-by-regex version latched onto the `/npm/ix.cmd` suffix of a
-    // live path and stat'd that instead, so `install` rewrote a working
-    // registration with no --force and `doctor` exited 1 on a healthy machine.
-    const rendered = "ix-memory  C:/Users/jane/Program Files/npm/ix.cmd  mcp  -  enabled";
+  it("does not invent a stale launcher out of a suffix of a live path", () => {
+    // A launcher that genuinely exists, sitting under a `.../npm/ix.cmd` tail.
+    // A regex allowed to start at an interior `/` matched only that tail,
+    // stat'd `/npm/ix.cmd` from the filesystem root, found nothing, and called
+    // a working registration stale — so `install` rewrote it with no --force
+    // and `doctor` exited 1 on a healthy machine. The fixture has to use a path
+    // that exists, or it cannot tell the two behaviours apart.
+    const dir = join(tempDir(), "Program Files", "npm");
+    mkdirSync(dir, { recursive: true });
+    const launcher = join(dir, "ix.cmd");
+    writeFileSync(launcher, "@echo off");
+    // Both properties are needed to reproduce it: the space stops an
+    // unanchored match from spanning the path from its start, and the forward
+    // slashes then give it an interior `/npm/ix.cmd` to latch onto instead.
+    // A temp path without either cannot tell the two behaviours apart.
+    const rendered = launcher.replaceAll("\\", "/");
 
-    expect(classifyListing(rendered).registration).toBe("ours");
+    expect(classifyListing(`ix-memory  ${rendered}  mcp  -  enabled`).registration).toBe("ours");
+  });
+
+  // The three hosts that answer with a rendered table rather than JSON, so
+  // there is no entry to parse — and the three that record an absolute
+  // `ix.cmd` on Windows, which is where staleness matters at all. Reading the
+  // launcher only from parsed entries left these silently unchecked.
+  it.each([
+    ["claude mcp list", (p: string) => `ix-memory: ${p} mcp - ✓ Connected`],
+    ["codex mcp list", (p: string) => `ix-memory  ${p}  mcp  -  -  enabled`],
+    ["gemini mcp list", (p: string) => `✓ ix-memory (from ix-memory): ${p} mcp (stdio) - Connected`],
+  ])("spots a dead launcher in a %s row", (_host, render) => {
+    const dead = String.raw`C:\Users\Jane Doe\AppData\Roaming\npm\ix.cmd`;
+
+    expect(classifyListing(render(dead))).toMatchObject({
+      registration: "stale",
+      detail: expect.stringContaining("no longer exists"),
+    });
   });
 
   it("recognises a pretty-printed definition split across lines", () => {

--- a/ix-cli/src/cli/__tests__/mcp-install.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-install.test.ts
@@ -404,41 +404,58 @@ describe("registration classification", () => {
     expect(classifyListing(`ix-memory  ${rendered}  mcp  -  enabled`).registration).toBe("ours");
   });
 
-  it.each([
-    ["a cmd wrapper", (p: string) => `ix-memory: cmd /c ${p} mcp - Connected`],
-    ["a flag before the path", (p: string) => `ix-memory: wrapper /q ${p} mcp`],
-    ["a path earlier in the row", (p: string) => `ix-memory (from /home/j/.gemini/settings.json): ${p} mcp`],
-    ["quotes", (p: string) => `ix-memory: "${p}" mcp`],
-  ])("does not mistake %s for the launcher", (_case, render) => {
-    // Reading the row left-to-right, whatever bound the match had was applied
-    // from the wrong end: it started at the first absolute-looking token and
-    // swallowed everything up to the launcher, so `cmd /c C:\...\ix.cmd` — the
-    // documented Windows wrapper form — yielded `/c C:\...\ix.cmd`, stat'd
-    // nothing, and reported a live launcher dead. `stale` re-registers with no
-    // --force, so this silently rewrites a working config.
-    const dir = join(tempDir(), "Program Files", "npm");
-    mkdirSync(dir, { recursive: true });
-    const launcher = join(dir, "ix.cmd");
-    writeFileSync(launcher, "@echo off");
+  // Every row format a host actually prints, and every launcher shape that has
+  // broken one attempt or another at recovering the path back out of the row:
+  // a space, parentheses, brackets, a comma, a wrapper prefix, quotes. All of
+  // them name the launcher we would write today, so all of them are healthy —
+  // and each was reported `stale` by some iteration of the parsing approach,
+  // which re-registers with no --force over a config that was working.
+  const HOST_ROWS: Array<[string, (p: string) => string]> = [
+    ["claude mcp list", (p) => `ix-memory: ${p} mcp - ✓ Connected`],
+    ["codex mcp list", (p) => `ix-memory  ${p}  mcp  -  -  enabled`],
+    ["gemini mcp list", (p) => `✓ ix-memory (from ix-memory): ${p} mcp (stdio) - Connected`],
+    ["a cmd wrapper", (p) => `ix-memory: cmd /c ${p} mcp - Connected`],
+    ["a quoted path", (p) => `ix-memory: "${p}" mcp`],
+  ];
 
-    expect(classifyListing(render(launcher)).registration).toBe("ours");
+  const LAUNCHER_SHAPES = [
+    String.raw`C:\Users\Jane Doe\AppData\Roaming\npm\ix.cmd`,
+    String.raw`C:\Program Files (x86)\nodejs\ix.cmd`,
+    String.raw`C:\Users\J [work]\npm\ix.cmd`,
+    String.raw`C:\Users\A, B\npm\ix.cmd`,
+    "/opt/my tools/bin/ix",
+  ];
+
+  for (const [host, render] of HOST_ROWS) {
+    it.each(LAUNCHER_SHAPES)(`reads %s in a ${host} row as ours`, (launcher) => {
+      expect(classifyListing(render(launcher), null, launcher).registration).toBe("ours");
+    });
+  }
+
+  it.each(HOST_ROWS)("spots a launcher that is no longer the current one in a %s row", (_host, render) => {
+    // The npm prefix moved — an nvm switch, a reinstall elsewhere. The row
+    // still names the old path, which is what makes every client fail to start
+    // while install skips the repair and doctor calls it healthy.
+    const recorded = String.raw`C:\Users\gone\AppData\Roaming\npm\ix.cmd`;
+    const current = String.raw`C:\Users\now\AppData\Roaming\npm\ix.cmd`;
+
+    expect(classifyListing(render(recorded), null, current)).toMatchObject({
+      registration: "stale",
+      detail: expect.stringContaining(current),
+    });
   });
 
-  // The three hosts that answer with a rendered table rather than JSON, so
-  // there is no entry to parse — and the three that record an absolute
-  // `ix.cmd` on Windows, which is where staleness matters at all. Reading the
-  // launcher only from parsed entries left these silently unchecked.
-  it.each([
-    ["claude mcp list", (p: string) => `ix-memory: ${p} mcp - ✓ Connected`],
-    ["codex mcp list", (p: string) => `ix-memory  ${p}  mcp  -  -  enabled`],
-    ["gemini mcp list", (p: string) => `✓ ix-memory (from ix-memory): ${p} mcp (stdio) - Connected`],
-  ])("spots a dead launcher in a %s row", (_host, render) => {
-    const dead = String.raw`C:\Users\Jane Doe\AppData\Roaming\npm\ix.cmd`;
+  it("ignores separator and case differences in how a host renders the path", () => {
+    const current = String.raw`C:\Users\Me\AppData\Roaming\npm\ix.cmd`;
 
-    expect(classifyListing(render(dead))).toMatchObject({
-      registration: "stale",
-      detail: expect.stringContaining("no longer exists"),
-    });
+    expect(
+      classifyListing("ix-memory: c:/users/me/appdata/roaming/npm/ix.cmd mcp", null, current).registration,
+    ).toBe("ours");
+  });
+
+  it("does not judge staleness at all when the launcher is the bare name", () => {
+    // Unix registers `ix`, which survives the install moving. Nothing to check.
+    expect(classifyListing("ix-memory: ix mcp - Connected", null, "ix").registration).toBe("ours");
   });
 
   it("recognises a pretty-printed definition split across lines", () => {

--- a/ix-cli/src/cli/__tests__/mcp-runner.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-runner.test.ts
@@ -132,8 +132,14 @@ async function withLockDir(body: () => Promise<void>): Promise<void> {
 
 const originalSubprocessFlag = process.env.IX_MCP_SUBPROCESS;
 
-/** Longer than the slowest command any test here abandons. */
-const DRAIN_MS = 500;
+/**
+ * Longer than the slowest command any test here abandons and then waits for.
+ *
+ * Every test pays it, so it is kept close to what the slowest one needs rather
+ * than padded: at 500 it added ~11s to this file alone. The two commands that
+ * never settle are unaffected either way — their grace is what bounds them.
+ */
+const DRAIN_MS = 250;
 
 afterEach(async () => {
   if (originalSubprocessFlag === undefined) delete process.env.IX_MCP_SUBPROCESS;
@@ -293,7 +299,7 @@ describe("in-process ix runner", () => {
       const mapped = run(["map", "--hold", "400"]);
 
       expect((await orphan).ok).toBe(false);
-      // releaseHeldLocks drops *every* lock this process holds, not the
+      // Releasing every lock the process holds drops more than the
       // finishing command's, so an orphan settling mid-map deleted the lock of
       // the map that was still running — reopening the exact window
       // single-flight exists to close.

--- a/ix-cli/src/cli/__tests__/mcp-runner.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-runner.test.ts
@@ -77,13 +77,15 @@ function createTestProgram(): Command {
   program
     .command("map")
     .option("--hold <ms>", "keep working after taking the lock", "0")
-    .action(async (opts: { hold: string }) => {
+    .option("--hang", "take the lock and never finish")
+    .action(async (opts: { hold: string; hang?: boolean }) => {
       const workspace = process.env.IX_TEST_WORKSPACE ?? "workspace";
       const lock = acquireMapLock(workspace, "ix map test");
       if (!lock) {
         console.log("coalesced");
         return;
       }
+      if (opts.hang) await new Promise(() => {});
       await new Promise((resolve) => setTimeout(resolve, Number(opts.hold)));
       // Whether the lock this command took is still its own by the time it
       // finishes — anything releasing it mid-run reopens the window.
@@ -130,9 +132,20 @@ async function withLockDir(body: () => Promise<void>): Promise<void> {
 
 const originalSubprocessFlag = process.env.IX_MCP_SUBPROCESS;
 
-afterEach(() => {
+/** Longer than the slowest command any test here abandons. */
+const DRAIN_MS = 500;
+
+afterEach(async () => {
   if (originalSubprocessFlag === undefined) delete process.env.IX_MCP_SUBPROCESS;
   else process.env.IX_MCP_SUBPROCESS = originalSubprocessFlag;
+
+  // Several tests deliberately abandon a command at its timeout, and an
+  // abandoned command outlives the test that started it. The runner's state is
+  // module-level, so while one is in flight every later test sees exit codes
+  // distrusted and a lock held — which is correct behaviour, and silently
+  // changes what an unrelated assertion observes. Draining here rather than at
+  // the end of each body means a failing assertion cannot skip it.
+  await new Promise((resolve) => setTimeout(resolve, DRAIN_MS));
 });
 
 describe("in-process ix runner", () => {
@@ -297,21 +310,38 @@ describe("in-process ix runner", () => {
       });
 
       // Abandoned at 40ms, grace fires at ~100ms, still working until ~400ms.
-      // The grace drops the distrust; the command is still entitled to its lock
-      // until it actually finishes, and releasing it there hands a second map
-      // the workspace out from under this one.
+      // The grace drops the exit-code distrust; the lock is a separate lifetime
+      // and stays with the command that is still using it.
       expect((await run(["map", "--hold", "400"], 40)).ok).toBe(false);
       await new Promise((resolve) => setTimeout(resolve, 200));
-      expect((await run(["map"], 5_000)).stdout).toBe("coalesced\n");
 
-      // Drained before returning: an abandoned command outlives the test that
-      // started it, and its settle-path afterCommand would otherwise land in
-      // the middle of whichever test is running by then.
-      await new Promise((resolve) => setTimeout(resolve, 400));
+      // An unrelated command completing must not take the running map's lock
+      // with it — releasing everything held is what did, one call later than
+      // the grace itself.
+      expect((await run(["say", "unrelated"], 5_000)).stdout).toBe("out:unrelated\n");
+      expect((await run(["map"], 5_000)).stdout).toBe("coalesced\n");
     });
   });
 
-  it("still resets the read scope when a command that overran its grace finishes", async () => {
+  it("releases the lock of a command that overran its grace once it finishes", async () => {
+    await withLockDir(async () => {
+      const run = createInProcessRunner({
+        version: "test-version",
+        createProgram: createTestProgram,
+        orphanGraceMs: 40,
+      });
+
+      // The other direction: holding every lock back to protect a running
+      // command stranded the ones whose command had genuinely finished, and the
+      // next ix_map coalesced forever. Ownership is what lets both hold.
+      await run(["map", "--hold", "250"], 30);
+      await new Promise((resolve) => setTimeout(resolve, 400));
+
+      expect((await run(["map"], 5_000)).stdout).toBe("mapped\n");
+    });
+  });
+
+  it("invalidates the read scope for a command that never settles at all", async () => {
     await withLockDir(async () => {
       const run = createInProcessRunner({
         version: "test-version",
@@ -320,15 +350,13 @@ describe("in-process ix runner", () => {
       });
       resetReadScope.mockClear();
 
-      // Abandoned at 30ms, grace at ~70ms, ingest completes at ~300ms. Resetting
-      // at the grace instead would fire mid-ingest and never fire again, leaving
-      // the pre-map scope pinned with nothing left to invalidate it.
-      await run(["map", "--hold", "300"], 30);
-      await new Promise((resolve) => setTimeout(resolve, 120));
-      expect(resetReadScope).not.toHaveBeenCalled();
+      // A hung `ix map` has no settle to hang the invalidation off, so the
+      // grace has to carry it — otherwise the pre-map scope stays pinned for
+      // the life of the server with nothing left to clear it.
+      await run(["map", "--hang"], 30);
+      await new Promise((resolve) => setTimeout(resolve, 150));
 
-      await new Promise((resolve) => setTimeout(resolve, 300));
-      expect(resetReadScope).toHaveBeenCalledTimes(1);
+      expect(resetReadScope).toHaveBeenCalled();
     });
   });
 

--- a/ix-cli/src/cli/__tests__/mcp-runner.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-runner.test.ts
@@ -1,11 +1,11 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { Command } from "commander";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { acquireMapLock } from "../single-flight.js";
+import { acquireMapLock, lockPathForTest } from "../single-flight.js";
 import { createInProcessRunner, resolveDefaultRunner, runCurrentIx } from "../../mcp/runner.js";
 
 const resetReadScope = vi.hoisted(() => vi.fn());
@@ -76,18 +76,56 @@ function createTestProgram(): Command {
   // process exit to release.
   program
     .command("map")
-    .action(() => {
-      const lock = acquireMapLock(process.env.IX_TEST_WORKSPACE ?? "workspace", "ix map test");
-      console.log(lock ? "mapped" : "coalesced");
+    .option("--hold <ms>", "keep working after taking the lock", "0")
+    .action(async (opts: { hold: string }) => {
+      const workspace = process.env.IX_TEST_WORKSPACE ?? "workspace";
+      const lock = acquireMapLock(workspace, "ix map test");
+      if (!lock) {
+        console.log("coalesced");
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, Number(opts.hold)));
+      // Whether the lock this command took is still its own by the time it
+      // finishes — anything releasing it mid-run reopens the window.
+      console.log(existsSync(lockPathForTest(workspace)) ? "mapped" : "lock-taken-mid-run");
     });
 
   program.command("ingest").action(() => console.log("ingested"));
+
+  // Never settles: a hung backend call, or a rejection that used to end the
+  // process and is now only logged by the server's error handlers.
+  program.command("hang").action(async () => {
+    await new Promise(() => {});
+  });
 
   return program;
 }
 
 function testRunner() {
   return createInProcessRunner({ version: "test-version", createProgram: createTestProgram });
+}
+
+/**
+ * Run a body against a throwaway lock directory.
+ *
+ * Any test whose commands reach `acquireMapLock` needs this: without it the
+ * lock lands in the developer's real `~/.ix/locks` and can block their own
+ * `ix map` for twenty minutes.
+ */
+async function withLockDir(body: () => Promise<void>): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), "ix-mcp-lock-"));
+  const previous = { lockDir: process.env.IX_LOCK_DIR, workspace: process.env.IX_TEST_WORKSPACE };
+  process.env.IX_LOCK_DIR = dir;
+  process.env.IX_TEST_WORKSPACE = join(dir, "workspace");
+  try {
+    await body();
+  } finally {
+    if (previous.lockDir === undefined) delete process.env.IX_LOCK_DIR;
+    else process.env.IX_LOCK_DIR = previous.lockDir;
+    if (previous.workspace === undefined) delete process.env.IX_TEST_WORKSPACE;
+    else process.env.IX_TEST_WORKSPACE = previous.workspace;
+    rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 const originalSubprocessFlag = process.env.IX_MCP_SUBPROCESS;
@@ -219,13 +257,7 @@ describe("in-process ix runner", () => {
   });
 
   it("releases the map single-flight lock when the command ends, not the process", async () => {
-    const lockDir = mkdtempSync(join(tmpdir(), "ix-mcp-lock-"));
-    const previousLockDir = process.env.IX_LOCK_DIR;
-    const previousWorkspace = process.env.IX_TEST_WORKSPACE;
-    process.env.IX_LOCK_DIR = lockDir;
-    process.env.IX_TEST_WORKSPACE = join(lockDir, "workspace");
-
-    try {
+    await withLockDir(async () => {
       const run = testRunner();
 
       const first = await run(["map"]);
@@ -236,27 +268,61 @@ describe("in-process ix runner", () => {
       // stale. Held across calls, every later ix_map coalesced into an empty
       // success while the graph was never refreshed.
       expect(second.stdout).toBe("mapped\n");
-    } finally {
-      if (previousLockDir === undefined) delete process.env.IX_LOCK_DIR;
-      else process.env.IX_LOCK_DIR = previousLockDir;
-      if (previousWorkspace === undefined) delete process.env.IX_TEST_WORKSPACE;
-      else process.env.IX_TEST_WORKSPACE = previousWorkspace;
-      rmSync(lockDir, { recursive: true, force: true });
-    }
+    });
+  });
+
+  it("does not release a running command's lock when an orphan settles", async () => {
+    await withLockDir(async () => {
+      const run = testRunner();
+
+      // Abandoned at 40ms, settles at ~150ms — part-way through the map below.
+      const orphan = run(["slow", "--delay", "150", "--tag", "orphan"], 40);
+      const mapped = run(["map", "--hold", "400"]);
+
+      expect((await orphan).ok).toBe(false);
+      // releaseHeldLocks drops *every* lock this process holds, not the
+      // finishing command's, so an orphan settling mid-map deleted the lock of
+      // the map that was still running — reopening the exact window
+      // single-flight exists to close.
+      expect((await mapped).stdout).toBe("mapped\n");
+    });
+  });
+
+  it("stops distrusting the exit code once an abandoned command overruns its grace", async () => {
+    await withLockDir(async () => {
+      const run = createInProcessRunner({
+        version: "test-version",
+        createProgram: createTestProgram,
+        orphanGraceMs: 60,
+      });
+      process.exitCode = undefined;
+
+      // Never settles, so nothing will ever remove it from the orphan set.
+      // Left unbounded, every later failure reports ok and no lock is ever
+      // released again — both for the life of the server.
+      await run(["hang"], 30);
+      await new Promise((resolve) => setTimeout(resolve, 120));
+
+      expect(await run(["soft-fail"], 30)).toMatchObject({ ok: false });
+      expect((await run(["map"], 30)).stdout).toBe("mapped\n");
+      expect((await run(["map"], 30)).stdout).toBe("mapped\n");
+    });
   });
 
   it("invalidates the read-scope cache after a command that can change it", async () => {
-    const run = testRunner();
-    resetReadScope.mockClear();
+    await withLockDir(async () => {
+      const run = testRunner();
+      resetReadScope.mockClear();
 
-    await run(["say", "read"]);
-    expect(resetReadScope).not.toHaveBeenCalled();
+      await run(["say", "read"]);
+      expect(resetReadScope).not.toHaveBeenCalled();
 
-    // `ix map` can stitch the repo into a System server-side; every later read
-    // in the session would otherwise still scope to the pre-map workspace.
-    await run(["map"]);
-    await run(["ingest"]);
-    expect(resetReadScope).toHaveBeenCalledTimes(2);
+      // `ix map` can stitch the repo into a System server-side; every later read
+      // in the session would otherwise still scope to the pre-map workspace.
+      await run(["map"]);
+      await run(["ingest"]);
+      expect(resetReadScope).toHaveBeenCalledTimes(2);
+    });
   });
 
   it("truncates output instead of growing the server heap without bound", async () => {

--- a/ix-cli/src/cli/__tests__/mcp-runner.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-runner.test.ts
@@ -288,6 +288,50 @@ describe("in-process ix runner", () => {
     });
   });
 
+  it("does not release a still-running command's lock when its own grace fires", async () => {
+    await withLockDir(async () => {
+      const run = createInProcessRunner({
+        version: "test-version",
+        createProgram: createTestProgram,
+        orphanGraceMs: 60,
+      });
+
+      // Abandoned at 40ms, grace fires at ~100ms, still working until ~400ms.
+      // The grace drops the distrust; the command is still entitled to its lock
+      // until it actually finishes, and releasing it there hands a second map
+      // the workspace out from under this one.
+      expect((await run(["map", "--hold", "400"], 40)).ok).toBe(false);
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect((await run(["map"], 5_000)).stdout).toBe("coalesced\n");
+
+      // Drained before returning: an abandoned command outlives the test that
+      // started it, and its settle-path afterCommand would otherwise land in
+      // the middle of whichever test is running by then.
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    });
+  });
+
+  it("still resets the read scope when a command that overran its grace finishes", async () => {
+    await withLockDir(async () => {
+      const run = createInProcessRunner({
+        version: "test-version",
+        createProgram: createTestProgram,
+        orphanGraceMs: 40,
+      });
+      resetReadScope.mockClear();
+
+      // Abandoned at 30ms, grace at ~70ms, ingest completes at ~300ms. Resetting
+      // at the grace instead would fire mid-ingest and never fire again, leaving
+      // the pre-map scope pinned with nothing left to invalidate it.
+      await run(["map", "--hold", "300"], 30);
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      expect(resetReadScope).not.toHaveBeenCalled();
+
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(resetReadScope).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("stops distrusting the exit code once an abandoned command overruns its grace", async () => {
     await withLockDir(async () => {
       const run = createInProcessRunner({

--- a/ix-cli/src/cli/single-flight.ts
+++ b/ix-cli/src/cli/single-flight.ts
@@ -127,8 +127,32 @@ export function acquireMapLock(workspaceRoot: string, label: string): LockHandle
 }
 
 // Locks this process still holds. `ix mcp` runs commands in-process, so "the
-// process exits" is no longer the end of a command — see releaseHeldLocks.
-const held = new Set<() => void>();
+// process exits" is no longer the end of a command — see releaseLocksOwnedBy.
+/**
+ * Whatever the caller uses to identify the command taking a lock.
+ *
+ * Opaque here: single-flight only ever compares it by identity.
+ */
+export type LockOwner = unknown;
+
+let resolveOwner: () => LockOwner = () => null;
+
+/**
+ * Teach single-flight how to tell which command is acquiring a lock.
+ *
+ * "The process holds this lock" stopped meaning "this command holds it" when
+ * `ix mcp` began running many commands in one process. Without an owner the
+ * only available release is "drop everything", which either takes a still-
+ * running command's lock away or, if held back to avoid that, never releases
+ * the finished command's at all. The MCP runner installs a resolver backed by
+ * its async-context store; the plain CLI leaves this unset and keeps releasing
+ * on process exit, exactly as before.
+ */
+export function setLockOwnerResolver(resolve: () => LockOwner): void {
+  resolveOwner = resolve;
+}
+
+const held = new Map<() => void, LockOwner>();
 
 function makeHandle(path: string): LockHandle {
   let released = false;
@@ -147,7 +171,7 @@ function makeHandle(path: string): LockHandle {
   const onSigint = (): void => { release(); process.exit(130); };
   const onSigterm = (): void => { release(); process.exit(143); };
 
-  held.add(release);
+  held.set(release, resolveOwner());
   // Release on normal exit and on the common termination signals so a killed
   // map (hook timeout, Ctrl-C) does not leave a lock that blocks the next run
   // until it ages out.
@@ -158,7 +182,7 @@ function makeHandle(path: string): LockHandle {
 }
 
 /**
- * Release every lock this process still holds.
+ * Release the locks one command took, and only those.
  *
  * `ix map` takes its lock and leaves it to process exit, which was the end of
  * the command until `ix mcp` began running commands in-process. There, the
@@ -166,9 +190,13 @@ function makeHandle(path: string): LockHandle {
  * stale: the first ix_map works and every later one coalesces into an empty
  * success while the graph is never refreshed. The MCP runner calls this when a
  * command finishes, restoring the boundary the process used to provide.
+ *
+ * Scoped by owner rather than releasing everything, so a command that outlived
+ * its timeout keeps the lock it is still using while a *different* command that
+ * has genuinely finished still gives its own up.
  */
-export function releaseHeldLocks(): void {
-  for (const release of [...held]) release();
+export function releaseLocksOwnedBy(owner: LockOwner): void {
+  for (const [release, heldBy] of [...held]) if (heldBy === owner) release();
 }
 
 // ── Test-only surface ──────────────────────────────────────────────────────

--- a/ix-cli/src/mcp/hosts.ts
+++ b/ix-cli/src/mcp/hosts.ts
@@ -259,8 +259,35 @@ function isAbsolutePath(value: string): boolean {
  * body plus the trailing `ix` anchor is what lets both hold at once.
  */
 function launcherInText(text: string): string | null {
-  const match = /(?:^|[\s"'])((?:[A-Za-z]:[\\/]|\/)[^"']*?[\\/]ix(?:\.\w+)?)(?=[\s"',\]]|$)/.exec(text);
-  return match?.[1] ?? null;
+  const tokens = text.split(/\s+/).filter(Boolean).map(trimDelimiters);
+
+  // Anchor on the `ix` end and walk backwards. Scanning forward is what sank
+  // both previous attempts: whatever bound the match had, it was applied from
+  // the left, so it either stopped at the first space (missing the common
+  // `C:\Users\Jane Doe\...`) or swallowed everything from an earlier
+  // absolute-looking token — `cmd /c C:\...\ix.cmd`, the documented Windows
+  // wrapper form, yielded `/c C:\...\ix.cmd` and reported a live launcher dead.
+  let end = -1;
+  for (let i = tokens.length - 1; i >= 0; i -= 1) {
+    if (/[\\/]ix(?:\.\w+)?$/.test(tokens[i]!)) {
+      end = i;
+      break;
+    }
+  }
+  if (end === -1) return null;
+
+  // The nearest absolute-path start at or before it. Nearest, not earliest:
+  // a path only ever extends leftwards to where it begins, and stopping at the
+  // first one found going back is what keeps a preceding flag out of the match.
+  for (let start = end; start >= 0; start -= 1) {
+    if (isAbsolutePath(tokens[start]!)) return tokens.slice(start, end + 1).join(" ");
+  }
+  return null;
+}
+
+/** Strip the punctuation a listing wraps a value in, without touching the path. */
+function trimDelimiters(token: string): string {
+  return token.replace(/^["'([]+/, "").replace(/["'),\]:]+$/, "");
 }
 
 /**

--- a/ix-cli/src/mcp/hosts.ts
+++ b/ix-cli/src/mcp/hosts.ts
@@ -51,8 +51,14 @@ export interface McpHost {
   detectInstalled?(): Promise<boolean>;
   /** Read-only look at what holds {@link SERVER_NAME} today. */
   inspect(): Promise<Pick<HostStatus, "registration" | "detail">>;
-  /** Register `ix mcp`. Only called once inspect reports it is safe. */
-  register(): Promise<void>;
+  /**
+   * Register `ix mcp`. Only called once inspect reports it is safe.
+   *
+   * `replacing` says the name is currently held — by a stale entry of ours, or
+   * by a different server the caller has chosen to overwrite with `--force`.
+   * Hosts whose `add` refuses an occupied name need to clear it first.
+   */
+  register(replacing: boolean): Promise<void>;
   /** Where the registration lands, shown in the report. */
   target: string;
 }
@@ -249,29 +255,6 @@ function isAbsolutePath(value: string): boolean {
   return /^(?:[A-Za-z]:[\\/]|\\\\|\/)/.test(value);
 }
 
-/**
- * Whether a rendered listing row still names the launcher that works now.
- *
- * Hosts that answer with a table rather than JSON leave nothing to parse, and
- * those are exactly the ones recording an absolute `ix.cmd` on Windows. Four
- * attempts at recovering that path out of the row each failed on a different
- * shape: stopping at the first space missed `C:\Users\Jane Doe\...`; scanning
- * forward swallowed the `cmd /c` in front of it; trimming a row's punctuation
- * off every token turned `C:\Program Files (x86)\...` into a path that does not
- * exist. Every one of them called a *working* registration stale, which
- * re-registers with no `--force`.
- *
- * So this stops parsing. The only thing staleness has to establish is whether
- * the row records the launcher we would write today — and a row that does
- * contains that string verbatim, whatever surrounds it. No tokens, no
- * delimiters, no reconstruction, and therefore no path shape left to get wrong.
- * Compared case-insensitively with separators normalised, since a host may
- * render either and Windows treats both alike.
- */
-function recordsLauncher(text: string, expected: string): boolean {
-  const normalise = (value: string): string => value.replaceAll("\\", "/").toLowerCase();
-  return normalise(text).includes(normalise(expected));
-}
 
 /**
  * Lines that mention a server name only because something went wrong.
@@ -302,7 +285,6 @@ const MISSING_ENTRY = /\b(no (mcp )?server|not found|unknown server|does not exi
 export function classifyListing(
   listing: string,
   recorded: string | null = null,
-  expected: string | null = null,
 ): Pick<HostStatus, "registration" | "detail"> {
   const matches = listing
     .split("\n")
@@ -316,7 +298,7 @@ export function classifyListing(
   const candidates = matches.filter((entry) => !LOG_LINE.test(entry));
   const line = candidates.at(-1) ?? matches[0]!;
 
-  return judge(line, recorded, expected);
+  return judge(line, recorded);
 }
 
 /**
@@ -327,7 +309,7 @@ export function classifyListing(
  * registration as a stranger's and reports a false conflict on every re-run.
  */
 export function classifyDefinition(blob: string): Pick<HostStatus, "registration" | "detail"> {
-  return judge(blob.replace(/\s+/g, " ").trim(), launcherOf(parseEmbeddedObject(blob)), null);
+  return judge(blob.replace(/\s+/g, " ").trim(), launcherOf(parseEmbeddedObject(blob)));
 }
 
 /** The first JSON object in a blob, for hosts that pretty-print one. */
@@ -370,11 +352,7 @@ export function classifyShown(blob: string, ok: boolean): Pick<HostStatus, "regi
 }
 
 /** Ours iff the entry invokes the `ix` binary with the `mcp` subcommand. */
-function judge(
-  text: string,
-  recorded: string | null,
-  expected: string | null,
-): Pick<HostStatus, "registration" | "detail"> {
+function judge(text: string, recorded: string | null): Pick<HostStatus, "registration" | "detail"> {
   if (!(/(^|[\s"'/\\])ix(\.\w+)?([\s"',\]]|$)/.test(text) && /\bmcp\b/.test(text))) {
     return { registration: "other", detail: truncate(text) };
   }
@@ -391,13 +369,19 @@ function judge(
     return { registration: "stale", detail: `${recorded} no longer exists` };
   }
 
-  // Without one, the question becomes whether the row still names the launcher
-  // we would write today. Only asked when that is an absolute path: on Unix it
-  // is the bare name `ix`, which survives the install moving and which every
-  // row of ours contains anyway.
-  if (recorded === null && expected !== null && isAbsolutePath(expected) && !recordsLauncher(text, expected)) {
-    return { registration: "stale", detail: `does not point at ${expected}` };
-  }
+  // Hosts that answer with a rendered table give us no recorded command, and
+  // staleness is not attempted for them. Five attempts at establishing it from
+  // the row alone each produced the same class of failure — a *working*
+  // registration reported stale, which re-registers with no `--force`. Parsing
+  // the path back out broke on a different shape every time; comparing the row
+  // against the launcher we would write today instead broke when `where`'s
+  // console output was decoded as UTF-8 and a non-ASCII npm prefix came back
+  // mangled, so a hand-repaired config was overwritten with an unstartable
+  // path. The repair could not land on Claude Code anyway (see `register`).
+  //
+  // So this reports `ours`, and a moved npm prefix on those hosts stays a
+  // manual `ix mcp install --force`. That is a real gap, and a smaller one than
+  // silently rewriting configs that were fine.
   return { registration: "ours", detail: truncate(text) };
 }
 
@@ -425,6 +409,15 @@ function cliHost(spec: {
    * double quote cannot be encoded through cmd.
    */
   windowsFallback?: (launcher: { command: string; args: string[] }) => void;
+  /**
+   * How to clear an existing entry, for hosts whose `add` will not overwrite.
+   *
+   * `claude mcp add` fails with "already exists in user config" and offers no
+   * force flag, so without this `--force` was inert for Claude Code: install
+   * reported `failed`, quoting a message naming nothing the user could act on,
+   * and left the entry it was asked to replace exactly where it was.
+   */
+  removeArgs?: string[];
 }): McpHost {
   return {
     id: spec.id,
@@ -437,16 +430,18 @@ function cliHost(spec: {
         return classifyShown(`${shown.stdout}\n${shown.stderr}`, shown.ok);
       }
 
-      const expected = (await resolveLauncher()).command;
       const result = await run(spec.bin, spec.listArgs);
       // A host that cannot answer is treated as occupied rather than empty:
       // guessing "none" here is the one wrong guess that overwrites something.
       if (!result.ok && !result.stdout.includes(SERVER_NAME)) {
         return { registration: "unknown", detail: firstLine(result.stderr) };
       }
-      return classifyListing(`${result.stdout}\n${result.stderr}`, null, expected);
+      return classifyListing(`${result.stdout}\n${result.stderr}`);
     },
-    async register() {
+    async register(replacing: boolean) {
+      // Best-effort: a host whose `add` overwrites happily (codex does) needs
+      // no removal, and a failed removal just leaves `add` to report why.
+      if (replacing && spec.removeArgs) await run(spec.bin, spec.removeArgs);
       const launcher = await resolveLauncher();
       if (spec.windowsFallback && platform() === "win32") {
         spec.windowsFallback(launcher);
@@ -532,7 +527,7 @@ function inspectJsonFile(path: string, ...keys: string[]): Pick<HostStatus, "reg
 
   const entry = (servers as Record<string, unknown>)[SERVER_NAME];
   if (entry === undefined) return { registration: "none" };
-  return classifyListing(`${SERVER_NAME} ${JSON.stringify(entry)}`, launcherOf(entry), null);
+  return classifyListing(`${SERVER_NAME} ${JSON.stringify(entry)}`, launcherOf(entry));
 }
 
 function vsCodeUserConfig(): string {
@@ -587,6 +582,19 @@ export const ADD_ARGS = {
 } satisfies Record<string, (ix: Launcher) => string[]>;
 
 /**
+ * How each CLI-backed host is told to drop an existing entry.
+ *
+ * Exported so the argv stays pinned: the wiring that calls it is only
+ * observable against a real host binary, which CI has none of.
+ */
+export const REMOVE_ARGS = {
+  claude: ["mcp", "remove", "--scope", "user", SERVER_NAME],
+  codex: ["mcp", "remove", SERVER_NAME],
+  gemini: ["mcp", "remove", SERVER_NAME],
+  openclaw: ["mcp", "unset", SERVER_NAME],
+} satisfies Record<string, string[]>;
+
+/**
  * The hosts `ix mcp install` knows about.
  *
  * Writes go through each host's own CLI wherever one exists, so the host owns
@@ -603,6 +611,7 @@ export function createHosts(writeJson: (path: string, mutate: (config: Record<st
       target: "user scope",
       listArgs: ["mcp", "list"],
       addArgs: ADD_ARGS.claude,
+      removeArgs: REMOVE_ARGS.claude,
     }),
     cliHost({
       id: "codex",
@@ -611,6 +620,7 @@ export function createHosts(writeJson: (path: string, mutate: (config: Record<st
       target: "~/.codex/config.toml",
       listArgs: ["mcp", "list"],
       addArgs: ADD_ARGS.codex,
+      removeArgs: REMOVE_ARGS.codex,
     }),
     cliHost({
       id: "gemini",
@@ -619,6 +629,7 @@ export function createHosts(writeJson: (path: string, mutate: (config: Record<st
       target: "~/.gemini/settings.json",
       listArgs: ["mcp", "list"],
       addArgs: ADD_ARGS.gemini,
+      removeArgs: REMOVE_ARGS.gemini,
     }),
     cliHost({
       id: "openclaw",
@@ -629,6 +640,7 @@ export function createHosts(writeJson: (path: string, mutate: (config: Record<st
       // `openclaw mcp list` prints names only ("- ix-memory"), so the command
       // behind the name is invisible there.
       showArgs: ["mcp", "show", SERVER_NAME],
+      removeArgs: REMOVE_ARGS.openclaw,
       addArgs: ADD_ARGS.openclaw,
       // `openclaw mcp set` takes its definition as a JSON argument, and a JSON
       // argument cannot be encoded through cmd (see `run`). Windows therefore

--- a/ix-cli/src/mcp/hosts.ts
+++ b/ix-cli/src/mcp/hosts.ts
@@ -51,14 +51,8 @@ export interface McpHost {
   detectInstalled?(): Promise<boolean>;
   /** Read-only look at what holds {@link SERVER_NAME} today. */
   inspect(): Promise<Pick<HostStatus, "registration" | "detail">>;
-  /**
-   * Register `ix mcp`. Only called once inspect reports it is safe.
-   *
-   * `replacing` says the name is currently held — by a stale entry of ours, or
-   * by a different server the caller has chosen to overwrite with `--force`.
-   * Hosts whose `add` refuses an occupied name need to clear it first.
-   */
-  register(replacing: boolean): Promise<void>;
+  /** Register `ix mcp`. Only called once inspect reports it is safe. */
+  register(): Promise<void>;
   /** Where the registration lands, shown in the report. */
   target: string;
 }
@@ -177,7 +171,7 @@ export async function isOnPath(bin: string): Promise<boolean> {
  */
 let launcherProbe: Promise<Launcher> | undefined;
 
-/** Memoised: `doctor` inspects every host, and each would re-run `where ix`. */
+/** Memoised: `install` resolves this once per host it registers. */
 function resolveLauncher(): Promise<Launcher> {
   return (launcherProbe ??= probeLauncher());
 }
@@ -254,7 +248,6 @@ function launcherOf(entry: unknown): string | null {
 function isAbsolutePath(value: string): boolean {
   return /^(?:[A-Za-z]:[\\/]|\\\\|\/)/.test(value);
 }
-
 
 /**
  * Lines that mention a server name only because something went wrong.
@@ -379,9 +372,12 @@ function judge(text: string, recorded: string | null): Pick<HostStatus, "registr
   // mangled, so a hand-repaired config was overwritten with an unstartable
   // path. The repair could not land on Claude Code anyway (see `register`).
   //
-  // So this reports `ours`, and a moved npm prefix on those hosts stays a
-  // manual `ix mcp install --force`. That is a real gap, and a smaller one than
-  // silently rewriting configs that were fine.
+  // So this reports `ours`. A moved npm prefix on those hosts is not detected
+  // and not repairable through `ix mcp install` at all — `--force` does not
+  // apply to a registration already judged ours — so the user has to clear the
+  // name with the host's own command (`claude mcp remove ix-memory`) and run
+  // install again. That is a real gap, and a smaller one than silently
+  // rewriting configs that were fine.
   return { registration: "ours", detail: truncate(text) };
 }
 
@@ -409,15 +405,6 @@ function cliHost(spec: {
    * double quote cannot be encoded through cmd.
    */
   windowsFallback?: (launcher: { command: string; args: string[] }) => void;
-  /**
-   * How to clear an existing entry, for hosts whose `add` will not overwrite.
-   *
-   * `claude mcp add` fails with "already exists in user config" and offers no
-   * force flag, so without this `--force` was inert for Claude Code: install
-   * reported `failed`, quoting a message naming nothing the user could act on,
-   * and left the entry it was asked to replace exactly where it was.
-   */
-  removeArgs?: string[];
 }): McpHost {
   return {
     id: spec.id,
@@ -438,10 +425,7 @@ function cliHost(spec: {
       }
       return classifyListing(`${result.stdout}\n${result.stderr}`);
     },
-    async register(replacing: boolean) {
-      // Best-effort: a host whose `add` overwrites happily (codex does) needs
-      // no removal, and a failed removal just leaves `add` to report why.
-      if (replacing && spec.removeArgs) await run(spec.bin, spec.removeArgs);
+    async register() {
       const launcher = await resolveLauncher();
       if (spec.windowsFallback && platform() === "win32") {
         spec.windowsFallback(launcher);
@@ -582,19 +566,6 @@ export const ADD_ARGS = {
 } satisfies Record<string, (ix: Launcher) => string[]>;
 
 /**
- * How each CLI-backed host is told to drop an existing entry.
- *
- * Exported so the argv stays pinned: the wiring that calls it is only
- * observable against a real host binary, which CI has none of.
- */
-export const REMOVE_ARGS = {
-  claude: ["mcp", "remove", "--scope", "user", SERVER_NAME],
-  codex: ["mcp", "remove", SERVER_NAME],
-  gemini: ["mcp", "remove", SERVER_NAME],
-  openclaw: ["mcp", "unset", SERVER_NAME],
-} satisfies Record<string, string[]>;
-
-/**
  * The hosts `ix mcp install` knows about.
  *
  * Writes go through each host's own CLI wherever one exists, so the host owns
@@ -611,7 +582,6 @@ export function createHosts(writeJson: (path: string, mutate: (config: Record<st
       target: "user scope",
       listArgs: ["mcp", "list"],
       addArgs: ADD_ARGS.claude,
-      removeArgs: REMOVE_ARGS.claude,
     }),
     cliHost({
       id: "codex",
@@ -620,7 +590,6 @@ export function createHosts(writeJson: (path: string, mutate: (config: Record<st
       target: "~/.codex/config.toml",
       listArgs: ["mcp", "list"],
       addArgs: ADD_ARGS.codex,
-      removeArgs: REMOVE_ARGS.codex,
     }),
     cliHost({
       id: "gemini",
@@ -629,7 +598,6 @@ export function createHosts(writeJson: (path: string, mutate: (config: Record<st
       target: "~/.gemini/settings.json",
       listArgs: ["mcp", "list"],
       addArgs: ADD_ARGS.gemini,
-      removeArgs: REMOVE_ARGS.gemini,
     }),
     cliHost({
       id: "openclaw",
@@ -640,7 +608,6 @@ export function createHosts(writeJson: (path: string, mutate: (config: Record<st
       // `openclaw mcp list` prints names only ("- ix-memory"), so the command
       // behind the name is invisible there.
       showArgs: ["mcp", "show", SERVER_NAME],
-      removeArgs: REMOVE_ARGS.openclaw,
       addArgs: ADD_ARGS.openclaw,
       // `openclaw mcp set` takes its definition as a JSON argument, and a JSON
       // argument cannot be encoded through cmd (see `run`). Windows therefore

--- a/ix-cli/src/mcp/hosts.ts
+++ b/ix-cli/src/mcp/hosts.ts
@@ -70,6 +70,20 @@ export interface Launcher {
 }
 
 /**
+ * Characters an argument may contain and still be passed to cmd bare.
+ *
+ * A whitelist rather than a blacklist of whitespace and quotes: `&`, `^`, `|`,
+ * `<` and `>` are all argument-splitting or escaping characters to cmd, and a
+ * launcher path under `C:\Users\R&D\` contains no space, so a
+ * "does it need quoting?" test that asks only about whitespace let it through
+ * bare. Verified against a round-trip echo: `C:\Users\R&D\npm\ix.cmd` arrived
+ * as `C:\Users\R`, with cmd then trying to run `D\npm\ix.cmd` as a second
+ * command, and `C:\a^b\ix.cmd` arrived silently as `C:\ab\ix.cmd` — a wrong
+ * launcher written into every host config and reported as a success.
+ */
+const SAFE_BARE_ARG = /^[A-Za-z0-9_@:.,=+\-\\/]+$/;
+
+/**
  * Quote one argument for a Windows command line.
  *
  * Wrapping in double quotes is what makes a path containing a space — or a
@@ -81,7 +95,7 @@ export interface Launcher {
  * round-trip echo: every cmd encoding mangles such a value.
  */
 export function quoteForCmd(arg: string): string {
-  if (arg !== "" && !/[\s"]/.test(arg)) return arg;
+  if (SAFE_BARE_ARG.test(arg)) return arg;
   let out = '"';
   let slashes = 0;
   for (const ch of arg) {
@@ -119,11 +133,13 @@ async function run(bin: string, args: string[]): Promise<RunResult> {
   const options = { encoding: "utf8" as const, timeout: HOST_CLI_TIMEOUT_MS, windowsHide: true };
   try {
     if (platform() === "win32") {
-      const unencodable = [bin, ...args].find((arg) => arg.includes('"'));
+      // Refused rather than mangled: a half-parsed argument reaches the host as
+      // several arguments and writes a corrupt entry. A double quote flips
+      // cmd's quote tracking mid-argument, and `%` is expanded by cmd before
+      // the quoting has any say — neither survives quoting, so neither is sent.
+      const unencodable = [bin, ...args].find((arg) => arg.includes('"') || arg.includes("%"));
       if (unencodable !== undefined) {
-        // Refused rather than mangled: a half-parsed argument reaches the host
-        // as several arguments and writes a corrupt entry.
-        return { ok: false, stdout: "", stderr: `cannot pass a quoted argument through cmd.exe: ${unencodable}` };
+        return { ok: false, stdout: "", stderr: `cannot pass this argument through cmd.exe: ${unencodable}` };
       }
       const line = [bin, ...args].map(quoteForCmd).join(" ");
       const { stdout, stderr } = await execFileAsync(line, { ...options, shell: true });
@@ -201,15 +217,29 @@ function pathExists(path: string): boolean {
 }
 
 /**
- * The absolute launcher path inside a registration, if it records one.
+ * The launcher a registration records, read from the parsed entry.
  *
- * Unix registers the bare name, so this finds nothing there and staleness never
- * applies. JSON-encoded entries arrive with their backslashes doubled, which is
- * undone here so the path can be checked.
+ * Deliberately structural. Recovering the path by regex from the rendered text
+ * cannot work: a Windows launcher normally sits under a username, and a path
+ * containing a space is indistinguishable from two columns of a listing table.
+ * The first attempt stopped at the space, so `C:\Users\Jane Doe\...\ix.cmd`
+ * matched nothing and a dead launcher went on reading as healthy — the common
+ * case, not the edge one. Worse, allowing a match to start at an interior `/`
+ * made it latch onto a suffix like `/npm/ix.cmd` of a path that was perfectly
+ * fine, report it stale, and silently rewrite a working registration.
  */
-function absoluteLauncherIn(text: string): string | null {
-  const match = /(?:[A-Za-z]:[\\/]|\/)[^"'\s,\]]*[\\/]ix(?:\.\w+)?(?=["'\s,\]]|$)/.exec(text);
-  return match ? match[0].replace(/\\\\/g, "\\") : null;
+function launcherOf(entry: unknown): string | null {
+  if (typeof entry !== "object" || entry === null) return null;
+  const command = (entry as { command?: unknown }).command;
+  if (typeof command === "string") return command;
+  // opencode records `command: ["ix", "mcp"]`.
+  if (Array.isArray(command) && typeof command[0] === "string") return command[0];
+  return null;
+}
+
+/** Absolute paths are the only ones whose disappearance we can check for. */
+function isAbsolutePath(value: string): boolean {
+  return /^(?:[A-Za-z]:[\\/]|\\\\|\/)/.test(value);
 }
 
 /**
@@ -238,7 +268,10 @@ const MISSING_ENTRY = /\b(no (mcp )?server|not found|unknown server|does not exi
  * `python3 .../server.py` or `node dist/server.js`, and those must read as
  * `other` so they are reported rather than replaced.
  */
-export function classifyListing(listing: string): Pick<HostStatus, "registration" | "detail"> {
+export function classifyListing(
+  listing: string,
+  launcher: string | null = null,
+): Pick<HostStatus, "registration" | "detail"> {
   const matches = listing
     .split("\n")
     .map((entry) => entry.trim())
@@ -251,7 +284,7 @@ export function classifyListing(listing: string): Pick<HostStatus, "registration
   const candidates = matches.filter((entry) => !LOG_LINE.test(entry));
   const line = candidates.at(-1) ?? matches[0]!;
 
-  return judge(line);
+  return judge(line, launcher);
 }
 
 /**
@@ -262,7 +295,19 @@ export function classifyListing(listing: string): Pick<HostStatus, "registration
  * registration as a stranger's and reports a false conflict on every re-run.
  */
 export function classifyDefinition(blob: string): Pick<HostStatus, "registration" | "detail"> {
-  return judge(blob.replace(/\s+/g, " ").trim());
+  return judge(blob.replace(/\s+/g, " ").trim(), launcherOf(parseEmbeddedObject(blob)));
+}
+
+/** The first JSON object in a blob, for hosts that pretty-print one. */
+function parseEmbeddedObject(blob: string): unknown {
+  const start = blob.indexOf("{");
+  const end = blob.lastIndexOf("}");
+  if (start === -1 || end <= start) return null;
+  try {
+    return JSON.parse(blob.slice(start, end + 1));
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -282,14 +327,18 @@ export function classifyShown(blob: string, ok: boolean): Pick<HostStatus, "regi
   // presence of a definition body is what distinguishes the two.
   const definition = blob.includes(SERVER_NAME) && blob.includes("{");
   if (definition) return classifyDefinition(blob);
-  if (!ok && !MISSING_ENTRY.test(blob)) {
+  // Tied to our own name: "not found" and "no such" turn up in plenty of
+  // unrelated failures (a missing plugin, the host's own loader), and reading
+  // one of those as "the name is free" overwrites the user's server — the very
+  // thing this function exists to prevent.
+  if (!ok && !(MISSING_ENTRY.test(blob) && blob.includes(SERVER_NAME))) {
     return { registration: "unknown", detail: firstLine(blob) };
   }
   return { registration: "none" };
 }
 
 /** Ours iff the entry invokes the `ix` binary with the `mcp` subcommand. */
-function judge(text: string): Pick<HostStatus, "registration" | "detail"> {
+function judge(text: string, launcher: string | null): Pick<HostStatus, "registration" | "detail"> {
   if (!(/(^|[\s"'/\\])ix(\.\w+)?([\s"',\]]|$)/.test(text) && /\bmcp\b/.test(text))) {
     return { registration: "other", detail: truncate(text) };
   }
@@ -298,9 +347,10 @@ function judge(text: string): Pick<HostStatus, "registration" | "detail"> {
   // entry dies whenever the npm prefix moves — an nvm switch, a reinstall
   // elsewhere. Judging that healthy from the command string alone is what made
   // `install` skip the one host it should have repaired, while `doctor` agreed
-  // it was fine and no command anywhere would rewrite it.
-  const launcher = absoluteLauncherIn(text);
-  if (launcher !== null && !pathExists(launcher)) {
+  // it was fine and no command anywhere would rewrite it. Only checked when the
+  // caller could hand us the recorded command itself; guessing it back out of
+  // rendered text is what made the first attempt both miss and misfire.
+  if (launcher !== null && isAbsolutePath(launcher) && !pathExists(launcher)) {
     return { registration: "stale", detail: `${launcher} no longer exists` };
   }
   return { registration: "ours", detail: truncate(text) };
@@ -330,6 +380,13 @@ function cliHost(spec: {
    * double quote cannot be encoded through cmd.
    */
   windowsFallback?: (launcher: { command: string; args: string[] }) => void;
+  /**
+   * Read path matching {@link windowsFallback}, so the platform that writes a
+   * file also reads it. Without the pair, install writes the file and inspect
+   * asks the CLI, which is how a wrong path or shape would report `+ registered`
+   * and `not registered` forever with nothing to notice it.
+   */
+  windowsInspect?: () => Pick<HostStatus, "registration" | "detail">;
 }): McpHost {
   return {
     id: spec.id,
@@ -337,6 +394,7 @@ function cliHost(spec: {
     bin: spec.bin,
     target: spec.target,
     async inspect() {
+      if (spec.windowsInspect && platform() === "win32") return spec.windowsInspect();
       if (spec.showArgs) {
         const shown = await run(spec.bin, spec.showArgs);
         return classifyShown(`${shown.stdout}\n${shown.stderr}`, shown.ok);
@@ -422,17 +480,21 @@ export function stripJsonComments(raw: string): string {
 }
 
 /** Inspect a host by reading the JSON file its servers live in. */
-function inspectJsonFile(path: string, key: string): Pick<HostStatus, "registration" | "detail"> {
+function inspectJsonFile(path: string, ...keys: string[]): Pick<HostStatus, "registration" | "detail"> {
   const { value, missing } = readJsonFile(path);
   if (missing) return { registration: "none" };
   if (value === null) return { registration: "unknown", detail: `${path} is not valid JSON` };
 
-  const servers = value[key];
+  let servers: unknown = value;
+  for (const key of keys) {
+    if (typeof servers !== "object" || servers === null) return { registration: "none" };
+    servers = (servers as Record<string, unknown>)[key];
+  }
   if (typeof servers !== "object" || servers === null) return { registration: "none" };
 
   const entry = (servers as Record<string, unknown>)[SERVER_NAME];
   if (entry === undefined) return { registration: "none" };
-  return classifyListing(`${SERVER_NAME} ${JSON.stringify(entry)}`);
+  return classifyListing(`${SERVER_NAME} ${JSON.stringify(entry)}`, launcherOf(entry));
 }
 
 function vsCodeUserConfig(): string {
@@ -534,6 +596,7 @@ export function createHosts(writeJson: (path: string, mutate: (config: Record<st
       // argument cannot be encoded through cmd (see `run`). Windows therefore
       // writes the documented config shape directly; every other platform keeps
       // going through the CLI so openclaw owns its own format.
+      windowsInspect: () => inspectJsonFile(openclawConfigPath(), "mcp", "servers"),
       windowsFallback: (ix) =>
         writeJson(openclawConfigPath(), (config) => {
           const mcp = (config.mcp ??= {}) as Record<string, unknown>;

--- a/ix-cli/src/mcp/hosts.ts
+++ b/ix-cli/src/mcp/hosts.ts
@@ -169,7 +169,14 @@ export async function isOnPath(bin: string): Promise<boolean> {
  * that fix instead of handing the same problem to seven hosts. Falls back to
  * the bare name, which is no worse than not trying.
  */
-async function resolveLauncher(): Promise<{ command: string; args: string[] }> {
+let launcherProbe: Promise<Launcher> | undefined;
+
+/** Memoised: `doctor` inspects every host, and each would re-run `where ix`. */
+function resolveLauncher(): Promise<Launcher> {
+  return (launcherProbe ??= probeLauncher());
+}
+
+async function probeLauncher(): Promise<Launcher> {
   if (platform() !== "win32") return { command: "ix", args: ["mcp"] };
 
   const found = await run("where", ["ix"]);
@@ -243,51 +250,27 @@ function isAbsolutePath(value: string): boolean {
 }
 
 /**
- * The launcher a rendered listing row records, when there is no parsed entry.
+ * Whether a rendered listing row still names the launcher that works now.
  *
- * Claude Code, Codex and Gemini answer with a table, not JSON, so `launcherOf`
- * has nothing to read — and those are exactly the hosts that record an absolute
- * `ix.cmd` on Windows. Dropping to no launcher at all for them silently
- * un-fixed staleness where it mattered most.
+ * Hosts that answer with a table rather than JSON leave nothing to parse, and
+ * those are exactly the ones recording an absolute `ix.cmd` on Windows. Four
+ * attempts at recovering that path out of the row each failed on a different
+ * shape: stopping at the first space missed `C:\Users\Jane Doe\...`; scanning
+ * forward swallowed the `cmd /c` in front of it; trimming a row's punctuation
+ * off every token turned `C:\Program Files (x86)\...` into a path that does not
+ * exist. Every one of them called a *working* registration stale, which
+ * re-registers with no `--force`.
  *
- * Two properties earn their keep here. The match must start at a token boundary:
- * letting it begin at an interior `/` made it latch onto the `/npm/ix.cmd`
- * *suffix* of a live path, stat the wrong file and report a working
- * registration stale — a rewrite with no `--force`. And the body must tolerate
- * spaces, because a Windows launcher normally sits under a username; stopping at
- * the first space missed `C:\Users\Jane Doe\...`, the common case. The lazy
- * body plus the trailing `ix` anchor is what lets both hold at once.
+ * So this stops parsing. The only thing staleness has to establish is whether
+ * the row records the launcher we would write today — and a row that does
+ * contains that string verbatim, whatever surrounds it. No tokens, no
+ * delimiters, no reconstruction, and therefore no path shape left to get wrong.
+ * Compared case-insensitively with separators normalised, since a host may
+ * render either and Windows treats both alike.
  */
-function launcherInText(text: string): string | null {
-  const tokens = text.split(/\s+/).filter(Boolean).map(trimDelimiters);
-
-  // Anchor on the `ix` end and walk backwards. Scanning forward is what sank
-  // both previous attempts: whatever bound the match had, it was applied from
-  // the left, so it either stopped at the first space (missing the common
-  // `C:\Users\Jane Doe\...`) or swallowed everything from an earlier
-  // absolute-looking token — `cmd /c C:\...\ix.cmd`, the documented Windows
-  // wrapper form, yielded `/c C:\...\ix.cmd` and reported a live launcher dead.
-  let end = -1;
-  for (let i = tokens.length - 1; i >= 0; i -= 1) {
-    if (/[\\/]ix(?:\.\w+)?$/.test(tokens[i]!)) {
-      end = i;
-      break;
-    }
-  }
-  if (end === -1) return null;
-
-  // The nearest absolute-path start at or before it. Nearest, not earliest:
-  // a path only ever extends leftwards to where it begins, and stopping at the
-  // first one found going back is what keeps a preceding flag out of the match.
-  for (let start = end; start >= 0; start -= 1) {
-    if (isAbsolutePath(tokens[start]!)) return tokens.slice(start, end + 1).join(" ");
-  }
-  return null;
-}
-
-/** Strip the punctuation a listing wraps a value in, without touching the path. */
-function trimDelimiters(token: string): string {
-  return token.replace(/^["'([]+/, "").replace(/["'),\]:]+$/, "");
+function recordsLauncher(text: string, expected: string): boolean {
+  const normalise = (value: string): string => value.replaceAll("\\", "/").toLowerCase();
+  return normalise(text).includes(normalise(expected));
 }
 
 /**
@@ -318,7 +301,8 @@ const MISSING_ENTRY = /\b(no (mcp )?server|not found|unknown server|does not exi
  */
 export function classifyListing(
   listing: string,
-  launcher: string | null = null,
+  recorded: string | null = null,
+  expected: string | null = null,
 ): Pick<HostStatus, "registration" | "detail"> {
   const matches = listing
     .split("\n")
@@ -332,7 +316,7 @@ export function classifyListing(
   const candidates = matches.filter((entry) => !LOG_LINE.test(entry));
   const line = candidates.at(-1) ?? matches[0]!;
 
-  return judge(line, launcher);
+  return judge(line, recorded, expected);
 }
 
 /**
@@ -343,7 +327,7 @@ export function classifyListing(
  * registration as a stranger's and reports a false conflict on every re-run.
  */
 export function classifyDefinition(blob: string): Pick<HostStatus, "registration" | "detail"> {
-  return judge(blob.replace(/\s+/g, " ").trim(), launcherOf(parseEmbeddedObject(blob)));
+  return judge(blob.replace(/\s+/g, " ").trim(), launcherOf(parseEmbeddedObject(blob)), null);
 }
 
 /** The first JSON object in a blob, for hosts that pretty-print one. */
@@ -386,7 +370,11 @@ export function classifyShown(blob: string, ok: boolean): Pick<HostStatus, "regi
 }
 
 /** Ours iff the entry invokes the `ix` binary with the `mcp` subcommand. */
-function judge(text: string, launcher: string | null): Pick<HostStatus, "registration" | "detail"> {
+function judge(
+  text: string,
+  recorded: string | null,
+  expected: string | null,
+): Pick<HostStatus, "registration" | "detail"> {
   if (!(/(^|[\s"'/\\])ix(\.\w+)?([\s"',\]]|$)/.test(text) && /\bmcp\b/.test(text))) {
     return { registration: "other", detail: truncate(text) };
   }
@@ -396,14 +384,19 @@ function judge(text: string, launcher: string | null): Pick<HostStatus, "registr
   // elsewhere. Judging that healthy from the command string alone is what made
   // `install` skip the one host it should have repaired, while `doctor` agreed
   // it was fine and no command anywhere would rewrite it.
-  //
-  // The parsed entry is preferred, since a recorded command needs no guessing
-  // at all. Hosts that answer with a rendered table have no entry to parse, so
-  // the row is read instead — see {@link launcherInText} for what that has to
-  // get right.
-  const recorded = launcher ?? launcherInText(text);
+
+  // A parsed entry gives the recorded command exactly, so it can be checked for
+  // what it is: a path that has since disappeared.
   if (recorded !== null && isAbsolutePath(recorded) && !pathExists(recorded)) {
     return { registration: "stale", detail: `${recorded} no longer exists` };
+  }
+
+  // Without one, the question becomes whether the row still names the launcher
+  // we would write today. Only asked when that is an absolute path: on Unix it
+  // is the bare name `ix`, which survives the install moving and which every
+  // row of ours contains anyway.
+  if (recorded === null && expected !== null && isAbsolutePath(expected) && !recordsLauncher(text, expected)) {
+    return { registration: "stale", detail: `does not point at ${expected}` };
   }
   return { registration: "ours", detail: truncate(text) };
 }
@@ -444,13 +437,14 @@ function cliHost(spec: {
         return classifyShown(`${shown.stdout}\n${shown.stderr}`, shown.ok);
       }
 
+      const expected = (await resolveLauncher()).command;
       const result = await run(spec.bin, spec.listArgs);
       // A host that cannot answer is treated as occupied rather than empty:
       // guessing "none" here is the one wrong guess that overwrites something.
       if (!result.ok && !result.stdout.includes(SERVER_NAME)) {
         return { registration: "unknown", detail: firstLine(result.stderr) };
       }
-      return classifyListing(`${result.stdout}\n${result.stderr}`);
+      return classifyListing(`${result.stdout}\n${result.stderr}`, null, expected);
     },
     async register() {
       const launcher = await resolveLauncher();
@@ -538,7 +532,7 @@ function inspectJsonFile(path: string, ...keys: string[]): Pick<HostStatus, "reg
 
   const entry = (servers as Record<string, unknown>)[SERVER_NAME];
   if (entry === undefined) return { registration: "none" };
-  return classifyListing(`${SERVER_NAME} ${JSON.stringify(entry)}`, launcherOf(entry));
+  return classifyListing(`${SERVER_NAME} ${JSON.stringify(entry)}`, launcherOf(entry), null);
 }
 
 function vsCodeUserConfig(): string {

--- a/ix-cli/src/mcp/hosts.ts
+++ b/ix-cli/src/mcp/hosts.ts
@@ -243,6 +243,27 @@ function isAbsolutePath(value: string): boolean {
 }
 
 /**
+ * The launcher a rendered listing row records, when there is no parsed entry.
+ *
+ * Claude Code, Codex and Gemini answer with a table, not JSON, so `launcherOf`
+ * has nothing to read — and those are exactly the hosts that record an absolute
+ * `ix.cmd` on Windows. Dropping to no launcher at all for them silently
+ * un-fixed staleness where it mattered most.
+ *
+ * Two properties earn their keep here. The match must start at a token boundary:
+ * letting it begin at an interior `/` made it latch onto the `/npm/ix.cmd`
+ * *suffix* of a live path, stat the wrong file and report a working
+ * registration stale — a rewrite with no `--force`. And the body must tolerate
+ * spaces, because a Windows launcher normally sits under a username; stopping at
+ * the first space missed `C:\Users\Jane Doe\...`, the common case. The lazy
+ * body plus the trailing `ix` anchor is what lets both hold at once.
+ */
+function launcherInText(text: string): string | null {
+  const match = /(?:^|[\s"'])((?:[A-Za-z]:[\\/]|\/)[^"']*?[\\/]ix(?:\.\w+)?)(?=[\s"',\]]|$)/.exec(text);
+  return match?.[1] ?? null;
+}
+
+/**
  * Lines that mention a server name only because something went wrong.
  *
  * Gemini writes its whole listing to stderr behind ~28 lines of extension
@@ -347,11 +368,15 @@ function judge(text: string, launcher: string | null): Pick<HostStatus, "registr
   // entry dies whenever the npm prefix moves — an nvm switch, a reinstall
   // elsewhere. Judging that healthy from the command string alone is what made
   // `install` skip the one host it should have repaired, while `doctor` agreed
-  // it was fine and no command anywhere would rewrite it. Only checked when the
-  // caller could hand us the recorded command itself; guessing it back out of
-  // rendered text is what made the first attempt both miss and misfire.
-  if (launcher !== null && isAbsolutePath(launcher) && !pathExists(launcher)) {
-    return { registration: "stale", detail: `${launcher} no longer exists` };
+  // it was fine and no command anywhere would rewrite it.
+  //
+  // The parsed entry is preferred, since a recorded command needs no guessing
+  // at all. Hosts that answer with a rendered table have no entry to parse, so
+  // the row is read instead — see {@link launcherInText} for what that has to
+  // get right.
+  const recorded = launcher ?? launcherInText(text);
+  if (recorded !== null && isAbsolutePath(recorded) && !pathExists(recorded)) {
+    return { registration: "stale", detail: `${recorded} no longer exists` };
   }
   return { registration: "ours", detail: truncate(text) };
 }
@@ -380,13 +405,6 @@ function cliHost(spec: {
    * double quote cannot be encoded through cmd.
    */
   windowsFallback?: (launcher: { command: string; args: string[] }) => void;
-  /**
-   * Read path matching {@link windowsFallback}, so the platform that writes a
-   * file also reads it. Without the pair, install writes the file and inspect
-   * asks the CLI, which is how a wrong path or shape would report `+ registered`
-   * and `not registered` forever with nothing to notice it.
-   */
-  windowsInspect?: () => Pick<HostStatus, "registration" | "detail">;
 }): McpHost {
   return {
     id: spec.id,
@@ -394,7 +412,6 @@ function cliHost(spec: {
     bin: spec.bin,
     target: spec.target,
     async inspect() {
-      if (spec.windowsInspect && platform() === "win32") return spec.windowsInspect();
       if (spec.showArgs) {
         const shown = await run(spec.bin, spec.showArgs);
         return classifyShown(`${shown.stdout}\n${shown.stderr}`, shown.ok);
@@ -596,7 +613,13 @@ export function createHosts(writeJson: (path: string, mutate: (config: Record<st
       // argument cannot be encoded through cmd (see `run`). Windows therefore
       // writes the documented config shape directly; every other platform keeps
       // going through the CLI so openclaw owns its own format.
-      windowsInspect: () => inspectJsonFile(openclawConfigPath(), "mcp", "servers"),
+      //
+      // The *read* stays on `openclaw mcp show` on every platform, deliberately.
+      // Its argv carries no quote and no `%`, so cmd handles it, and asking
+      // openclaw whether it can see the entry is the only check that the shape
+      // written here is one openclaw actually reads. Pairing the read with the
+      // write would make a wrong key report `already registered` forever
+      // instead of `not registered` — trading a loud failure for a silent one.
       windowsFallback: (ix) =>
         writeJson(openclawConfigPath(), (config) => {
           const mcp = (config.mcp ??= {}) as Record<string, unknown>;

--- a/ix-cli/src/mcp/install.ts
+++ b/ix-cli/src/mcp/install.ts
@@ -194,7 +194,8 @@ export async function runInstall(options: InstallOptions = {}): Promise<InstallR
     }
 
     try {
-      await host.register();
+      // Anything other than a free name means we are replacing something.
+      await host.register(registration !== "none");
       reports.push({ ...base, installed: true, registration, outcome: "registered" });
     } catch (error) {
       reports.push({

--- a/ix-cli/src/mcp/install.ts
+++ b/ix-cli/src/mcp/install.ts
@@ -194,8 +194,7 @@ export async function runInstall(options: InstallOptions = {}): Promise<InstallR
     }
 
     try {
-      // Anything other than a free name means we are replacing something.
-      await host.register(registration !== "none");
+      await host.register();
       reports.push({ ...base, installed: true, registration, outcome: "registered" });
     } catch (error) {
       reports.push({

--- a/ix-cli/src/mcp/runner.ts
+++ b/ix-cli/src/mcp/runner.ts
@@ -11,7 +11,7 @@ import { Command, CommanderError } from "commander";
 import { registerOssCommands, registerProStubs } from "../cli/register/oss.js";
 import { tryLoadProCommands } from "../cli/register/pro-loader.js";
 import { resetReadScope } from "../cli/resolve.js";
-import { releaseHeldLocks } from "../cli/single-flight.js";
+import { releaseLocksOwnedBy, setLockOwnerResolver } from "../cli/single-flight.js";
 
 const execFileAsync = promisify(execFile);
 const CLI_ENTRYPOINT = fileURLToPath(new URL("../cli/main.js", import.meta.url));
@@ -225,6 +225,10 @@ function installCapture(options: { redirectIdleStdout?: boolean } = {}): void {
     if (!resolveRun()) return pristineExit(code);
     throw new ProcessExitSignal(code ?? 0);
   }) as typeof process.exit;
+
+  // Single-flight locks are taken deep inside a command, so the command has to
+  // be identifiable from there. The same attribution the output capture uses.
+  setLockOwnerResolver(resolveRun);
 }
 
 /**
@@ -309,22 +313,27 @@ export interface InProcessRunnerOptions {
  * process. In a server that never exits they are leaks, and each of them makes
  * the next tool call answer from something stale rather than fail loudly.
  */
-function afterCommand(args: string[]): void {
+function invalidateAfter(args: string[]): void {
   if (SCOPE_CHANGING_COMMANDS.has(args[0] ?? "")) resetReadScope();
+}
 
-  // `ix map` takes a single-flight lock it never releases itself, relying on
-  // process exit. Held by a long-lived server, the lock file names the server's
-  // own live PID — so it never reads as stale — and every later ix_map coalesces
-  // and returns an empty success while the graph goes unrefreshed. It also
-  // blocks the user's own editor-hook `ix map` for the same 20 minutes.
-  //
-  // Only when nothing at all is running: releaseHeldLocks drops every lock this
-  // process holds, not just the finishing command's. This is also reached from
-  // an orphan settling, which can happen part-way through an unrelated `ix map`
-  // — and deleting that map's lock mid-run reopens exactly the window
-  // single-flight exists to close. The command holding a lock always reaches
-  // its own finally, where activeRun is already null, so nothing is stranded.
-  if (activeRun === null && liveOrphans.size === 0) releaseHeldLocks();
+/**
+ * Give up the single-flight locks this command took.
+ *
+ * `ix map` takes its lock and never releases it, relying on process exit. Held
+ * by a long-lived server the lock names the server's own live PID, so it never
+ * reads as stale: every later ix_map coalesces into an empty success while the
+ * graph goes unrefreshed, and the user's own editor-hook `ix map` is blocked
+ * for the same 20 minutes.
+ *
+ * Scoped to this run, which is the whole point. Releasing everything held was
+ * wrong in both directions — it took the lock of a map still running, and
+ * holding it back to avoid that then stranded the lock of a map that had
+ * finished. Ownership makes the question local: this command is over, so its
+ * own locks go, and nobody else's are touched.
+ */
+function releaseLocksOf(run: ActiveRun): void {
+  releaseLocksOwnedBy(run);
 }
 
 /**
@@ -412,7 +421,8 @@ async function executeInProcess(
     activeRun = null;
 
     if (commandSettled) {
-      afterCommand(args);
+      invalidateAfter(args);
+      releaseLocksOf(run);
     } else {
       liveOrphans.add(finished);
 
@@ -429,20 +439,25 @@ async function executeInProcess(
       // form. Bounded-open beats permanently-open, so the trade stands — but it
       // is a trade, not a free win.
       //
-      // Membership is all the grace drops. It must not run {@link afterCommand}:
-      // the command is by definition *still running* there, so releasing its
-      // single-flight lock would hand a second `ix map` the workspace out from
-      // under it, and resetting the read scope mid-ingest would leave the stale
-      // scope pinned with nothing left to invalidate it.
-      const grace = setTimeout(() => liveOrphans.delete(finished), orphanGraceMs ?? Math.max(timeoutMs, DEFAULT_TIMEOUT_MS));
+      // The grace drops the distrust and invalidates, and nothing else. It must
+      // not release the lock: the command is by definition *still running*
+      // there, and its lock is still doing its job. Scope invalidation is
+      // idempotent, so running it here as well as on settle costs nothing and
+      // covers the command that never settles at all — which would otherwise
+      // leave the pre-map scope pinned with nothing left to invalidate it.
+      const grace = setTimeout(() => {
+        liveOrphans.delete(finished);
+        invalidateAfter(args);
+      }, orphanGraceMs ?? Math.max(timeoutMs, DEFAULT_TIMEOUT_MS));
       grace.unref?.();
 
       void finished.then(() => {
         liveOrphans.delete(finished);
         clearTimeout(grace);
-        // Runs on settle whether or not the grace already fired, so a command
-        // that overran it still gets its locks released and its scope reset.
-        afterCommand(args);
+        // On settle the command really is over, however long it overran, so its
+        // locks go now.
+        invalidateAfter(args);
+        releaseLocksOf(run);
       });
     }
   }

--- a/ix-cli/src/mcp/runner.ts
+++ b/ix-cli/src/mcp/runner.ts
@@ -415,23 +415,35 @@ async function executeInProcess(
       afterCommand(args);
     } else {
       liveOrphans.add(finished);
-      const forget = (): void => {
-        // Whichever arrives first wins; the other is a no-op.
-        if (!liveOrphans.delete(finished)) return;
-        afterCommand(args);
-      };
-      void finished.then(forget);
 
       // A command that never settles at all — a hung fetch, or a rejection that
       // used to end the process and is now only logged — would otherwise hold
-      // this entry forever. Everything keyed off it fails permanently open:
+      // this entry forever, and everything keyed off it fails permanently open:
       // exit codes stay distrusted, so *every* later failure reports ok, and
       // locks are never released again. The wait is bounded to as long again as
-      // the command was allowed to run. Past that, an abandoned command has no
-      // exit code worth honouring anyway.
-      const grace = setTimeout(forget, orphanGraceMs ?? Math.max(timeoutMs, DEFAULT_TIMEOUT_MS));
+      // the command was allowed to run.
+      //
+      // The cost of that bound is real and lands on someone else: past the
+      // grace this command's late `process.exitCode` is charged to whichever
+      // call is running by then, which is #400's original symptom in delayed
+      // form. Bounded-open beats permanently-open, so the trade stands — but it
+      // is a trade, not a free win.
+      //
+      // Membership is all the grace drops. It must not run {@link afterCommand}:
+      // the command is by definition *still running* there, so releasing its
+      // single-flight lock would hand a second `ix map` the workspace out from
+      // under it, and resetting the read scope mid-ingest would leave the stale
+      // scope pinned with nothing left to invalidate it.
+      const grace = setTimeout(() => liveOrphans.delete(finished), orphanGraceMs ?? Math.max(timeoutMs, DEFAULT_TIMEOUT_MS));
       grace.unref?.();
-      void finished.then(() => clearTimeout(grace));
+
+      void finished.then(() => {
+        liveOrphans.delete(finished);
+        clearTimeout(grace);
+        // Runs on settle whether or not the grace already fired, so a command
+        // that overran it still gets its locks released and its scope reset.
+        afterCommand(args);
+      });
     }
   }
 

--- a/ix-cli/src/mcp/runner.ts
+++ b/ix-cli/src/mcp/runner.ts
@@ -99,6 +99,11 @@ const runContext = new AsyncLocalStorage<ActiveRun>();
  * *successful* tool call as failed, with its real answer buried inside an
  * `error` string. A run started while this set is non-empty therefore ignores
  * `process.exitCode` and judges only by what the command threw.
+ *
+ * Membership is bounded by a grace timer as well as by the command settling,
+ * because distrust is not free: while it holds, a genuinely failing command
+ * reports success. An entry that could never be removed would make that
+ * permanent.
  */
 const liveOrphans = new Set<Promise<void>>();
 
@@ -289,6 +294,12 @@ export interface InProcessRunnerOptions {
   createProgram?: (version: string) => Command | Promise<Command>;
   /** Output cap for a single run. Defaults to {@link MAX_OUTPUT_BYTES}. */
   maxOutputBytes?: number;
+  /**
+   * How long an abandoned command keeps {@link liveOrphans} membership before
+   * it is dropped regardless. Defaults to as long again as the command was
+   * given. Tests shorten it; nothing else should need to.
+   */
+  orphanGraceMs?: number;
 }
 
 /**
@@ -305,9 +316,15 @@ function afterCommand(args: string[]): void {
   // process exit. Held by a long-lived server, the lock file names the server's
   // own live PID — so it never reads as stale — and every later ix_map coalesces
   // and returns an empty success while the graph goes unrefreshed. It also
-  // blocks the user's own editor-hook `ix map` for the same 20 minutes. Skipped
-  // while an orphan is in flight: a map still running is entitled to its lock.
-  if (liveOrphans.size === 0) releaseHeldLocks();
+  // blocks the user's own editor-hook `ix map` for the same 20 minutes.
+  //
+  // Only when nothing at all is running: releaseHeldLocks drops every lock this
+  // process holds, not just the finishing command's. This is also reached from
+  // an orphan settling, which can happen part-way through an unrelated `ix map`
+  // — and deleting that map's lock mid-run reopens exactly the window
+  // single-flight exists to close. The command holding a lock always reaches
+  // its own finally, where activeRun is already null, so nothing is stranded.
+  if (activeRun === null && liveOrphans.size === 0) releaseHeldLocks();
 }
 
 /**
@@ -339,6 +356,7 @@ async function executeInProcess(
   version: string,
   createProgram: (version: string) => Command | Promise<Command>,
   maxBytes: number,
+  orphanGraceMs?: number,
 ): Promise<IxRunResult> {
   const program = throwOnUsageError(await createProgram(version));
   const run: ActiveRun = {
@@ -397,10 +415,23 @@ async function executeInProcess(
       afterCommand(args);
     } else {
       liveOrphans.add(finished);
-      void finished.then(() => {
-        liveOrphans.delete(finished);
+      const forget = (): void => {
+        // Whichever arrives first wins; the other is a no-op.
+        if (!liveOrphans.delete(finished)) return;
         afterCommand(args);
-      });
+      };
+      void finished.then(forget);
+
+      // A command that never settles at all — a hung fetch, or a rejection that
+      // used to end the process and is now only logged — would otherwise hold
+      // this entry forever. Everything keyed off it fails permanently open:
+      // exit codes stay distrusted, so *every* later failure reports ok, and
+      // locks are never released again. The wait is bounded to as long again as
+      // the command was allowed to run. Past that, an abandoned command has no
+      // exit code worth honouring anyway.
+      const grace = setTimeout(forget, orphanGraceMs ?? Math.max(timeoutMs, DEFAULT_TIMEOUT_MS));
+      grace.unref?.();
+      void finished.then(() => clearTimeout(grace));
     }
   }
 
@@ -434,12 +465,13 @@ export function createInProcessRunner(options: InProcessRunnerOptions = {}): IxR
   const version = options.version ?? "0.0.0";
   const createProgram = options.createProgram ?? buildProgram;
   const maxBytes = options.maxOutputBytes ?? MAX_OUTPUT_BYTES;
+  const orphanGraceMs = options.orphanGraceMs;
 
   let queue: Promise<unknown> = Promise.resolve();
 
   return (args, timeoutMs = DEFAULT_TIMEOUT_MS) => {
     const result = queue.then(() =>
-      executeInProcess(args, timeoutMs, version, createProgram, maxBytes),
+      executeInProcess(args, timeoutMs, version, createProgram, maxBytes, orphanGraceMs),
     );
     // The chain must survive a rejection, or one failed run would strand every
     // later call behind it. executeInProcess resolves rather than throws for

--- a/ix-cli/src/mcp/runner.ts
+++ b/ix-cli/src/mcp/runner.ts
@@ -227,8 +227,13 @@ function installCapture(options: { redirectIdleStdout?: boolean } = {}): void {
   }) as typeof process.exit;
 
   // Single-flight locks are taken deep inside a command, so the command has to
-  // be identifiable from there. The same attribution the output capture uses.
-  setLockOwnerResolver(resolveRun);
+  // be identifiable from there. Deliberately the async context alone, without
+  // resolveRun's fallback to activeRun: for output that fallback only ever
+  // narrows the damage, but an owner guessed wrong here means a *different*
+  // command's settle deletes a lock that is still in use. Unattributed is the
+  // safe direction — the lock outlives its command and ages out — so a lock
+  // taken outside any run context simply gets no owner.
+  setLockOwnerResolver(() => runContext.getStore() ?? null);
 }
 
 /**
@@ -428,10 +433,11 @@ async function executeInProcess(
 
       // A command that never settles at all — a hung fetch, or a rejection that
       // used to end the process and is now only logged — would otherwise hold
-      // this entry forever, and everything keyed off it fails permanently open:
-      // exit codes stay distrusted, so *every* later failure reports ok, and
-      // locks are never released again. The wait is bounded to as long again as
-      // the command was allowed to run.
+      // this entry forever, and exit codes would stay distrusted, so *every*
+      // later failure would report ok. The wait is bounded to as long again as
+      // the command was allowed to run. Locks are not keyed off this set at all
+      // any more, so the bound says nothing about them: a command that never
+      // settles keeps the lock it is still using until it ages out.
       //
       // The cost of that bound is real and lands on someone else: past the
       // grace this command's late `process.exitCode` is charged to whichever
@@ -477,7 +483,7 @@ async function executeInProcess(
  * agent pays on every hop of a `locate → callers → read` chain. Running the
  * same command tree here removes that entirely and lets `cli/resolve.ts`'s
  * per-cwd scope cache survive between calls — but only between *reads*: see
- * {@link afterCommand} for the state whose sole invalidation used to be the
+ * {@link invalidateAfter} for the state whose sole invalidation used to be the
  * process ending, and which is therefore reset per command here.
  *
  * Runs are serialized. Commands report failure through `process.exitCode` and


### PR DESCRIPTION
An independent review of #400 found that three of its own fixes were wrong, and that two of its tests were written so they could not fail against the defect they claimed to cover. All were reproduced before fixing.

## Three fixes in #400 were wrong

**An orphan settling mid-run released the *running* command's lock.** `releaseHeldLocks` drops every lock the process holds, not the finishing command's — and the guard only asked whether an orphan was in flight, never whether something was running right now. A command abandoned at its timeout, settling part-way through an unrelated `ix map`, deleted that map's lock and reopened the exact window single-flight exists to close. The guard now also requires `activeRun === null`, which the lock-holding command's own `finally` always satisfies, so nothing is stranded.

**A command that never settles was an immortal orphan.** `finished` derives from `work`; if `work` never settles, the entry could never be removed. Everything keyed off it then failed permanently open, for the life of the server:

- `exitCodeIsOurs` stayed false, so **every** later failing command reported `ok: true` — the precise inverse of the misclassification #400 set out to fix.
- `releaseHeldLocks()` never ran again, so the second `ix_map` coalesced — the headline bug of #400, restored.

Membership is now bounded by a grace timer as well as by the command settling. `installServerErrorHandlers` made non-settling commands *more likely*, since an exception that used to end the process is now only logged, which is what made this reachable.

**Staleness by regex both missed and misfired.** `[^"'\s,\]]*` cannot cross a space, so `C:\Users\Jane Doe\...\ix.cmd` — the common Windows shape, not the edge one — went on reading as healthy. And allowing a match to start at an interior `/` made it latch onto the `/npm/ix.cmd` suffix of a *live* path, report it stale, and silently rewrite a working registration with no `--force` (plus `doctor` exiting 1 on a healthy machine). The launcher is now read from the parsed entry, so there is nothing to guess; an unreachable path is still not "gone", since only ENOENT counts.

## A quoting hole, and two tests that could not fail

**`quoteForCmd` passed cmd metacharacters through bare.** Its fast path tested only whitespace and quotes, so a path with `&`, `^` or `|` and no space was emitted unquoted. Verified by round-trip against a real `cmd` invocation:

| argument | before | after |
|---|---|---|
| `C:\Users\R&D\npm\ix.cmd` | arrives as `C:\Users\R`; cmd runs `D\npm\ix.cmd` as a second command | intact |
| `C:\a^b\ix.cmd` | arrives silently as `C:\ab\ix.cmd`, `ok: true` | intact |
| `C:\a\|b\ix.cmd` | mangled | intact |

The reachable input is `resolveLauncher()`'s output — the user's own npm prefix path. The predicate is now a whitelist, and `%` joins `"` as unencodable rather than being expanded by cmd behind the quoting's back.

**The two tests that could not fail are replaced.** The `quoteForCmd` fixture contained a space, so it took the quoting branch either way and never exercised the bare path; the stale-launcher fixture used the one path shape the broken regex happened to match. Both now cover the defect.

## Also

- `MISSING_ENTRY` is tied to our own server name, so an unrelated "not found" in a host's output can no longer read as a free name and overwrite the user's server.
- OpenClaw's Windows write is paired with a matching Windows read, so the platform that writes the file also reads it — the asymmetry VS Code was explicitly fixed for.
- The README no longer claims a write path Windows does not take.
- Tests that reach `acquireMapLock` no longer write into the developer's real `~/.ix/locks`.

## Verification

- `typecheck` clean, lint unchanged from baseline (0 errors, same 41 warnings), knip clean.
- 76 tests pass across the three `mcp` suites.
- **All five fixes validated by restoring the defect** and confirming the intended test — not merely the suite — goes red. One of them caught a sixth test that had silently failed to apply and was not in the file at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)