### PR TITLE
docs(install): update the issue 349 upgrade note

### DIFF
--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -56,8 +56,8 @@ $NodeMinMajor = 22
 # resolves it. Moving off TEMP fixes that reading too, which is why this is
 # worth shipping ahead of the diagnosis.
 #
-# Note `ix upgrade` still stages through os.tmpdir() (upgrade.ts), which on
-# Windows is TEMP verbatim. If this class is real, it is unfixed there.
+# `ix upgrade` originally retained the same os.tmpdir()/TEMP exposure. #392
+# moved its CLI and Compass download scratch under IX_HOME as well.
 #
 # The `.cli-staging-` prefix on both scratch names is deliberate:
 # sweepUpgradeOrphans in upgrade.ts reclaims `.cli-staging-*` out of IX_HOME.


### PR DESCRIPTION
## Summary

Correct the stale Windows installer comment left after the #349 fix. The note still said `ix upgrade` staged through `os.tmpdir()`/`TEMP`, but #392 subsequently moved both CLI and Compass download scratch under `IX_HOME`.

Comment-only; runtime behavior is unchanged.

Refs #349
Refs #392

## Validation

- `git diff --check`
- parsed `scripts/install/install.ps1` with Windows PowerShell 5.1
- parsed `scripts/install/install.ps1` with PowerShell 7