### PR TITLE
fix(mcp): mark smells as mutating

### DIFF
--- a/docs/mcp-plugin-consolidation.md
+++ b/docs/mcp-plugin-consolidation.md
@@ -60,8 +60,9 @@ gemini, openclaw and opencode lose only `ix_query` and the two composites.
 - **Tool annotations.** Every advertised tool carries a `title`, and every tool
   implemented in this repository also carries `readOnlyHint`, `destructiveHint`,
   `idempotentHint` and `openWorldHint` so a client can present and route it
-  correctly. Graph reads are read-only and idempotent; `ix_map` and `ix_ingest`
-  are destructive because they mutate backend state; only `ix_ingest` is
+  correctly. Graph reads are read-only and idempotent; `ix_map`, `ix_ingest`,
+  and `ix_smells` in its default mode, which stores versioned claims, are
+  destructive because they mutate backend state; only `ix_ingest` is
   open-world, because its GitHub form reaches an external API.
 
   The Pro tools — `ix_briefing`, `ix_decisions`, `ix_decide` — carry a title and

--- a/ix-cli/src/cli/__tests__/mcp-annotations.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-annotations.test.ts
@@ -41,16 +41,24 @@ describe("ix mcp tool annotations", () => {
   });
 
   it("marks mutating tools destructive, non-idempotent, and non-read-only", async () => {
-    const client = await connect(async () => ({ ok: true, stdout: "ok", stderr: "" }), true);
+    const calls: string[][] = [];
+    const client = await connect(async (args) => {
+      calls.push(args);
+      return { ok: true, stdout: "{}", stderr: "" };
+    }, true);
     const byName = new Map((await client.listTools()).tools.map((entry) => [entry.name, entry]));
 
     // ix_decide is deliberately absent: it lives in @ix/pro, so its behavior
     // cannot be verified from here. See the Pro-tool case below.
-    for (const name of ["ix_map", "ix_ingest"]) {
+    for (const name of ["ix_map", "ix_smells", "ix_ingest"]) {
       expect(byName.get(name)?.annotations?.destructiveHint, name).toBe(true);
       expect(byName.get(name)?.annotations?.readOnlyHint, name).toBe(false);
       expect(byName.get(name)?.annotations?.idempotentHint, name).toBe(false);
     }
+
+    await client.callTool({ name: "ix_smells", arguments: {} });
+    expect(calls).toEqual([["smells", "--format=json"]]);
+    expect(calls[0]).not.toContain("--list");
   });
 
   it("asserts no behavioral hint for tools implemented outside this repository", async () => {
@@ -97,8 +105,9 @@ describe("ix mcp tool annotations", () => {
 
     // ix_ingest is the one tool that reaches outside the host (GitHub API).
     expect(byName.get("ix_ingest")?.annotations?.openWorldHint).toBe(true);
-    // Local graph reads and the local map refresh do not.
+    // Local graph reads, smell detection, and the local map refresh do not.
     expect(byName.get("ix_map")?.annotations?.openWorldHint).toBe(false);
+    expect(byName.get("ix_smells")?.annotations?.openWorldHint).toBe(false);
     expect(byName.get("ix_text")?.annotations?.openWorldHint).toBe(false);
   });
 

--- a/ix-cli/src/mcp/server.ts
+++ b/ix-cli/src/mcp/server.ts
@@ -129,7 +129,7 @@ const TOOL_ANNOTATIONS: Record<(typeof IX_MCP_TOOL_NAMES)[number], ToolAnnotatio
   ix_explain: { ...READ_ONLY, title: "Explain a symbol using graph evidence" },
   ix_rank: { ...READ_ONLY, title: "Rank graph entities by importance" },
   ix_inventory: { ...READ_ONLY, title: "List graph entities by kind" },
-  ix_smells: { ...READ_ONLY, title: "Detect graph-backed architecture smells" },
+  ix_smells: { ...WRITE, title: "Detect graph-backed architecture smells" },
   ix_stats: { ...READ_ONLY, title: "Return graph-wide statistics" },
   ix_subsystems: { ...READ_ONLY, title: "List graph-derived subsystems" },
   ix_history: { ...READ_ONLY, title: "Show provenance and patch history" },


### PR DESCRIPTION
Fixes #427

## Summary

Advertise `ix_smells` as a mutating MCP tool because its default command stores versioned claims in the graph.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Apply the existing mutating-tool annotations to `ix_smells`.
- Verify that the MCP handler invokes the write path rather than `smells --list`.
- Document that default smell detection mutates local graph state.

## Validation

- `npx vitest run src/cli/__tests__/mcp-annotations.test.ts src/cli/__tests__/mcp.test.ts src/cli/__tests__/mcp-structured-output.test.ts` (31 passed)
- `npm test` (928 passed, 1 skipped; parser smoke passed)
- `npm run typecheck`
- `npm run build`
- `npm run lint` (0 errors; 41 existing warnings)
- `npm run knip`
- `git diff --check`

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
