### PR TITLE
chore(security): backfill SAST record for PR #380

### DIFF
--- a/ix-cli/src/cli/__tests__/search-ranking.test.ts
+++ b/ix-cli/src/cli/__tests__/search-ranking.test.ts
@@ -193,6 +193,66 @@ describe("resolveEntityFull: method preferred over chunk for PascalCase names", 
   });
 });
 
+describe("resolveEntityFull: same-kind ambiguity", () => {
+  const duplicateClasses = [
+    {
+      id: "alpha-service-id",
+      name: "DuplicateService",
+      kind: "class",
+      provenance: { sourceUri: "src/alpha/DuplicateService.ts" },
+    },
+    {
+      id: "beta-service-id",
+      name: "DuplicateService",
+      kind: "class",
+      provenance: { sourceUri: "src/beta/DuplicateService.ts" },
+    },
+  ];
+
+  it("stays ambiguous when --kind matches multiple exact-name candidates", async () => {
+    const mockClient = {
+      search: vi.fn().mockResolvedValue(duplicateClasses),
+    } as any;
+
+    const result = await resolveEntityFull(
+      mockClient,
+      "DuplicateService",
+      ["class"],
+      { kind: "class" },
+    );
+
+    expect(result.resolved).toBe(false);
+    if (!result.resolved) {
+      expect(result.ambiguous).toBe(true);
+      if (result.ambiguous) {
+        expect(result.result.candidates.map(candidate => candidate.id)).toEqual([
+          "alpha-service-id",
+          "beta-service-id",
+        ]);
+      }
+    }
+  });
+
+  it("honors --pick after --kind leaves multiple candidates", async () => {
+    const mockClient = {
+      search: vi.fn().mockResolvedValue(duplicateClasses),
+    } as any;
+
+    const result = await resolveEntityFull(
+      mockClient,
+      "DuplicateService",
+      ["class"],
+      { kind: "class", pick: 2 },
+    );
+
+    expect(result.resolved).toBe(true);
+    if (result.resolved) {
+      expect(result.entity.id).toBe("beta-service-id");
+      expect(result.entity.path).toBe("src/beta/DuplicateService.ts");
+    }
+  });
+});
+
 describe("resolveEntityFull --path hard exclusion", () => {
   it("excludes out-of-scope candidates even on exact name match", async () => {
     // Simulates Bug 1: etcd has 'Notifier' but prometheus does not.

--- a/ix-cli/src/cli/resolve.ts
+++ b/ix-cli/src/cli/resolve.ts
@@ -330,11 +330,6 @@ function pickBest(
     return { resolved: true, entity: nodeToResolved(best.node, symbol, resolutionMode(best, opts)) };
   }
 
-  // If user specified --kind, take the best — they asked for it
-  if (opts?.kind) {
-    return { resolved: true, entity: nodeToResolved(best.node, symbol, "exact") };
-  }
-
   // Check if all top candidates at the same score tier are the same entity
   const topScore = best.score;
   const topTier = unique.filter(s => s.score === topScore);


### PR DESCRIPTION
Temporary audit-only PR to backfill the missing SAST check record on historical head commit b890461 (original PR #380). No merge intended; this will be closed and the branch deleted after GitHub records the scan.