### PR TITLE
fix(config): respect workspace path boundaries

### DIFF
--- a/ix-cli/src/cli/__tests__/config-workspace-boundary.test.ts
+++ b/ix-cli/src/cli/__tests__/config-workspace-boundary.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { selectWorkspaceForCwd, type WorkspaceConfig } from "../config.js";
+
+function workspace(rootPath: string, name = rootPath): WorkspaceConfig {
+  return {
+    workspace_id: name,
+    workspace_name: name,
+    root_path: rootPath,
+    default: false,
+  };
+}
+
+describe("workspace path matching", () => {
+  it("matches a workspace root and its descendants", () => {
+    const candidate = workspace("/work/app", "app");
+
+    expect(selectWorkspaceForCwd([candidate], "/work/app")).toBe(candidate);
+    expect(selectWorkspaceForCwd([candidate], "/work/app/src/features")).toBe(candidate);
+  });
+
+  it("does not match a sibling whose name only shares the root prefix", () => {
+    const candidate = workspace("/work/app", "app");
+
+    expect(selectWorkspaceForCwd([candidate], "/work/app-copy")).toBeUndefined();
+    expect(selectWorkspaceForCwd([candidate], "/work/application")).toBeUndefined();
+  });
+
+  it("selects the nearest workspace when roots are nested", () => {
+    const parent = workspace("/work/app", "parent");
+    const child = workspace("/work/app/packages/api", "child");
+
+    expect(selectWorkspaceForCwd([parent, child], "/work/app/packages/api/src")).toBe(child);
+  });
+});

--- a/ix-cli/src/cli/config.ts
+++ b/ix-cli/src/cli/config.ts
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync, existsSync, rmSync, chmodSync, renameSync } from "node:fs";
-import { join, resolve as resolvePath } from "node:path";
+import { isAbsolute, join, relative, resolve as resolvePath, sep } from "node:path";
 import { homedir } from "node:os";
 import { createHash } from "node:crypto";
 import { execSync } from "node:child_process";
@@ -133,11 +133,24 @@ export function loadWorkspaces(): WorkspaceConfig[] {
   return config.workspaces ?? []; // workspace_id already normalized to string in loadConfig
 }
 
-export function findWorkspaceForCwd(cwd: string): WorkspaceConfig | undefined {
-  const workspaces = loadWorkspaces();
+export function selectWorkspaceForCwd(
+  workspaces: WorkspaceConfig[],
+  cwd: string,
+): WorkspaceConfig | undefined {
+  const resolvedCwd = resolvePath(cwd);
   return workspaces
-    .filter(w => cwd.startsWith(w.root_path))
+    .filter((workspace) => {
+      const relativePath = relative(resolvePath(workspace.root_path), resolvedCwd);
+      return (
+        relativePath === "" ||
+        (relativePath !== ".." && !relativePath.startsWith(`..${sep}`) && !isAbsolute(relativePath))
+      );
+    })
     .sort((a, b) => b.root_path.length - a.root_path.length)[0];
+}
+
+export function findWorkspaceForCwd(cwd: string): WorkspaceConfig | undefined {
+  return selectWorkspaceForCwd(loadWorkspaces(), cwd);
 }
 
 export function getDefaultWorkspace(): WorkspaceConfig | undefined {


### PR DESCRIPTION
Fixes #402

## Summary

Prevent workspace lookup from treating an unrelated sibling directory whose name shares a prefix as part of a registered workspace.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes

- Match workspace roots using path-component boundaries instead of raw string prefixes.
- Preserve nearest-workspace selection for nested workspaces.
- Add regression coverage for exact roots, descendants, sibling prefixes, and nested roots.

## Validation

- `npm test` (61 files, 843 tests, including parser smoke tests)
- `npm run typecheck`
- `npm run build`
- Targeted ESLint and Prettier checks
- Live synthetic reproduction with a distinct default workspace. A sibling path no longer resolves a symbol mapped only from the prefix-sharing workspace.

## Checklist

- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)

- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
