### PR TITLE
fix: deduplicate deterministic patch edges

### DIFF
--- a/core-ingestion/src/__tests__/patchBuilder.test.ts
+++ b/core-ingestion/src/__tests__/patchBuilder.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import { parseFile } from '../index.js';
 import {
+  buildPatch,
+  buildPatchWithResolution,
   buildDeletionPatch,
   extractorName,
   PREVIOUS_EXTRACTORS,
@@ -46,5 +49,36 @@ describe('patch-builder extractor policy', () => {
     expect(patch.source.sourceHash).not.toBe(sourceHash);
     expect(patch.ops).toEqual(ops);
     expect(patch.replaces).toEqual(candidates);
+  });
+});
+
+describe('patch-builder edge identity', () => {
+  it.each([
+    ['buildPatch', (result: NonNullable<ReturnType<typeof parseFile>>) => buildPatch(result, 'source-hash')],
+    ['buildPatchWithResolution', (result: NonNullable<ReturnType<typeof parseFile>>) =>
+      buildPatchWithResolution(result, 'source-hash', '', [])],
+  ])('emits each deterministic edge once for Python overloads via %s', (_name, build) => {
+    const result = parseFile('backend/tests/unit/test_exir_adapter.py', `
+from typing import overload
+
+class Adapter:
+    @overload
+    def convert(self, value: int) -> int: ...
+
+    @overload
+    def convert(self, value: str) -> str: ...
+
+    def convert(self, value):
+        return value
+`);
+
+    expect(result).not.toBeNull();
+    const patch = build(result!);
+    const edgeIds = patch.ops
+      .filter(op => op.type === 'UpsertEdge')
+      .map(op => op.id);
+
+    expect(edgeIds.length).toBeGreaterThan(0);
+    expect(edgeIds).toHaveLength(new Set(edgeIds).size);
   });
 });

--- a/core-ingestion/src/__tests__/patchBuilder.test.ts
+++ b/core-ingestion/src/__tests__/patchBuilder.test.ts
@@ -77,8 +77,52 @@ class Adapter:
     const edgeIds = patch.ops
       .filter(op => op.type === 'UpsertEdge')
       .map(op => op.id);
+    const chunkNodeIds = patch.ops
+      .filter(op => op.type === 'UpsertNode' && (op.kind === 'chunk' || op.kind === 'section'))
+      .map(op => op.id);
+    const containsChunkEdges = patch.ops.filter(
+      op => op.type === 'UpsertEdge' && op.predicate === 'CONTAINS_CHUNK',
+    );
+    const definesEdges = patch.ops.filter(
+      op => op.type === 'UpsertEdge' && op.predicate === 'DEFINES',
+    );
 
     expect(edgeIds.length).toBeGreaterThan(0);
     expect(edgeIds).toHaveLength(new Set(edgeIds).size);
+    expect(result!.chunks.every(chunk => chunk.name !== null)).toBe(true);
+    expect(containsChunkEdges).toHaveLength(result!.chunks.length);
+    expect(definesEdges).toHaveLength(result!.chunks.length);
+    expect(new Set(containsChunkEdges.map(edge => edge.dst))).toEqual(new Set(chunkNodeIds));
+    expect(new Set(definesEdges.map(edge => edge.src))).toEqual(new Set(chunkNodeIds));
+  });
+
+  it.each([
+    ['buildPatch', (result: NonNullable<ReturnType<typeof parseFile>>) => buildPatch(result, 'source-hash')],
+    ['buildPatchWithResolution', (result: NonNullable<ReturnType<typeof parseFile>>) =>
+      buildPatchWithResolution(result, 'source-hash', '', [])],
+  ])('keeps distinct NEXT edges between top-level overload chunks via %s', (_name, build) => {
+    const result = parseFile('adapter.py', `
+from typing import overload
+
+@overload
+def convert(value: int) -> int: ...
+
+@overload
+def convert(value: str) -> str: ...
+
+def convert(value):
+    return value
+`);
+
+    expect(result).not.toBeNull();
+    const patch = build(result!);
+    const nextEdges = patch.ops.filter(
+      op => op.type === 'UpsertEdge' && op.predicate === 'NEXT',
+    );
+
+    expect(result!.chunks).toHaveLength(3);
+    expect(nextEdges).toHaveLength(2);
+    expect(new Set(nextEdges.map(edge => edge.id)).size).toBe(2);
+    expect(nextEdges[0].dst).toBe(nextEdges[1].src);
   });
 });

--- a/core-ingestion/src/patch-builder.ts
+++ b/core-ingestion/src/patch-builder.ts
@@ -88,6 +88,24 @@ function sourceType(filePath: string): string {
   return 'code';
 }
 
+/**
+ * Keep each logical edge once per patch. Parsers can emit the same relationship
+ * more than once (for example, every declaration in a Python @overload group).
+ * Edge ids intentionally collapse those declarations to one graph edge, so
+ * forwarding every occurrence would send duplicate physical keys to ArangoDB.
+ */
+function deduplicateUpsertEdges(ops: PatchOp[]): PatchOp[] {
+  const seenEdgeIds = new Set<string>();
+  return ops.filter(op => {
+    if (op.type !== 'UpsertEdge') return true;
+    const edgeId = op.id;
+    if (typeof edgeId !== 'string') return true;
+    if (seenEdgeIds.has(edgeId)) return false;
+    seenEdgeIds.add(edgeId);
+    return true;
+  });
+}
+
 export function extractorName(): string {
   return `tree-sitter/1.24`;
 }
@@ -367,7 +385,7 @@ export function buildPatch(
       ...(multiRepo?.repoId ? { repoId: multiRepo.repoId } : {}),
     },
     baseRev: 0,
-    ops,
+    ops: deduplicateUpsertEdges(ops),
     replaces,
     intent: `Parsed ${nodePath.basename(filePath)}`,
   };
@@ -659,7 +677,7 @@ export function buildPatchWithResolution(
       ...(multiRepo?.repoId ? { repoId: multiRepo.repoId } : {}),
     },
     baseRev: 0,
-    ops,
+    ops: deduplicateUpsertEdges(ops),
     replaces,
     intent: `Parsed ${nodePath.basename(filePath)}`,
   };

--- a/core-ingestion/src/patch-builder.ts
+++ b/core-ingestion/src/patch-builder.ts
@@ -93,25 +93,44 @@ function sourceType(filePath: string): string {
  * more than once (for example, every declaration in a Python @overload group).
  * Edge ids intentionally collapse those declarations to one graph edge, so
  * forwarding every occurrence would send duplicate physical keys to ArangoDB.
+ * A repeated id with different endpoints is an identity bug, not a duplicate;
+ * fail before commit rather than silently disconnecting part of the graph.
  */
 function deduplicateUpsertEdges(ops: PatchOp[]): PatchOp[] {
-  const seenEdgeIds = new Set<string>();
-  return ops.filter(op => {
-    if (op.type !== 'UpsertEdge') return true;
+  const deduplicated: PatchOp[] = [];
+  const edgeIndexById = new Map<string, number>();
+  for (const op of ops) {
+    if (op.type !== 'UpsertEdge') {
+      deduplicated.push(op);
+      continue;
+    }
     const edgeId = op.id;
-    if (typeof edgeId !== 'string') return true;
-    if (seenEdgeIds.has(edgeId)) return false;
-    seenEdgeIds.add(edgeId);
-    return true;
-  });
+    if (typeof edgeId !== 'string') {
+      deduplicated.push(op);
+      continue;
+    }
+    const existingIndex = edgeIndexById.get(edgeId);
+    if (existingIndex === undefined) {
+      edgeIndexById.set(edgeId, deduplicated.length);
+      deduplicated.push(op);
+      continue;
+    }
+    const existing = deduplicated[existingIndex];
+    if (existing.src !== op.src || existing.dst !== op.dst || existing.predicate !== op.predicate) {
+      throw new Error(`Conflicting UpsertEdge identity for deterministic id ${edgeId}`);
+    }
+    // Exact logical duplicate: retain the last operation's attributes.
+    deduplicated[existingIndex] = op;
+  }
+  return deduplicated;
 }
 
 export function extractorName(): string {
-  return `tree-sitter/1.24`;
+  return `tree-sitter/1.25`;
 }
 
 /** Previous extractor versions — their patches are superseded when re-ingesting. */
-export const PREVIOUS_EXTRACTORS = ['tree-sitter/1.23', 'tree-sitter/1.22', 'tree-sitter/1.21', 'tree-sitter/1.20', 'tree-sitter/1.19', 'tree-sitter/1.18', 'tree-sitter/1.17', 'tree-sitter/1.16', 'tree-sitter/1.15', 'tree-sitter/1.14', 'tree-sitter/1.13', 'tree-sitter/1.12', 'tree-sitter/1.11', 'tree-sitter/1.10', 'tree-sitter/1.9', 'tree-sitter/1.8', 'tree-sitter/1.7', 'tree-sitter/1.6', 'tree-sitter/1.5', 'tree-sitter/1.4', 'tree-sitter/1.3', 'tree-sitter/1.2', 'tree-sitter/1.1'];
+export const PREVIOUS_EXTRACTORS = ['tree-sitter/1.24', 'tree-sitter/1.23', 'tree-sitter/1.22', 'tree-sitter/1.21', 'tree-sitter/1.20', 'tree-sitter/1.19', 'tree-sitter/1.18', 'tree-sitter/1.17', 'tree-sitter/1.16', 'tree-sitter/1.15', 'tree-sitter/1.14', 'tree-sitter/1.13', 'tree-sitter/1.12', 'tree-sitter/1.11', 'tree-sitter/1.10', 'tree-sitter/1.9', 'tree-sitter/1.8', 'tree-sitter/1.7', 'tree-sitter/1.6', 'tree-sitter/1.5', 'tree-sitter/1.4', 'tree-sitter/1.3', 'tree-sitter/1.2', 'tree-sitter/1.1'];
 
 /** Patch ids that may own the active graph entities for a stored source hash. */
 export function sourcePatchIdCandidates(
@@ -266,7 +285,7 @@ export function buildPatch(
     // File -[CONTAINS]-> Chunk
     ops.push({
       type: 'UpsertEdge',
-      id: edgeId(idPath, 'file', chunkName, 'CONTAINS_CHUNK'),
+      id: edgeId(idPath, fileNodeId, cid, 'CONTAINS_CHUNK'),
       src: fileNodeId,
       dst: cid,
       predicate: 'CONTAINS_CHUNK',
@@ -278,7 +297,7 @@ export function buildPatch(
       const symbolNid = nodeId(idPath, symbolKey);
       ops.push({
         type: 'UpsertEdge',
-        id: edgeId(idPath, chunkName, symbolKey, 'DEFINES'),
+        id: edgeId(idPath, cid, symbolNid, 'DEFINES'),
         src: cid,
         dst: symbolNid,
         predicate: 'DEFINES',
@@ -295,11 +314,9 @@ export function buildPatch(
     if (a.container == null && b.container == null) {
       const aid = chunkId(idPath, a.chunkKind, a.name, a.lineStart);
       const bid = chunkId(idPath, b.chunkKind, b.name, b.lineStart);
-      const aName = a.name ?? `file_body:${a.lineStart}`;
-      const bName = b.name ?? `file_body:${b.lineStart}`;
       ops.push({
         type: 'UpsertEdge',
-        id: edgeId(idPath, aName, bName, 'NEXT'),
+        id: edgeId(idPath, aid, bid, 'NEXT'),
         src: aid,
         dst: bid,
         predicate: 'NEXT',
@@ -561,7 +578,7 @@ export function buildPatchWithResolution(
     });
     ops.push({
       type: 'UpsertEdge',
-      id: edgeId(idPath, 'file', chunkName, 'CONTAINS_CHUNK'),
+      id: edgeId(idPath, fileNodeId2, cid, 'CONTAINS_CHUNK'),
       src: fileNodeId2,
       dst: cid,
       predicate: 'CONTAINS_CHUNK',
@@ -572,7 +589,7 @@ export function buildPatchWithResolution(
       const symbolNid = nodeId(idPath, symbolKey);
       ops.push({
         type: 'UpsertEdge',
-        id: edgeId(idPath, chunkName, symbolKey, 'DEFINES'),
+        id: edgeId(idPath, cid, symbolNid, 'DEFINES'),
         src: cid,
         dst: symbolNid,
         predicate: 'DEFINES',
@@ -587,11 +604,9 @@ export function buildPatchWithResolution(
     if (a.container == null && b.container == null) {
       const aid = chunkId(idPath, a.chunkKind, a.name, a.lineStart);
       const bid = chunkId(idPath, b.chunkKind, b.name, b.lineStart);
-      const aName = a.name ?? `file_body:${a.lineStart}`;
-      const bName = b.name ?? `file_body:${b.lineStart}`;
       ops.push({
         type: 'UpsertEdge',
-        id: edgeId(idPath, aName, bName, 'NEXT'),
+        id: edgeId(idPath, aid, bid, 'NEXT'),
         src: aid,
         dst: bid,
         predicate: 'NEXT',

--- a/ix-cli/src/cli/__tests__/ingest-reconcile.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-reconcile.test.ts
@@ -16,7 +16,7 @@ function patchWith(ops: GraphPatchPayload["ops"]): GraphPatchPayload {
     source: {
       uri: "src/example.ts",
       sourceHash: "next-hash",
-      extractor: "tree-sitter/1.24",
+      extractor: "tree-sitter/1.25",
       sourceType: "code",
       workspaceId: "deadbeef",
     },


### PR DESCRIPTION
Fixes #409

## Summary
Prevent deterministic graph edges from appearing more than once in a file patch without collapsing distinct chunk connections. Python `@overload` declarations and similar repeated parser relationships can produce the same logical relationship edge repeatedly; sending every occurrence causes the memory layer to hit ArangoDB error 1210 while snapshotting an existing edge.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- coalesce repeated `UpsertEdge` operations only when ID, endpoints, and predicate agree
- reject same-ID edges with conflicting identities rather than silently disconnecting graph data
- derive `CONTAINS_CHUNK`, `DEFINES`, and `NEXT` IDs from their physical node endpoints in both patch builders
- advance the extractor identity to `tree-sitter/1.25` and supersede `1.24` so old graph ownership is replaced
- add Python overload regressions covering relationship de-duplication and preservation of every chunk connection

## Validation
- Before the fix, the regression emitted 14 edge operations with only 8 unique IDs and failed for both patch builders
- Against the published `ix-memory-layer:latest`, an initial unique edge committed at revision 1; an incremental patch containing that edge twice returned HTTP 500 wrapping ArangoDB 409/1210 (`conflicting key: <edge-id>_2`); the de-duplicated equivalent committed at revision 2
- Independent review caught and verified fixes for chunk-edge identity and extractor migration; final review reported no remaining findings
- `cd core-ingestion && npm test -- --run src/__tests__/patchBuilder.test.ts` (6 passed)
- `cd ix-cli && npm test` (60 files passed, 854 tests passed, 3 skipped; parser smoke passed)
- `cd ix-cli && npm run typecheck && npm run build && npm run lint` (0 lint errors; 41 existing warnings)
- `cd core-ingestion && npm test` (316 passed; 6 unrelated repository-baseline failures involving missing private Scala fixtures, a stale snapshot, and stale parser expectations)

## Backend note
Current backend `main` already de-duplicates bulk documents. The direct `/v1/patch` history snapshot should still be made idempotent as defense-in-depth, but Ix will no longer generate the duplicate edge operations that trigger #409.

## Checklist
- [x] Tests pass for the changed paths; unrelated core-suite failures are documented above
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works