### PR TITLE
fix: resolve local export aliases

### DIFF
--- a/core-ingestion/src/__tests__/resolveEdges.test.ts
+++ b/core-ingestion/src/__tests__/resolveEdges.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildGlobalResolutionIndex, resolveEdges, type FileParseResult, type ParsedEntity, type ParsedRelationship } from '../index.js';
+import { buildGlobalResolutionIndex, parseFile, resolveEdges, type FileParseResult, type ParsedEntity, type ParsedRelationship } from '../index.js';
 import { SupportedLanguages } from '../languages.js';
 
 function entity(
@@ -283,6 +283,203 @@ describe('resolveEdges', () => {
       dstName: 'crossBatchTarget',
       dstQualifiedKey: 'crossBatchTarget',
       predicate: 'CALLS',
+      confidence: 0.9,
+    });
+  });
+
+  it('resolves a call through a provider export alias', () => {
+    const provider = parseFile(
+      '/repo/provider.ts',
+      'function impl() { return 1; }\nexport { impl as publicFn };\n',
+    )!;
+    const consumer = parseFile(
+      '/repo/consumer.ts',
+      'import { publicFn } from "./provider";\nexport function caller() { return publicFn(); }\n',
+    )!;
+    const unrelated = parseFile(
+      '/repo/unrelated.ts',
+      'export function publicFn() { return 2; }\n',
+    )!;
+
+    const resolved = resolveEdges([consumer, provider, unrelated]);
+    expect(resolved).toContainEqual({
+      srcFilePath: '/repo/consumer.ts',
+      srcName: 'caller',
+      dstFilePath: '/repo/provider.ts',
+      dstName: 'publicFn',
+      dstQualifiedKey: 'impl',
+      predicate: 'CALLS',
+      confidence: 0.9,
+    });
+    expect(resolved.some(edge => edge.dstFilePath === '/repo/unrelated.ts')).toBe(false);
+  });
+
+  it('resolves a default import to the provider local symbol', () => {
+    const provider = parseFile(
+      '/repo/provider.ts',
+      'function actualName() { return 1; }\nexport default actualName;\n',
+    )!;
+    const consumer = parseFile(
+      '/repo/consumer.ts',
+      'import localName from "./provider";\nexport function caller() { return localName(); }\n',
+    )!;
+    const unrelated = parseFile(
+      '/repo/unrelated.ts',
+      'export function localName() { return 2; }\n',
+    )!;
+
+    const resolved = resolveEdges([consumer, provider, unrelated]);
+    expect(resolved).toContainEqual({
+      srcFilePath: '/repo/consumer.ts',
+      srcName: 'caller',
+      dstFilePath: '/repo/provider.ts',
+      dstName: 'localName',
+      dstQualifiedKey: 'actualName',
+      predicate: 'CALLS',
+      confidence: 0.9,
+    });
+    expect(resolved.some(edge => edge.dstFilePath === '/repo/unrelated.ts')).toBe(false);
+  });
+
+  it('resolves provider public names from the global index', () => {
+    const consumer = parseFile(
+      '/repo/consumer.ts',
+      'import localName from "./provider";\nexport function caller() { return localName(); }\n',
+    )!;
+    const providerPath = '/repo/provider.ts';
+    const globalIndex = buildGlobalResolutionIndex(
+      ['/repo/consumer.ts', providerPath],
+      new Map([[providerPath, 'function actualName() { return 1; }\nexport default actualName;\n']]),
+    );
+
+    expect(resolveEdges([consumer], undefined, globalIndex)).toContainEqual({
+      srcFilePath: '/repo/consumer.ts',
+      srcName: 'caller',
+      dstFilePath: providerPath,
+      dstName: 'localName',
+      dstQualifiedKey: 'actualName',
+      predicate: 'CALLS',
+      confidence: 0.9,
+    });
+  });
+
+  it('does not resolve a shadowed import name to the provider', () => {
+    const provider = parseFile(
+      '/repo/provider.ts',
+      'function actualName() { return 1; }\nexport default actualName;\n',
+    )!;
+    const consumer = parseFile(
+      '/repo/consumer.ts',
+      'import localName from "./provider";\nexport function caller() { const localName = () => 2; return localName(); }\n',
+    )!;
+
+    const resolved = resolveEdges([consumer, provider]);
+    expect(resolved.some(edge => edge.predicate === 'CALLS' && edge.dstFilePath === '/repo/provider.ts')).toBe(false);
+  });
+
+  it('still resolves the import outside the scope that shadows it', () => {
+    const provider = parseFile(
+      '/repo/provider.ts',
+      'function Actual() { return 1; }\nexport default Actual;\n',
+    )!;
+    const consumer = parseFile(
+      '/repo/consumer.ts',
+      'import Local from "./provider";\nfunction shadow() {\n  const Local = () => 2;\n  return Local();\n}\nexport function caller() {\n  return Local();\n}\n',
+    )!;
+
+    const calls = resolveEdges([consumer, provider]).filter(edge => edge.predicate === 'CALLS');
+    expect(calls).toContainEqual({
+      srcFilePath: '/repo/consumer.ts',
+      srcName: 'caller',
+      dstFilePath: '/repo/provider.ts',
+      dstName: 'Local',
+      dstQualifiedKey: 'Actual',
+      predicate: 'CALLS',
+      confidence: 0.9,
+    });
+    expect(calls.some(edge => edge.srcName === 'shadow' && edge.dstFilePath === '/repo/provider.ts')).toBe(false);
+  });
+
+  it('keeps ordinary same-file calls ahead of imported provider symbols', () => {
+    const provider = parseFile(
+      '/repo/provider.ts',
+      'export function other() {}\nexport function helper() {}\n',
+    )!;
+    const consumer = parseFile(
+      '/repo/consumer.ts',
+      'import { other } from "./provider";\nfunction helper() {}\nexport function caller() { return helper(); }\n',
+    )!;
+
+    const resolved = resolveEdges([consumer, provider]);
+    expect(resolved.some(edge => edge.predicate === 'CALLS' && edge.dstFilePath === '/repo/provider.ts')).toBe(false);
+  });
+
+  it('does not use a public export name to choose between ambiguous modules', () => {
+    const consumer = parseFile(
+      '/repo/a/consumer.ts',
+      'import { publicFn } from "./provider";\nexport function caller() { return publicFn(); }\n',
+    )!;
+    const intendedProvider = parseFile(
+      '/repo/a/provider.ts',
+      'export function otherFn() { return 1; }\n',
+    )!;
+    const unrelatedProvider = parseFile(
+      '/repo/b/provider.ts',
+      'function impl() { return 2; }\nexport { impl as publicFn };\n',
+    )!;
+
+    const resolved = resolveEdges([consumer, intendedProvider, unrelatedProvider]);
+    expect(resolved.some(edge => edge.predicate === 'CALLS')).toBe(false);
+  });
+
+  it('does not confuse a provider public name with a different local entity', () => {
+    const provider = parseFile(
+      '/repo/provider.ts',
+      'function impl() { return 1; }\nexport { impl as publicFn };\n',
+    )!;
+    const consumer = parseFile(
+      '/repo/consumer.ts',
+      'import { publicFn as localFn } from "./provider";\nfunction publicFn() { return 2; }\nexport function caller() { return localFn(); }\n',
+    )!;
+
+    expect(resolveEdges([consumer, provider])).toContainEqual({
+      srcFilePath: '/repo/consumer.ts',
+      srcName: 'caller',
+      dstFilePath: '/repo/provider.ts',
+      dstName: 'localFn',
+      dstQualifiedKey: 'impl',
+      predicate: 'CALLS',
+      confidence: 0.9,
+    });
+  });
+
+  it('resolves default imports used in inheritance and type references', () => {
+    const provider = parseFile(
+      '/repo/provider.ts',
+      'class ActualBase {}\nexport default ActualBase;\n',
+    )!;
+    const consumer = parseFile(
+      '/repo/consumer.ts',
+      'import LocalBase from "./provider";\nexport class Child extends LocalBase {}\nexport function takes(value: LocalBase) { return value; }\n',
+    )!;
+
+    const resolved = resolveEdges([consumer, provider]);
+    expect(resolved).toContainEqual({
+      srcFilePath: '/repo/consumer.ts',
+      srcName: 'Child',
+      dstFilePath: '/repo/provider.ts',
+      dstName: 'LocalBase',
+      dstQualifiedKey: 'ActualBase',
+      predicate: 'EXTENDS',
+      confidence: 0.9,
+    });
+    expect(resolved).toContainEqual({
+      srcFilePath: '/repo/consumer.ts',
+      srcName: 'takes',
+      dstFilePath: '/repo/provider.ts',
+      dstName: 'LocalBase',
+      dstQualifiedKey: 'ActualBase',
+      predicate: 'REFERENCES',
       confidence: 0.9,
     });
   });

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -542,11 +542,13 @@ function extractJsExportPublicNames(rootNode: any): ExportPublicName[] {
       }
       let clause: any = null;
       let decl: any = null;
+      let defaultIdentifier: any = null;
       for (let i = 0; i < node.namedChildCount; i++) {
         const c = node.namedChild(i);
         if (c.type === 'export_clause') clause = c;
         else if (c.type === 'function_declaration' || c.type === 'class_declaration'
           || c.type === 'lexical_declaration' || c.type === 'generator_function_declaration') decl = c;
+        else if (c.type === 'identifier') defaultIdentifier = c;
       }
       // Local re-export `export { a as b }` (NOT `... from './x'`): a is public as b.
       if (clause && !hasSource) {
@@ -564,9 +566,12 @@ function extractJsExportPublicNames(rootNode: any): ExportPublicName[] {
           }
         }
       }
-      // `export default function debug(){}` / `export default class X {}` → public "default".
-      if (isDefault && decl) {
-        const nameNode = (decl.childForFieldName && decl.childForFieldName('name')) || decl.namedChild(0);
+      // Named default declarations and `export default localName` advertise the
+      // local entity under the public name "default".
+      if (isDefault && (decl || defaultIdentifier)) {
+        const nameNode = decl
+          ? (decl.childForFieldName && decl.childForFieldName('name')) || decl.namedChild(0)
+          : defaultIdentifier;
         const nm = nameNode?.text;
         if (nm) {
           const k = `${nm}\x00default`;
@@ -2625,6 +2630,7 @@ function bestQKey(
 export interface GlobalResolutionIndex {
   fileHasSymbol:    Map<string, Set<string>>;
   fileQKeys:        Map<string, Map<string, string[]>>;
+  filePublicNames?: Map<string, Map<string, string>>;
   symbolToFiles:    Map<string, string[]>;
   stemToFiles:      Map<string, string[]>;
   dirToIndexFiles:  Map<string, string[]>;
@@ -2706,6 +2712,7 @@ export function buildGlobalResolutionIndex(
 
   // Entity maps (built from sources if provided, via fast regex scan)
   const fileQKeys = new Map<string, Map<string, string[]>>();
+  const filePublicNames = new Map<string, Map<string, string>>();
   const fileHasSymbol = new Map<string, Set<string>>();
   const symbolToFiles = new Map<string, string[]>();
 
@@ -2774,6 +2781,9 @@ export function buildGlobalResolutionIndex(
       if (qkMap.size > 0) {
         fileQKeys.set(fp, qkMap);
         fileHasSymbol.set(fp, new Set(qkMap.keys()));
+      }
+      if (parsed.exportPublicNames) {
+        filePublicNames.set(fp, new Map(parsed.exportPublicNames.map(name => [name.public, name.local])));
       }
     }
 
@@ -2853,6 +2863,7 @@ export function buildGlobalResolutionIndex(
   return {
     fileHasSymbol,
     fileQKeys,
+    filePublicNames,
     symbolToFiles,
     stemToFiles,
     dirToIndexFiles,
@@ -2957,13 +2968,17 @@ export function resolveEdges(
   // Renamed-import call resolution (Z): a call to a renamed local binding (`import
   // { format as fmt }; fmt()`) should resolve as the provider's public symbol
   // (`format`), so in-repo AND co-ingest resolution link it to the real definition.
-  // Map per file: local binding name -> imported public symbol, EXCLUDING default
-  // imports (imported == "default" is not a by-name symbol in the provider; those are
-  // handled in the cross-repo stitch path) and no-op named imports (local == imported).
+  // Map per file: local binding name -> imported public symbol, excluding default
+  // and no-op named imports from the by-name rewrite. Provider public-name
+  // resolution below handles those bindings against the imported file itself.
   const callBindings = new Map<string, Map<string, string>>();
+  const importBindingsByLocal = new Map<string, Map<string, ImportBinding>>();
   for (const r of results) {
     if (!r.importBindings) continue;
     for (const b of r.importBindings) {
+      let imports = importBindingsByLocal.get(r.filePath);
+      if (!imports) { imports = new Map(); importBindingsByLocal.set(r.filePath, imports); }
+      if (!imports.has(b.local)) imports.set(b.local, b);
       if (b.imported === 'default' || b.local === b.imported) continue;
       let m = callBindings.get(r.filePath);
       if (!m) { m = new Map(); callBindings.set(r.filePath, m); }
@@ -3088,6 +3103,17 @@ export function resolveEdges(
       qkMap.set(e.name, list);
     }
     fileQKeys.set(r.filePath, qkMap);  // overrides global entry if present
+  }
+
+  const filePublicNames = globalIndex
+    ? new Map<string, Map<string, string>>(globalIndex.filePublicNames ?? [])
+    : new Map<string, Map<string, string>>();
+  for (const r of results) {
+    if (r.exportPublicNames) {
+      filePublicNames.set(r.filePath, new Map(r.exportPublicNames.map(name => [name.public, name.local])));
+    } else {
+      filePublicNames.delete(r.filePath);
+    }
   }
 
   // fileHasSymbol: rebuilt from merged fileQKeys so per-batch overrides take effect.
@@ -3484,12 +3510,21 @@ export function resolveEdges(
     return qks.includes(`${qualifierPart}.${memberPart}`);
   }
 
+  function sameScopeDefines(result: FileParseResult, srcName: string, dstName: string): boolean {
+    const sourceEntities = result.entities.filter(e => e.name === srcName || qualifiedKey(e) === srcName);
+    if (sourceEntities.length === 0) return false;
+    return result.entities.some(definition =>
+      definition.name === dstName && sourceEntities.some(source =>
+        definition.lineStart >= source.lineStart && definition.lineEnd <= source.lineEnd,
+      ),
+    );
+  }
+
   const resolved: ResolvedEdge[] = [];
 
   for (const result of results) {
     const srcFilePath = result.filePath;
     const srcLanguage = result.language;
-    const srcSymbols = fileHasSymbol.get(srcFilePath)!;
 
     // Build the set of file paths this file explicitly imports.
     const importedFilePaths = new Set<string>();
@@ -3598,6 +3633,40 @@ export function resolveEdges(
       // back to the source call by name). No-op unless this is a renamed-import call.
       const dstName = (rel.predicate === 'CALLS' ? callBindings.get(srcFilePath)?.get(rel.dstName) : undefined) ?? rel.dstName;
       const srcName = rel.srcName;
+      const binding = importBindingsByLocal.get(srcFilePath)?.get(origDstName);
+
+      // Tier 1: same-file — already correct in buildPatch, skip here. Check the
+      // call-site name before any import binding rewrite so a local shadow wins.
+      // Without an import binding, preserve the existing file-wide preference.
+      const hasSameFileDefinition = fileHasSymbol.get(srcFilePath)?.has(origDstName) === true;
+      if (hasSameFileDefinition && (!binding || sameScopeDefines(result, srcName, origDstName))) continue;
+
+      if (rel.predicate === 'CALLS' || rel.predicate === 'EXTENDS' || rel.predicate === 'REFERENCES') {
+        if (binding) {
+          const providerFiles = [...new Set(resolveImportTargets(srcFilePath, srcLanguage, binding.pkg))];
+          const publicMatches: Array<{ fp: string; local: string }> = [];
+          for (const fp of providerFiles.length === 1 ? providerFiles : []) {
+            const local = filePublicNames.get(fp)?.get(binding.imported);
+            if (local && fileHasSymbol.get(fp)?.has(local)) publicMatches.push({ fp, local });
+          }
+          if (publicMatches.length === 1) {
+            const { fp, local } = publicMatches[0];
+            const dstQualifiedKey = bestQKey(fileQKeys, fp, local);
+            if (dstQualifiedKey !== null) {
+              resolved.push({
+                srcFilePath,
+                srcName,
+                dstFilePath: fp,
+                dstName: origDstName,
+                dstQualifiedKey,
+                predicate: rel.predicate,
+                confidence: 0.9,
+              });
+              continue;
+            }
+          }
+        }
+      }
 
       // Tier 1b: qualifier-assisted (confidence 0.9 / 0.7)
       // For dotted names like "NodeKind.Decision" (emitted by field_expression queries):
@@ -3666,9 +3735,6 @@ export function resolveEdges(
           continue; // qualified name exhausted — don't try bare-name tiers
         }
       }
-
-      // Tier 1: same-file — already correct in buildPatch, skip here
-      if (srcSymbols.has(dstName)) continue;
 
       // Tier 2: import-scoped (confidence 0.9)
       const importMatches: string[] = [];


### PR DESCRIPTION
Fixes #407

## Summary
Resolve same-repository JavaScript and TypeScript imports through provider-side default and aliased export names.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- preserve `export default LocalName` as a provider public-name mapping
- index provider public names for cross-batch resolution
- resolve `CALLS`, `EXTENDS`, and `REFERENCES` from consumer import bindings to provider local entities
- keep local shadows and ordinary same-file calls ahead of imported provider symbols
- avoid using public names to choose between ambiguous module candidates

## Validation
- `cd core-ingestion && npx vitest run src/__tests__/resolveEdges.test.ts` (44 passed)
- `cd ix-cli && npm test` (60 files, 853 passed, 1 skipped; parser smoke passed)
- `cd ix-cli && npm run typecheck && npm run build && npm run lint` (0 lint errors; 41 existing warnings)
- `cd core-ingestion && npm test` (290 passed; the same 6 pre-existing failures reproduce on unmodified `origin/main`, including missing private Scala fixtures and stale expectations)

## Checklist
- [x] Tests pass for the changed paths; pre-existing core failures are documented above
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
