### PR TITLE
fix(mcp): reject conflicting ingest sources

### DIFF
--- a/ix-cli/src/cli/__tests__/mcp.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp.test.ts
@@ -280,9 +280,40 @@ describe("ix mcp", () => {
       return { ok: true, stdout: "{}", stderr: "" };
     });
 
-    await client.callTool({ name: "ix_ingest", arguments: { github: "owner/repo", limit: 25 } });
+    await client.callTool({
+      name: "ix_ingest",
+      arguments: { github: "owner/repo", since: "2026-01-01", limit: 25 },
+    });
 
-    expect(calls).toEqual([["ingest", "--github=owner/repo", "--limit=25", "--format=json"]]);
+    expect(calls).toEqual([
+      ["ingest", "--github=owner/repo", "--since=2026-01-01", "--limit=25", "--format=json"],
+    ]);
+  });
+
+  it("rejects simultaneous ix_ingest path and github sources before running the CLI", async () => {
+    const calls: string[][] = [];
+    const client = await connect(async (args) => {
+      calls.push(args);
+      return { ok: true, stdout: "{}", stderr: "" };
+    });
+
+    const result = (await client.callTool({
+      name: "ix_ingest",
+      arguments: { path: "src", github: "owner/repo" },
+    })) as CallToolResult;
+
+    expect(calls).toEqual([]);
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toBeUndefined();
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: JSON.stringify({
+          error: "path and github are mutually exclusive; provide only one",
+          tool: "ix_ingest",
+        }),
+      },
+    ]);
   });
 
   it("does not pass --limit when ingesting a local path", async () => {

--- a/ix-cli/src/mcp/server.ts
+++ b/ix-cli/src/mcp/server.ts
@@ -439,6 +439,12 @@ export function createIxMcpServer(options: CreateServerOptions = {}): McpServer 
       since: z.string().min(1).optional().describe("ISO 8601 date"),
     },
     async (input) => {
+      if (typeof input.path === "string" && typeof input.github === "string") {
+        return textResult(
+          JSON.stringify({ error: "path and github are mutually exclusive; provide only one", tool: "ix_ingest" }),
+          true,
+        );
+      }
       const options: string[] = [];
       pushOption(options, "--github", input.github);
       pushOption(options, "--since", input.since);


### PR DESCRIPTION
Fixes #431

## Summary

Reject MCP `ix_ingest` requests that specify both a local path and a GitHub source instead of silently discarding the local path.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes

- Return an MCP error before the runner is called when both source inputs are present.
- Omit structured output for the rejected request.
- Preserve the existing local-only, GitHub-only, and no-source behavior.
- Add regression coverage for conflicting and valid source modes.

## Validation

- `npx vitest run src/cli/__tests__/mcp.test.ts` (25 passed)
- `npm test` (67 files, 929 passed, 1 skipped, parser smoke passed)
- `npm run typecheck`
- `npm run build`
- `npm run lint` (0 errors, 41 existing warnings)
- `npm run knip`
- `git diff --check`

## Checklist

- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)

- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
