### PR TITLE
fix(mcp): fail truncated in-process output

### DIFF
--- a/ix-cli/src/cli/__tests__/mcp-runner.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-runner.test.ts
@@ -403,7 +403,7 @@ describe("in-process ix runner", () => {
     });
   });
 
-  it("truncates output instead of growing the server heap without bound", async () => {
+  it("fails the run when output is truncated to protect the server heap", async () => {
     const run = createInProcessRunner({
       createProgram: createTestProgram,
       maxOutputBytes: 500,
@@ -411,6 +411,7 @@ describe("in-process ix runner", () => {
 
     const result = await run(["flood"]);
 
+    expect(result.ok).toBe(false);
     expect(result.stdout.length).toBeLessThanOrEqual(500);
     expect(result.stderr).toContain("exceeded 500 bytes and was truncated");
   });

--- a/ix-cli/src/cli/__tests__/mcp-structured-output.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-structured-output.test.ts
@@ -1,9 +1,11 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { Command } from "commander";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { createIxMcpServer, type IxRunner } from "../../mcp/server.js";
+import { createInProcessRunner } from "../../mcp/runner.js";
 
 const clients: Client[] = [];
 
@@ -50,6 +52,33 @@ describe("ix mcp structured output", () => {
     // the raw text still carries the answer.
     expect(result.structuredContent).toEqual({});
     expect(result.content[0]).toEqual({ type: "text", text: "not json at all" });
+  });
+
+  it("returns an MCP error without structured content when in-process output is truncated", async () => {
+    const runIx = createInProcessRunner({
+      maxOutputBytes: 100,
+      createProgram: () => {
+        const program = new Command();
+        program
+          .command("map")
+          .option("--format <format>")
+          .action(() => console.log(JSON.stringify({ payload: "x".repeat(500) })));
+        return program;
+      },
+    });
+    const client = await connect(runIx);
+
+    const result = (await client.callTool({ name: "ix_map", arguments: {} })) as CallToolResult;
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toBeUndefined();
+    const content = result.content[0];
+    expect(content?.type).toBe("text");
+    const error = JSON.parse(content?.type === "text" ? content.text : "{}");
+    expect(error).toEqual({
+      error: "[ix mcp] output exceeded 100 bytes and was truncated",
+      tool: "ix_map",
+    });
   });
 
   it("exposes the filtered smell candidates as structuredContent", async () => {

--- a/ix-cli/src/mcp/runner.ts
+++ b/ix-cli/src/mcp/runner.ts
@@ -468,7 +468,7 @@ async function executeInProcess(
     }
   }
 
-  const ok = failure === null && (commandExitCode === undefined || commandExitCode === 0);
+  const ok = !run.truncated && failure === null && (commandExitCode === undefined || commandExitCode === 0);
   return {
     ok,
     stdout: run.stdout.join(""),


### PR DESCRIPTION
Fixes #425

## Summary

Treat truncated in-process command output as an MCP execution failure instead of returning an incomplete structured result as successful.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Include the runner's truncation state in its success calculation.
- Preserve the existing truncation reason in the MCP error result.
- Cover the runner boundary and the MCP structured-output boundary with regression tests.

## Validation

- `npx vitest run src/cli/__tests__/mcp-runner.test.ts src/cli/__tests__/mcp-structured-output.test.ts src/cli/__tests__/mcp.test.ts` (48 passed)
- `npm test` (929 passed, 1 skipped; parser smoke passed)
- `npm run typecheck`
- `npm run build`
- `npm run lint` (0 errors; 41 existing warnings)
- `npm run knip`
- `git diff --check`

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
