### PR TITLE
fix(ingest): resolve renamed type imports, with a default-import guard

### DIFF
--- a/core-ingestion/src/__tests__/resolveEdges.test.ts
+++ b/core-ingestion/src/__tests__/resolveEdges.test.ts
@@ -616,6 +616,25 @@ describe('resolveEdges', () => {
     });
   });
 
+  it('does not bind a default import to a provider member named "default"', () => {
+    // `imported` is the sentinel 'default' for `import run from "./m"`, not an
+    // export name. Without the guard, the renamed-import fallback matches the
+    // *method* `M.default` and emits a confident edge to the wrong member.
+    const provider = parseFile(
+      '/repo/m.ts',
+      'export class M { default() { return 1; } }\nexport default new M();\n',
+    )!;
+    const consumer = parseFile(
+      '/repo/n.ts',
+      'import run from "./m";\nexport function go() { return run(); }\n',
+    )!;
+
+    const resolved = resolveEdges([consumer, provider]);
+    expect(
+      resolved.filter((e) => e.srcName === 'go' && e.dstQualifiedKey === 'M.default'),
+    ).toEqual([]);
+  });
+
   it('uses caller-supplied parse results instead of re-parsing', () => {
     // The CLI parses prescan sources on its worker pool and hands the results
     // in, so the index costs no main-thread parsing. Proven by supplying a

--- a/core-ingestion/src/__tests__/resolveEdges.test.ts
+++ b/core-ingestion/src/__tests__/resolveEdges.test.ts
@@ -583,6 +583,39 @@ describe('resolveEdges', () => {
     });
   });
 
+  it('resolves renamed imports used in inheritance and type references', () => {
+    const provider = parseFile(
+      '/repo/types.ts',
+      'export interface User { id: string; }\nexport class Base {}\n',
+    )!;
+    const consumer = parseFile(
+      '/repo/consumer.ts',
+      'import { type User as ExternalUser, Base as LocalBase } from "./types";\n'
+        + 'export class Child extends LocalBase {}\n'
+        + 'export function use(value: ExternalUser) { return value.id; }\n',
+    )!;
+
+    const resolved = resolveEdges([consumer, provider]);
+    expect(resolved).toContainEqual({
+      srcFilePath: '/repo/consumer.ts',
+      srcName: 'Child',
+      dstFilePath: '/repo/types.ts',
+      dstName: 'LocalBase',
+      dstQualifiedKey: 'Base',
+      predicate: 'EXTENDS',
+      confidence: 0.9,
+    });
+    expect(resolved).toContainEqual({
+      srcFilePath: '/repo/consumer.ts',
+      srcName: 'use',
+      dstFilePath: '/repo/types.ts',
+      dstName: 'ExternalUser',
+      dstQualifiedKey: 'User',
+      predicate: 'REFERENCES',
+      confidence: 0.9,
+    });
+  });
+
   it('uses caller-supplied parse results instead of re-parsing', () => {
     // The CLI parses prescan sources on its worker pool and hands the results
     // in, so the index costs no main-thread parsing. Proven by supplying a

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -3989,8 +3989,13 @@ export function resolveEdges(
           ))];
           const publicMatches: Array<{ fp: string; local: string }> = [];
           for (const fp of providerFiles.length === 1 ? providerFiles : []) {
+            // `imported` is the literal sentinel 'default' for a default import, never a
+            // real export name, so a provider member that happens to be *called* `default`
+            // (a method, getter, or static) must not satisfy the fallback.
             const local = filePublicNames.get(fp)?.get(binding.imported)
-              ?? (fileHasSymbol.get(fp)?.has(binding.imported) ? binding.imported : undefined);
+              ?? (binding.imported !== 'default' && fileHasSymbol.get(fp)?.has(binding.imported)
+                ? binding.imported
+                : undefined);
             if (local && fileHasSymbol.get(fp)?.has(local)) publicMatches.push({ fp, local });
           }
           if (publicMatches.length === 1) {

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -3989,7 +3989,8 @@ export function resolveEdges(
           ))];
           const publicMatches: Array<{ fp: string; local: string }> = [];
           for (const fp of providerFiles.length === 1 ? providerFiles : []) {
-            const local = filePublicNames.get(fp)?.get(binding.imported);
+            const local = filePublicNames.get(fp)?.get(binding.imported)
+              ?? (fileHasSymbol.get(fp)?.has(binding.imported) ? binding.imported : undefined);
             if (local && fileHasSymbol.get(fp)?.has(local)) publicMatches.push({ fp, local });
           }
           if (publicMatches.length === 1) {


### PR DESCRIPTION
Carries **@Hiro-Chiba's #434** plus one review fix. Landing it here closes #434 as merged.

> ⚠️ **Merge with a merge commit, not squash.** This branch contains Hiro-Chiba's commit alongside mine; a squash would collapse an external contributor's work into one commit authored by me.

## Their change (`819d67e`)

Resolves renamed consumer-side TS bindings for inheritance and type references — `import { Base as LocalBase }` now resolves `EXTENDS`/`REFERENCES`/`CALLS` to the provider's real symbol.

## My fix (`eab1075`)

The fallback matched `binding.imported` against every parsed symbol in the provider file. For `import run from "./m"`, `binding.imported` is the literal sentinel `'default'` (set at `index.ts:514`), not an export name — and `fileHasSymbol` holds every entity including non-exported methods. So any provider member *called* `default` satisfied it:

```
/repo/m.ts  export class M { default() { return 1; } }
            export default new M();
/repo/n.ts  import run from "./m"; export function go() { return run(); }
```

main emits nothing; #434 emits `CALLS go -> m.ts` with `dstQualifiedKey: "M.default"` at **0.9** — confident, and wrong. Guarded with the same `!== 'default'` exclusion `index.ts:3199` already uses.

CI was green because every existing default-import test uses a *named* default export, which resolves before the fallback is reached.

## Verification

Mutation-tested: delete the guard and the added test alone goes red. `tsc --noEmit` clean; core-ingestion shows the same 6 pre-existing fixture-missing failures as the untouched base.

Reviewed as part of a full pass over all 9 open PRs; the per-PR findings and a security review of the combined tree are in the thread on #434.