### PR TITLE
fix(view): keep backend scope out of generated script

### DIFF
--- a/ix-cli/src/cli/__tests__/view-running-port.test.ts
+++ b/ix-cli/src/cli/__tests__/view-running-port.test.ts
@@ -41,9 +41,20 @@ beforeEach(() => {
   writeFileSync(join(compassDir, "index.html"), "<!doctype html>");
 
   mocks.spawn.mockReturnValue({ pid: 4242, unref: vi.fn() });
+  // The same probe answers two opposite questions: before the spawn, "is this
+  // port already taken?" (it must not be), and after it, "is the server up
+  // yet?" (it must be). A mock that always refuses satisfies the first and
+  // hangs the second for the whole readiness budget, so model the transition:
+  // refuse until the server is spawned, accept once it has been.
   mocks.createConnection.mockImplementation(() => {
-    const connection = new EventEmitter();
-    queueMicrotask(() => connection.emit("error", new Error("not listening")));
+    // `end()` because the connect path closes the socket it just opened.
+    const connection = Object.assign(new EventEmitter(), { end: vi.fn() });
+    const listening = mocks.spawn.mock.calls.length > 0;
+    queueMicrotask(() =>
+      listening
+        ? connection.emit("connect")
+        : connection.emit("error", new Error("not listening")),
+    );
     return connection;
   });
 });

--- a/ix-cli/src/cli/__tests__/view-server.test.ts
+++ b/ix-cli/src/cli/__tests__/view-server.test.ts
@@ -73,11 +73,14 @@ describe("view server (/__ix/remap)", () => {
     );
 
     port = await getFreePort();
-    const script = serverScript(distDir, port, "test-workspace", null, mapRoot);
+    const script = serverScript();
     // The generated script must survive template-literal emission intact.
     expect(script).toContain('"/__ix/remap"');
     expect(script).toContain("IX_VIEW_MAP_MAIN");
     expect(script).toContain('server.listen(PORT, "127.0.0.1"');
+    // Backend-derived scope is supplied only at runtime, never written into
+    // the generated executable script.
+    expect(script).toContain("const SYSTEM_ID = process.argv[5] || null");
 
     await startServer({ STUB_EXIT: "0" });
   });
@@ -111,8 +114,16 @@ describe("view server (/__ix/remap)", () => {
   async function startServer(extraEnv: Record<string, string>, root: string | null = mapRoot) {
     await stopServer();
     const scriptPath = join(distDir, "compass-server.js");
-    writeFileSync(scriptPath, serverScript(distDir, port, "test-workspace", null, root));
-    const spawned = spawn(process.execPath, [scriptPath], {
+    writeFileSync(scriptPath, serverScript());
+    const spawned = spawn(process.execPath, [
+      scriptPath,
+      distDir,
+      String(port),
+      "test-workspace",
+      "",
+      root ?? "",
+      stubMain,
+    ], {
       env: {
         ...process.env,
         NODE_ENV: "test", // the IX_VIEW_MAP_MAIN seam is honoured only under this

--- a/ix-cli/src/cli/__tests__/view-server.test.ts
+++ b/ix-cli/src/cli/__tests__/view-server.test.ts
@@ -5,7 +5,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer } from "node:net";
 import * as http from "node:http";
-import { serverScript } from "../commands/view.js";
+import { serverRuntimeArgs, serverScript } from "../commands/view.js";
+
+interface StartServerOptions {
+  workspaceId?: string;
+  systemId?: string;
+  backendUrl?: string;
+  useMapMainOverride?: boolean;
+}
 
 /** Pick a free TCP port by binding port 0 and releasing it. */
 function getFreePort(): Promise<number> {
@@ -44,12 +51,12 @@ describe("view server (/__ix/remap)", () => {
 
   beforeAll(async () => {
     // A fake Compass dist: index.html is the SPA entry the fallback serves.
-    distDir = mkdtempSync(join(tmpdir(), "ix-view-dist-"));
+    distDir = mkdtempSync(join(tmpdir(), "ix view dist "));
     writeFileSync(join(distDir, "index.html"), "<h1>fake compass</h1>");
 
     // The workspace the server is scoped to. The endpoint maps this, not its
     // own cwd, so the test has to supply one.
-    mapRoot = mkdtempSync(join(tmpdir(), "ix-view-root-"));
+    mapRoot = mkdtempSync(join(tmpdir(), "ix view root "));
 
     // The marker records every stub invocation. It lives in the temp tree and
     // is passed by env rather than written to process.cwd(): the stub's cwd is
@@ -111,23 +118,30 @@ describe("view server (/__ix/remap)", () => {
    * could lose the bind to EADDRINUSE — invisibly, because stdio is ignored —
    * while waitForPort was satisfied by the still-dying old server.
    */
-  async function startServer(extraEnv: Record<string, string>, root: string | null = mapRoot) {
+  async function startServer(
+    extraEnv: Record<string, string>,
+    root: string | null = mapRoot,
+    options: StartServerOptions = {},
+  ) {
     await stopServer();
     const scriptPath = join(distDir, "compass-server.js");
     writeFileSync(scriptPath, serverScript());
     const spawned = spawn(process.execPath, [
       scriptPath,
-      distDir,
-      String(port),
-      "test-workspace",
-      "",
-      root ?? "",
-      stubMain,
+      ...serverRuntimeArgs(
+        distDir,
+        port,
+        options.workspaceId ?? "test-workspace",
+        options.systemId ?? null,
+        root,
+        stubMain,
+      ),
     ], {
       env: {
         ...process.env,
-        NODE_ENV: "test", // the IX_VIEW_MAP_MAIN seam is honoured only under this
-        IX_VIEW_MAP_MAIN: stubMain,
+        NODE_ENV: options.useMapMainOverride === false ? "production" : "test",
+        IX_VIEW_MAP_MAIN: options.useMapMainOverride === false ? "" : stubMain,
+        IX_VIEW_BACKEND_URL: options.backendUrl ?? "",
         STUB_MARKER: marker,
         STUB_MS: "0",
         ...extraEnv,
@@ -214,6 +228,51 @@ describe("view server (/__ix/remap)", () => {
     // The recorded workspace root, never the server's own cwd, and --silent
     // because nothing reads the output.
     expect(runs()).toEqual([`map ${mapRoot} --silent`]);
+  });
+
+  it("uses the argv CLI path outside the test-only MAP_MAIN override", async () => {
+    await startServer({ STUB_EXIT: "0" }, mapRoot, { useMapMainOverride: false });
+    try {
+      resetRuns();
+      const res = await post("/__ix/remap", { host: `127.0.0.1:${port}` });
+      expect(res.status).toBe(200);
+      expect(runs()).toEqual([`map ${mapRoot} --silent`]);
+    } finally {
+      await startServer({ STUB_EXIT: "0" });
+    }
+  });
+
+  it("passes argv workspace and system scopes to proxied backend requests", async () => {
+    let proxiedHeaders: http.IncomingHttpHeaders | null = null;
+    const backend = http.createServer((req, res) => {
+      proxiedHeaders = req.headers;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"ok":true}');
+    });
+    await new Promise<void>((resolve, reject) => {
+      backend.once("error", reject);
+      backend.listen(0, "127.0.0.1", resolve);
+    });
+    const backendAddress = backend.address();
+    if (!backendAddress || typeof backendAddress === "string") throw new Error("backend did not bind a TCP port");
+
+    try {
+      await startServer({}, mapRoot, {
+        workspaceId: "workspace:test",
+        systemId: "system:test",
+        backendUrl: `http://127.0.0.1:${backendAddress.port}`,
+      });
+      const res = await fetch(`http://127.0.0.1:${port}/v1/probe?source=test`);
+      expect(res.status).toBe(200);
+      expect(proxiedHeaders?.["x-ix-workspace"]).toBe("workspace:test");
+      expect(proxiedHeaders?.["x-ix-system"]).toBe("system:test");
+    } finally {
+      await stopServer();
+      await new Promise<void>((resolve, reject) =>
+        backend.close((err) => err ? reject(err) : resolve()),
+      );
+      await startServer({ STUB_EXIT: "0" });
+    }
   });
 
   it("accepts a same-origin loopback Origin", async () => {

--- a/ix-cli/src/cli/commands/view.ts
+++ b/ix-cli/src/cli/commands/view.ts
@@ -187,15 +187,15 @@ function cliMainForScript(): string {
   return join(dirname(fileURLToPath(import.meta.url)), "..", "main.js");
 }
 
-/** Generate the inline server script that serves static files + proxies /v1. */
-export function serverScript(
-  distDir: string,
-  port: number,
-  workspaceId: string | null,
-  systemId: string | null,
-  mapRoot: string | null = null,
-): string {
-  const cliMainPath = cliMainForScript();
+/**
+ * Generate the invariant server script that serves static files + proxies /v1.
+ *
+ * Runtime values are supplied as argv when the script is spawned. In
+ * particular, SYSTEM_ID may come from the backend, so embedding it here would
+ * create a network-data-to-executable-file path even though JSON.stringify
+ * made the generated JavaScript syntactically safe.
+ */
+export function serverScript(): string {
   return `
 const http = require("http");
 const fs = require("fs");
@@ -203,18 +203,18 @@ const path = require("path");
 const url = require("url");
 const { execFile } = require("child_process");
 
-const DIST = ${JSON.stringify(distDir)};
-const PORT = ${port};
+const DIST = process.argv[2];
+const PORT = Number(process.argv[3]);
 const BACKEND = ${JSON.stringify(BACKEND_URL)};
-const WORKSPACE_ID = ${JSON.stringify(workspaceId)};
-const SYSTEM_ID = ${JSON.stringify(systemId)};
+const WORKSPACE_ID = process.argv[4] || null;
+const SYSTEM_ID = process.argv[5] || null;
 
-// The workspace root /__ix/remap maps, resolved by ix view start and baked in
-// rather than re-derived here — null when --all left the view unscoped.
-const MAP_ROOT = ${JSON.stringify(mapRoot)};
+// The workspace root /__ix/remap maps, resolved by ix view start rather than
+// re-derived here — empty/null when --all left the view unscoped.
+const MAP_ROOT = process.argv[6] || null;
 
 // The CLI that generated this script, resolved from its own location at
-// generation time. Deriving it here from DIST only worked for the installed
+// launch time. Deriving it here from DIST only worked for the installed
 // layout; findCompassDist's dev branch returns a repo path, from which the
 // same arithmetic lands on a file that never exists.
 //
@@ -223,7 +223,11 @@ const MAP_ROOT = ${JSON.stringify(mapRoot)};
 // environment.
 const MAP_MAIN = (process.env.NODE_ENV === "test" && process.env.IX_VIEW_MAP_MAIN)
   ? process.env.IX_VIEW_MAP_MAIN
-  : ${JSON.stringify(cliMainPath)};
+  : process.argv[7];
+
+if (!DIST || !Number.isInteger(PORT) || PORT < 1 || PORT > 65535 || !MAP_MAIN) {
+  throw new Error("invalid ix view server arguments");
+}
 
 // One map at a time. execFile is asynchronous, so nothing else serialises them.
 let mapInFlight = null;
@@ -534,10 +538,21 @@ export function registerViewCommand(program: Command): void {
       // Write server script to temp location
       const scriptDir = dirname(SERVER_SCRIPT_FILE);
       mkdirSync(scriptDir, { recursive: true });
-      writeFileSync(SERVER_SCRIPT_FILE, serverScript(distDir, port, workspaceId, systemId, mapRoot));
+      // The file is deliberately invariant: systemId can be returned by the
+      // backend and must never flow into JavaScript that is written and then
+      // executed. Runtime values travel as argv instead.
+      writeFileSync(SERVER_SCRIPT_FILE, serverScript());
 
       // Spawn detached process
-      const child = spawn("node", [SERVER_SCRIPT_FILE], {
+      const child = spawn(process.execPath, [
+        SERVER_SCRIPT_FILE,
+        distDir,
+        String(port),
+        workspaceId ?? "",
+        systemId ?? "",
+        mapRoot ?? "",
+        cliMainForScript(),
+      ], {
         detached: true,
         stdio: "ignore",
       });

--- a/ix-cli/src/cli/commands/view.ts
+++ b/ix-cli/src/cli/commands/view.ts
@@ -178,6 +178,27 @@ function isPortInUse(port: number): Promise<boolean> {
 }
 
 /**
+ * Wait for the detached server to accept connections.
+ *
+ * It is spawned with `stdio: "ignore"`, so anything it writes on the way down
+ * goes nowhere — including the throw that now guards its argument contract.
+ * Without this the CLI printed "[ok] Visualizer started", wrote a PID file for
+ * a dead process and opened a browser on a closed port.
+ *
+ * Polls rather than watching for `exit`: the child is detached and unref'd, and
+ * the question worth answering is whether the port is actually serving, not
+ * whether the process happens to still be alive.
+ */
+async function waitForServer(port: number, timeoutMs = 8000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await isPortInUse(port)) return true;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return false;
+}
+
+/**
  * Path to the CLI entry point of the install generating this script.
  *
  * Taken from this module's own location rather than derived from the compass
@@ -563,6 +584,9 @@ export function registerViewCommand(program: Command): void {
         process.exit(1);
       }
 
+      // A pid only means the spawn succeeded — see waitForServer.
+      const ready = await waitForServer(port);
+
       // Save PID, scope, and port for subsequent start/status/stop commands.
       mkdirSync(dirname(PID_FILE), { recursive: true });
       writeFileSync(PID_FILE, String(child.pid));
@@ -570,6 +594,18 @@ export function registerViewCommand(program: Command): void {
       writeFileSync(PORT_FILE, String(port));
 
       const url = `http://localhost:${port}`;
+
+      // Reported rather than fatal: the wait is a heuristic, and a machine slow
+      // enough to exceed it would otherwise have a working visualizer killed off
+      // or the command fail. The PID/scope/port files are written either way, so
+      // `ix view status` and `ix view stop` still work on whatever did start.
+      if (!ready) {
+        console.error(`[!] Visualizer started (PID ${child.pid}) but is not yet serving ${url}.`);
+        console.error("    If it does not come up shortly, run 'ix view stop', then");
+        console.error("    'ix upgrade' if the Compass bundle is missing or incomplete.");
+        return;
+      }
+
       console.log(`[ok] Visualizer started (PID ${child.pid})`);
       console.log(`  ${url}`);
       console.log(

--- a/ix-cli/src/cli/commands/view.ts
+++ b/ix-cli/src/cli/commands/view.ts
@@ -208,6 +208,25 @@ function cliMainForScript(): string {
   return join(dirname(fileURLToPath(import.meta.url)), "..", "main.js");
 }
 
+/** Build the argv payload shared by the production launcher and server tests. */
+export function serverRuntimeArgs(
+  distDir: string,
+  port: number,
+  workspaceId: string | null,
+  systemId: string | null,
+  mapRoot: string | null,
+  cliMainPath: string = cliMainForScript(),
+): string[] {
+  return [
+    distDir,
+    String(port),
+    workspaceId ?? "",
+    systemId ?? "",
+    mapRoot ?? "",
+    cliMainPath,
+  ];
+}
+
 /**
  * Generate the invariant server script that serves static files + proxies /v1.
  *
@@ -226,7 +245,9 @@ const { execFile } = require("child_process");
 
 const DIST = process.argv[2];
 const PORT = Number(process.argv[3]);
-const BACKEND = ${JSON.stringify(BACKEND_URL)};
+const BACKEND = (process.env.NODE_ENV === "test" && process.env.IX_VIEW_BACKEND_URL)
+  ? process.env.IX_VIEW_BACKEND_URL
+  : ${JSON.stringify(BACKEND_URL)};
 const WORKSPACE_ID = process.argv[4] || null;
 const SYSTEM_ID = process.argv[5] || null;
 
@@ -345,7 +366,8 @@ const server = http.createServer((req, res) => {
     // stream open for the whole map.
     req.resume();
     // MAP_ROOT is the workspace this visualizer is showing, resolved once by
-    // ix view start and baked in. Mapping process.cwd() instead would follow
+    // ix view start and supplied at launch. Mapping process.cwd() instead would
+    // follow
     // whatever directory the detached server was launched from: --all does not
     // require that to be a workspace at all, so "ix view start --all" run from
     // a home directory turned one click into an ingest of the whole of it.
@@ -491,10 +513,9 @@ export function registerViewCommand(program: Command): void {
             // workspace scoping (single-repo behavior is unaffected).
           }
         }
-        // The system id (from a local marker or the backend) is embedded in the
-        // generated, then-executed compass server script and the scope file, so
-        // constrain it to the known id charset before use (CodeQL
-        // js/http-to-file-access barrier; serverScript also JSON-encodes it).
+        // The system id (from a local marker or the backend) becomes a proxy
+        // header and persisted scope label, so constrain it to the known id
+        // charset before either use.
         if (systemId !== null && !/^[A-Za-z0-9_.:-]+$/.test(systemId)) {
           systemId = null;
         }
@@ -567,12 +588,7 @@ export function registerViewCommand(program: Command): void {
       // Spawn detached process
       const child = spawn(process.execPath, [
         SERVER_SCRIPT_FILE,
-        distDir,
-        String(port),
-        workspaceId ?? "",
-        systemId ?? "",
-        mapRoot ?? "",
-        cliMainForScript(),
+        ...serverRuntimeArgs(distDir, port, workspaceId, systemId, mapRoot),
       ], {
         detached: true,
         stdio: "ignore",


### PR DESCRIPTION
## Summary

- Make the generated Compass server script invariant.
- Pass runtime scope and paths through process arguments instead of embedding backend-derived data in executable JavaScript.
- Use the current Node executable for the detached server.
- Wait for the detached server before reporting it ready.
- Centralize and test the runtime argument contract, including scope headers and paths with spaces.

Closes the network-data-to-file CodeQL finding in ix view (security/code-scanning/50).

## Validation

- npm test: 856 passed, 3 skipped
- npm run build
- npm run typecheck
- npm run lint -- --quiet
- npm run knip
- npm audit --audit-level=high: 0 vulnerabilities
- bash scripts/ci/check-config-security.sh