### PR TITLE
fix(context): validate pick option

### DIFF
--- a/ix-cli/src/cli/__tests__/context-pick-validation.test.ts
+++ b/ix-cli/src/cli/__tests__/context-pick-validation.test.ts
@@ -1,0 +1,65 @@
+import { Command, type CommanderError } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveFileOrEntity = vi.hoisted(() => vi.fn());
+
+vi.mock("../resolve.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../resolve.js")>()),
+  resolveFileOrEntity,
+}));
+
+import { registerContextCommand } from "../commands/context.js";
+
+async function runContext(args: string[]): Promise<{ error?: CommanderError; stderr: string }> {
+  const stderr: string[] = [];
+  const program = new Command()
+    .name("ix")
+    .exitOverride()
+    .configureOutput({ writeErr: (chunk) => stderr.push(chunk) });
+  registerContextCommand(program);
+
+  try {
+    await program.parseAsync(["context", "Widget", ...args], { from: "user" });
+    return { stderr: stderr.join("") };
+  } catch (error) {
+    return { error: error as CommanderError, stderr: stderr.join("") };
+  }
+}
+
+describe("ix context --pick validation", () => {
+  beforeEach(() => {
+    resolveFileOrEntity.mockReset().mockResolvedValue(undefined);
+  });
+
+  it.each(["nope", "1nope"])("rejects the complete value %j before resolving", async (pick) => {
+    const result = await runContext(["--pick", pick]);
+
+    expect(result.error?.exitCode).toBe(1);
+    expect(result.stderr).toContain("argument '" + pick + "' is invalid");
+    expect(result.stderr).toContain("must be an integer");
+    expect(result.stderr).not.toContain("TypeError");
+    expect(resolveFileOrEntity).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["1", 1],
+    ["2", 2],
+  ])("passes valid pick %s to resolution as an integer", async (rawPick, expectedPick) => {
+    const result = await runContext([
+      "--pick",
+      rawPick,
+      "--kind",
+      "function",
+      "--path",
+      "src/main.ts",
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(resolveFileOrEntity).toHaveBeenCalledOnce();
+    expect(resolveFileOrEntity.mock.calls[0]?.[2]).toEqual({
+      kind: "function",
+      path: "src/main.ts",
+      pick: expectedPick,
+    });
+  });
+});

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -1,4 +1,4 @@
-import type { Command } from "commander";
+import { InvalidArgumentError, type Command } from "commander";
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -29,7 +29,7 @@ const BUNDLE_SCHEMA = "ix-context-bundle/1";
 interface ContextOptions {
   kind?: string;
   path?: string;
-  pick?: string;
+  pick?: number;
   depth?: string;
   asOfRev?: string;
   maxEntities?: string;
@@ -41,6 +41,14 @@ interface ContextOptions {
   resume?: string;
   diff?: string;
   format: string;
+}
+
+function parsePickOption(value: string): number {
+  const normalized = value.trim();
+  if (!/^[+-]?\d+$/.test(normalized)) {
+    throw new InvalidArgumentError("must be an integer (for example, 1 or 2)");
+  }
+  return Number(normalized);
 }
 
 /** Stable evidence kinds, ordered by relevance tier (lower is more relevant). */
@@ -119,7 +127,7 @@ export function registerContextCommand(program: Command): void {
     )
     .option("--kind <kind>", "Filter target entity by kind")
     .option("--path <path>", "Prefer symbols from files matching this path substring")
-    .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)")
+    .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
     .option("--depth <depth>", "Context-graph expansion depth")
     .option("--as-of-rev <n>", "Historical context as of a graph revision")
     .option("--max-entities <n>", "Maximum entities in the bundle", "50")
@@ -162,7 +170,7 @@ export function registerContextCommand(program: Command): void {
       const resolved = await resolveFileOrEntity(client, target, {
         kind: opts.kind,
         path: opts.path,
-        pick: opts.pick ? parseInt(opts.pick, 10) : undefined,
+        pick: opts.pick,
       });
       if (!resolved) return;
 
@@ -243,14 +251,14 @@ export function registerContextCommand(program: Command): void {
 
 async function buildFreshBundle(
   target: string,
-  opts: { kind?: string; path?: string; pick?: string; depth?: string; asOfRev?: string },
+  opts: { kind?: string; path?: string; pick?: number; depth?: string; asOfRev?: string },
   budgets: { maxEntities: number; maxRelationships: number; maxEvidence: number; maxChars: number },
 ): Promise<ContextBundle | undefined> {
   const client = new IxClient(getEndpoint());
   const resolved = await resolveFileOrEntity(client, target, {
     kind: opts.kind,
     path: opts.path,
-    pick: opts.pick ? parseInt(opts.pick, 10) : undefined,
+    pick: opts.pick,
   });
   if (!resolved) return undefined;
 


### PR DESCRIPTION
Fixes #429

## Summary

Validate the `ix context --pick` value at the command boundary so malformed values cannot reach target resolution.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes

- Parse `--pick` with a strict whole-value integer validator.
- Reject malformed values before the context action and resolver run.
- Keep existing handling for valid integers, including the shared out-of-range behavior.
- Add command-level coverage for invalid and valid values.

## Validation

- `npx vitest run src/cli/__tests__/context-pick-validation.test.ts src/cli/__tests__/context.test.ts src/cli/__tests__/context-investigation.test.ts` (29 passed)
- `npm test` (67 files, 932 passed, 1 skipped, parser smoke passed)
- `npm run typecheck`
- `npm run build`
- `npm run lint` (0 errors, 41 existing warnings)
- `npm run knip`
- Built CLI smoke test confirmed `nope` exits with status 1 and a formatted option error
- `git diff --check`

## Checklist

- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)

- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
