### PR TITLE
fix(cli): drop the dead `plans` and `goals` Pro stubs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ accept `--format`, despite being an action command.)
 
 **Pro features.** Some commands below are marked **[Pro]**, as are the whole
 **Planning** and **Workflows** sections — every command in those two tables is
-Pro-only, including `plan`, `plans`, `task`, `tasks` and `workflow`. If any Pro
+Pro-only, including `plan`, `task`, `tasks` and `workflow`. If any Pro
 command prints `The '<name>' command requires Ix Pro.`, this install does not
 have them — skip that step, do not retry it, and do not mention it again for the
 rest of the session. Nothing outside those marks and those two sections is
@@ -193,7 +193,7 @@ Only the first four work without Pro.
 | Plan status | `ix plan status` | `ix plan status <id> --format json` |
 | Next actionable task | `ix plan next` | `ix plan next <id> --with-workflow --format json` |
 | Run next task workflow | `ix plan next` | `ix plan next <id> --run-workflow --stage discover --format json` |
-| List all plans | `ix plans` | `ix plans --format json` |
+| List all plans | `ix plan list` | `ix plan list --format json` |
 | List tasks | `ix tasks` | `ix tasks --status pending --plan <id> --format json` |
 | Task details | `ix task show` | `ix task show <id> --with-workflow --format json` |
 | Update task | `ix task update` | `ix task update <id> --status done --format json` |

--- a/ix-cli/src/cli/__tests__/help-topics.test.ts
+++ b/ix-cli/src/cli/__tests__/help-topics.test.ts
@@ -86,14 +86,17 @@ describe("collapsed plural help topics resolve", () => {
   it.each([
     ["bugs", "bug"],
     ["goals", "goal"],
+    ["plans", "plan"],
   ])("ix help %s forwards to the %s command instead of erroring", (plural, singular) => {
     const { stdout, stderr, exitCode } = runHelp(plural);
     expect(stderr).not.toContain("Unknown help topic");
     expect(exitCode).toBeUndefined();
-    // Anchored on a word boundary, not a prefix: `goals` is still a registered
-    // Pro stub, and its own help starts `Usage: ix goals` — which *contains*
-    // `Usage: ix goal`. Without the boundary this assertion passes with the
-    // forwarder deleted outright, which is exactly how it was first written.
+    // Anchored on a word boundary, not a prefix. `Usage: ix goals` *contains*
+    // `Usage: ix goal`, so without the boundary this assertion passes with the
+    // forwarder deleted outright — which is exactly how it was first written,
+    // back when `goals` was still a registered stub that answered for itself.
+    // Keep the boundary: it is what makes the row test forwarding rather than
+    // the mere presence of some command whose name starts with the singular.
     expect(stdout).toMatch(new RegExp(`^Usage: ix ${singular}\\b`, "m"));
   });
 

--- a/ix-cli/src/cli/__tests__/pro-stub-message.test.ts
+++ b/ix-cli/src/cli/__tests__/pro-stub-message.test.ts
@@ -56,7 +56,6 @@ describe("Pro stubs", () => {
     ["truth", ["truth", "add", "Support 100k file repos"]],
     ["truth", ["truth", "list", "--format", "json"]],
     ["goal", ["goal", "create", "Support GitHub", "--format", "json"]],
-    ["goals", ["goals", "--status", "active", "--format", "json"]],
     ["decide", ["decide", "Use X", "--rationale", "because", "--affects", "Entity"]],
     ["briefing", ["briefing", "--format", "json"]],
     ["decisions", ["decisions", "--topic", "ingestion", "--limit", "10"]],
@@ -100,25 +99,35 @@ describe("Pro stubs", () => {
     expect(patches?.options.map(o => o.long)).toContain("--format");
   });
 
-  // @ix/pro registers a plural list command alongside `plan` and `task`
-  // (register.ts: registerPlansCommand, registerTasksCommand). Stubbing only the
-  // singular is the failure this pins: the plural fell through to commander's
-  // "unknown command" instead of the sentinel above, so an agent told to stop on
+  // `tasks` is the ONLY plural @ix/pro still registers as its own command
+  // (register.ts: registerTasksCommand). Stubbing only the singular is the
+  // failure this pins: the plural fell through to commander's "unknown command"
+  // instead of the sentinel above, so an agent told to stop on
   // `requires Ix Pro.` saw an unrecognized error and had nothing to match.
   //
-  // `goals` is NOT in that category and is only still stubbed by oversight:
-  // Ix-pro#103 deleted the command, #327 correctly dropped the stub, and #384
-  // re-added it on the stated premise that Pro registers a plural for *every*
-  // singular — which was already false. Do not use this row as evidence that
-  // `ix goals` exists; removing it is a pending follow-up.
+  // This list is NOT "every singular has a plural" — that premise was already
+  // false when it was written, and acting on it is what re-added the dead
+  // `goals` stub in #384. Add a row only after confirming @ix/pro registers
+  // that exact plural.
   it.each([
-    ["plan", "plans"],
     ["task", "tasks"],
-    ["goal", "goals"],
   ])("stubs both %s and %s", (singular, plural) => {
     for (const name of [singular, plural]) {
       expect(runStub([name]).err).toContain(`The '${name}' command requires Ix Pro.`);
     }
+  });
+
+  // The collapsed plurals: the singular stub must cover the new subcommand form
+  // (it swallows operands), and the retired plural must NOT answer at all.
+  // Without the second half, restoring either stub goes unnoticed.
+  it.each([
+    ["goal", "list", "goals"],
+    ["plan", "list", "plans"],
+  ])("stubs the collapsed '%s %s' subcommand, not a '%s' command", (singular, sub, plural) => {
+    expect(runStub([singular, sub, "--format", "json"]).err).toContain(
+      `The '${singular}' command requires Ix Pro.`,
+    );
+    expect(runStub([plural]).err).not.toContain("requires Ix Pro");
   });
 
   // `bugs` is deliberately absent from the pairs above: @ix/pro collapsed it into

--- a/ix-cli/src/cli/commands/workflows.ts
+++ b/ix-cli/src/cli/commands/workflows.ts
@@ -63,6 +63,7 @@ Use "ix <command> --help" for details on any command.
 const COLLAPSED_HELP_TOPICS: Record<string, string> = {
   goals: "goal",
   bugs: "bug",
+  plans: "plan",
 };
 
 export function registerWorkflowsHelpCommand(program: Command): void {

--- a/ix-cli/src/cli/register/oss.ts
+++ b/ix-cli/src/cli/register/oss.ts
@@ -43,14 +43,17 @@ const PRO_COMMANDS: { name: string; desc: string }[] = [
   { name: "decide", desc: "Record a design decision" },
   { name: "decisions", desc: "List recorded design decisions" },
   { name: "goal", desc: "Manage project goals" },
-  { name: "goals", desc: "List all goals" },
+  // `goals` and `plans` are deliberately absent: @ix/pro collapsed both into a
+  // subcommand of the singular (`ix goal list`, Ix-pro#103; `ix plan list`,
+  // Ix-pro#109), so stubbing them upsold Pro for commands Pro does not have.
+  // The singular stubs still cover the new subcommand form — they swallow
+  // operands, so `plan list` reaches the sentinel. Same fix as `bugs` in #396.
   // `patches` is deliberately absent: ix-cli owns the real implementation
   // (commands/patches.ts, registered above). It sat in this list while never
   // being registered, so `ix patches` answered "requires Ix Pro" on OSS and
   // shadowed a working command — see #371.
   { name: "plan", desc: "Manage plans and plan tasks" },
   { name: "task", desc: "Manage tasks" },
-  { name: "plans", desc: "List all plans" },
   { name: "tasks", desc: "List all tasks across plans" },
   { name: "truth", desc: "Manage project intents (truth)" },
   { name: "workflow", desc: "Attach, show, validate, or run staged workflows" },

--- a/skills/ix/references/output-formats.md
+++ b/skills/ix/references/output-formats.md
@@ -26,13 +26,13 @@ documented.
 
 Commands marked **[Pro]** require Ix Pro (server-side). The **Planning** and
 **Workflows** sections of the CLI are entirely Pro-only — including `plan`,
-`plans`, `task`, `tasks`, and `workflow`.
+`task`, `tasks`, and `workflow`.
 
 If any Pro command prints `The '<name>' command requires Ix Pro.`, this install
 does not have them — skip that step, do not retry it, and do not mention it
 again for the rest of the session. Nothing outside those marks is Pro-gated.
 
-Pro-only surface: `plan`, `plans`, `task`, `tasks`, `workflow`, `decide`,
+Pro-only surface: `plan`, `task`, `tasks`, `workflow`, `decide`,
 `decisions`, `goal`, `truth`, `bug`, `briefing`.
 
 ### Semantic boundaries (Pro record types)


### PR DESCRIPTION
## Summary
Companion to **Ix-pro#109** (merged as `da55e53`), which collapsed `ix plans` into `ix plan list`. `PRO_COMMANDS` still stubbed the plural, so an OSS-only install answered *"The 'plans' command requires Ix Pro."* — an upsell for a command installing Pro would not provide.

It turned out to be **two** stale stubs, not one. `goals` has been dead since Ix-pro#103: Ix#327 correctly dropped the stub, and **Ix#384 re-added it** on the stated premise that Pro registers a plural for every singular — which was already false. That premise was encoded in the paired-rule test, which is why it came back.

Verified against Pro `main` (`da55e53`): neither `registerPlansCommand` nor `registerGoalsCommand` is registered. `tasks` is now the only plural Pro actually registers.

## Changes
- `register/oss.ts` — drop both stubs. The singular stubs still cover the subcommand form; they swallow operands, so `plan list` reaches the sentinel.
- `commands/workflows.ts` — add `plans` to `COLLAPSED_HELP_TOPICS`. Per the lesson from #396, dropping a stub breaks `ix help <plural>`, which resolves topics against `program.commands`.
- `pro-stub-message.test.ts` — rewrite the paired-rule block so it no longer *asserts* the false premise. It now carries only `task`/`tasks`, plus a collapsed-subcommand table for `goal`/`plan` that pins both halves: the singular must reach the sentinel, the plural must not answer at all. The comment says to verify registration before adding a row rather than inferring one from the singular.
- `help-topics.test.ts` — add the `plans` → `plan` forwarding row.
- `CLAUDE.md`, `skills/ix/references/output-formats.md` — stop naming `ix plans`.

## Restore-the-bug
Each guard verified by reintroducing what it exists to catch:

| restored bug | result |
|---|---|
| re-add the `plans` stub | red — `stubs the collapsed 'plan list' subcommand, not a 'plans' command` |
| re-add the `goals` stub | red — `stubs the collapsed 'goal list' subcommand, not a 'goals' command` |
| drop the `plans` help forwarder | red — `ix help plans forwards to the plan command` |

## Test plan
- [x] `pro-stub-message.test.ts` + `help-topics.test.ts` — 30/30 green
- [x] Full `ix-cli` suite — 795 passed. Two files fail at *collection* on a missing `@modelcontextprotocol/sdk` in my local `node_modules`; reproduces with this change reverted, so it is environmental, not from this PR.

## Note on ordering
Deliberately opened **after** Ix-pro#109 merged — dropping the stub first would have given OSS users "unknown command" for something Pro still had.

This one needs a review from someone else; the ruleset won't let me approve my own.