### PR TITLE
fix(config): create Ix home before saving config

### DIFF
--- a/ix-cli/src/cli/__tests__/config-file-mode.test.ts
+++ b/ix-cli/src/cli/__tests__/config-file-mode.test.ts
@@ -44,6 +44,13 @@ describe("saveConfig persistence", () => {
     expect(fs.readdirSync(cfgDir())).toEqual(["config.yaml"]);
   });
 
+  it.skipIf(!posix)("creates the config directory 0700", () => {
+    // The 0600 on the file is undone by a 0755 directory beside it: the names
+    // in ~/.ix are themselves a disclosure, and this is the call that creates it.
+    saveConfig({ endpoint: "http://localhost:8090", format: "text" });
+    expect(fs.statSync(cfgDir()).mode & 0o777).toBe(0o700);
+  });
+
   it.skipIf(!posix)("creates the config 0600", () => {
     saveConfig({ endpoint: "http://localhost:8090", format: "text" });
     expect(fs.statSync(cfgPath()).mode & 0o777).toBe(0o600);

--- a/ix-cli/src/cli/__tests__/config-file-mode.test.ts
+++ b/ix-cli/src/cli/__tests__/config-file-mode.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as nodePath from "node:path";
+import { parse } from "yaml";
 
 import { saveConfig } from "../config.js";
 
@@ -16,7 +17,6 @@ beforeEach(() => {
   savedProfile = process.env.USERPROFILE;
   process.env.HOME = home;
   process.env.USERPROFILE = home;
-  fs.mkdirSync(nodePath.join(home, ".ix"), { recursive: true });
 });
 
 afterEach(() => {
@@ -26,23 +26,76 @@ afterEach(() => {
 });
 
 const cfgPath = () => nodePath.join(home, ".ix", "config.yaml");
+const cfgDir = () => nodePath.dirname(cfgPath());
+const readConfig = () => parse(fs.readFileSync(cfgPath(), "utf8")) as Record<string, unknown>;
 
 // POSIX permission bits are meaningless on Windows (chmod only toggles the
 // read-only bit), so statSync reports modes like 0o666 and these assertions
 // can't hold. The 0600 guard protects unix-like systems; skip the checks there.
 const posix = process.platform !== "win32";
 
-describe("saveConfig file mode (credentials live in this file)", () => {
+describe("saveConfig persistence", () => {
+  it("creates a config from a fresh home without leaving the staging file", () => {
+    expect(fs.existsSync(cfgDir())).toBe(false);
+
+    saveConfig({ endpoint: "http://localhost:8090", format: "json" });
+
+    expect(readConfig()).toMatchObject({ endpoint: "http://localhost:8090", format: "json" });
+    expect(fs.readdirSync(cfgDir())).toEqual(["config.yaml"]);
+  });
+
   it.skipIf(!posix)("creates the config 0600", () => {
     saveConfig({ endpoint: "http://localhost:8090", format: "text" });
     expect(fs.statSync(cfgPath()).mode & 0o777).toBe(0o600);
   });
 
   it.skipIf(!posix)("tightens a pre-existing group/world-readable config to 0600", () => {
+    fs.mkdirSync(cfgDir(), { recursive: true });
     fs.writeFileSync(cfgPath(), "endpoint: http://localhost:8090\nformat: text\n", { mode: 0o644 });
     fs.chmodSync(cfgPath(), 0o644); // force 0644 regardless of umask
     saveConfig({ endpoint: "http://localhost:8090", format: "text" });
     // No group/world bits remain.
     expect(fs.statSync(cfgPath()).mode & 0o077).toBe(0);
+  });
+
+  it.skipIf(!posix)("atomically replaces an existing config and removes the staging file", () => {
+    fs.mkdirSync(cfgDir(), { recursive: true });
+    fs.writeFileSync(cfgPath(), "endpoint: http://old.example\nformat: text\n");
+    const previousInode = fs.statSync(cfgPath()).ino;
+
+    saveConfig({ endpoint: "http://new.example", format: "json" });
+
+    const currentInode = fs.statSync(cfgPath()).ino;
+    if (previousInode !== 0 && currentInode !== 0) expect(currentInode).not.toBe(previousInode);
+    expect(fs.readdirSync(cfgDir())).toEqual(["config.yaml"]);
+    expect(readConfig()).toMatchObject({ endpoint: "http://new.example", format: "json" });
+  });
+
+  it("preserves extension and user-owned fields in an existing config", () => {
+    fs.mkdirSync(cfgDir(), { recursive: true });
+    fs.writeFileSync(
+      cfgPath(),
+      [
+        "endpoint: http://old.example",
+        "format: text",
+        "active: private-cloud",
+        "instances:",
+        "  private-cloud:",
+        "    refresh_token: secret",
+        "user:",
+        "  name: Alice",
+        "",
+      ].join("\n"),
+    );
+
+    saveConfig({ endpoint: "http://new.example", format: "json" });
+
+    expect(readConfig()).toEqual({
+      active: "private-cloud",
+      instances: { "private-cloud": { refresh_token: "secret" } },
+      user: { name: "Alice" },
+      endpoint: "http://new.example",
+      format: "json",
+    });
   });
 });

--- a/ix-cli/src/cli/config.ts
+++ b/ix-cli/src/cli/config.ts
@@ -77,7 +77,12 @@ const OSS_OWNED_KEYS = new Set<keyof IxConfig>([
 export function saveConfig(config: IxConfig): void {
   const configDir = join(homedir(), ".ix");
   const configPath = join(configDir, "config.yaml");
-  mkdirSync(configDir, { recursive: true });
+  // 0700, to match the 0600 the config itself is written with below: the file
+  // holds credentials (Pro's instances carry a tunnel JWT and a long-lived IdP
+  // refresh token), and a directory created at the default umask (typically
+  // 0755) lets anyone on the host list the names beside it. `mode` applies only
+  // to directories this call creates, so an existing ~/.ix keeps its own mode.
+  mkdirSync(configDir, { recursive: true, mode: 0o700 });
   let existing: Record<string, unknown> = {};
   if (existsSync(configPath)) {
     try {

--- a/ix-cli/src/cli/config.ts
+++ b/ix-cli/src/cli/config.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync, rmSync, chmodSync, renameSync, realpathSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, rmSync, chmodSync, renameSync, realpathSync, mkdirSync } from "node:fs";
 import { isAbsolute, join, relative, resolve as resolvePath, sep } from "node:path";
 import { homedir } from "node:os";
 import { createHash } from "node:crypto";
@@ -75,7 +75,9 @@ const OSS_OWNED_KEYS = new Set<keyof IxConfig>([
 ]);
 
 export function saveConfig(config: IxConfig): void {
-  const configPath = join(homedir(), ".ix", "config.yaml");
+  const configDir = join(homedir(), ".ix");
+  const configPath = join(configDir, "config.yaml");
+  mkdirSync(configDir, { recursive: true });
   let existing: Record<string, unknown> = {};
   if (existsSync(configPath)) {
     try {


### PR DESCRIPTION
Fixes #413

## Summary
Create the Ix home directory when `saveConfig()` performs the first config write, while preserving the existing private atomic replacement path.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Create `~/.ix` recursively before writing the same-directory staging file.
- Keep the existing `0600` staging mode, atomic rename, and post-rename permission tightening.
- Cover a fresh home, file permissions, atomic replacement, staging cleanup, and preservation of extension and user-owned fields.

## Validation
- `npx vitest run src/cli/__tests__/config-file-mode.test.ts` (5 passed)
- `npm test` (61 files; 861 passed, 1 skipped; parser smoke passed)
- `npm run typecheck`
- `npm run build`
- `npm run lint` (0 errors; 41 existing warnings)
- Fresh-home CLI probe: `ix config set format json` wrote a `0600` config with no staging file left behind
- `git diff --check`
- `npm run format:check` still reports the same 123 pre-existing files as unformatted on both `origin/main` and this branch

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
