### PR TITLE
fix(mcp): cap thrown error output, and keep the reason when the cap already fired

### DIFF
--- a/ix-cli/src/cli/__tests__/mcp-runner.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-runner.test.ts
@@ -403,7 +403,7 @@ describe("in-process ix runner", () => {
     });
   });
 
-  it("truncates output instead of growing the server heap without bound", async () => {
+  it("fails the run when output is truncated to protect the server heap", async () => {
     const run = createInProcessRunner({
       createProgram: createTestProgram,
       maxOutputBytes: 500,
@@ -411,6 +411,7 @@ describe("in-process ix runner", () => {
 
     const result = await run(["flood"]);
 
+    expect(result.ok).toBe(false);
     expect(result.stdout.length).toBeLessThanOrEqual(500);
     expect(result.stderr).toContain("exceeded 500 bytes and was truncated");
   });

--- a/ix-cli/src/cli/__tests__/mcp-runner.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-runner.test.ts
@@ -416,6 +416,26 @@ describe("in-process ix runner", () => {
     expect(result.stderr).toContain("exceeded 500 bytes and was truncated");
   });
 
+  it("applies the output cap to thrown error messages", async () => {
+    const run = createInProcessRunner({
+      maxOutputBytes: 500,
+      createProgram: () => {
+        const program = new Command();
+        program.command("throw-long").action(() => {
+          throw new Error("E".repeat(2_000));
+        });
+        return program;
+      },
+    });
+
+    const result = await run(["throw-long"]);
+
+    expect(result.ok).toBe(false);
+    expect(Buffer.byteLength(result.stderr)).toBeLessThanOrEqual(500);
+    expect(result.stderr).toContain("exceeded 500 bytes and was truncated");
+    expect(result.stderr).not.toContain("E".repeat(500));
+  });
+
   it("reports an unknown command as a failure with commander's message", async () => {
     const run = testRunner();
 

--- a/ix-cli/src/cli/__tests__/mcp-runner.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-runner.test.ts
@@ -436,6 +436,29 @@ describe("in-process ix runner", () => {
     expect(result.stderr).not.toContain("E".repeat(500));
   });
 
+  it("keeps the failure reason when the cap already fired before the throw", async () => {
+    // Routing thrown text through appendChunk means it is dropped outright once
+    // the cap has fired, so a crash reaches the client as nothing but "output
+    // exceeded N bytes" — exactly when an operator most needs the reason.
+    const run = createInProcessRunner({
+      maxOutputBytes: 500,
+      createProgram: () => {
+        const program = new Command();
+        program.command("flood-then-throw").action(() => {
+          for (let i = 0; i < 20; i += 1) console.log("x".repeat(100));
+          throw new Error("backend refused the connection");
+        });
+        return program;
+      },
+    });
+
+    const result = await run(["flood-then-throw"]);
+
+    expect(result.ok).toBe(false);
+    expect(result.stderr).toContain("exceeded 500 bytes and was truncated");
+    expect(result.stderr).toContain("backend refused the connection");
+  });
+
   it("reports an unknown command as a failure with commander's message", async () => {
     const run = testRunner();
 

--- a/ix-cli/src/cli/__tests__/mcp-structured-output.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-structured-output.test.ts
@@ -81,6 +81,34 @@ describe("ix mcp structured output", () => {
     });
   });
 
+  it("caps thrown command errors before returning them through MCP", async () => {
+    const runIx = createInProcessRunner({
+      maxOutputBytes: 100,
+      createProgram: () => {
+        const program = new Command();
+        program
+          .command("map")
+          .option("--format <format>")
+          .action(() => {
+            throw new Error("E".repeat(500));
+          });
+        return program;
+      },
+    });
+    const client = await connect(runIx);
+
+    const result = (await client.callTool({ name: "ix_map", arguments: {} })) as CallToolResult;
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toBeUndefined();
+    const content = result.content[0];
+    const error = JSON.parse(content?.type === "text" ? content.text : "{}");
+    expect(error).toEqual({
+      error: "[ix mcp] output exceeded 100 bytes and was truncated",
+      tool: "ix_map",
+    });
+  });
+
   it("exposes the filtered smell candidates as structuredContent", async () => {
     const client = await connect(async () => ({
       ok: true,

--- a/ix-cli/src/cli/__tests__/mcp-structured-output.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp-structured-output.test.ts
@@ -1,9 +1,11 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { Command } from "commander";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { createIxMcpServer, type IxRunner } from "../../mcp/server.js";
+import { createInProcessRunner } from "../../mcp/runner.js";
 
 const clients: Client[] = [];
 
@@ -50,6 +52,33 @@ describe("ix mcp structured output", () => {
     // the raw text still carries the answer.
     expect(result.structuredContent).toEqual({});
     expect(result.content[0]).toEqual({ type: "text", text: "not json at all" });
+  });
+
+  it("returns an MCP error without structured content when in-process output is truncated", async () => {
+    const runIx = createInProcessRunner({
+      maxOutputBytes: 100,
+      createProgram: () => {
+        const program = new Command();
+        program
+          .command("map")
+          .option("--format <format>")
+          .action(() => console.log(JSON.stringify({ payload: "x".repeat(500) })));
+        return program;
+      },
+    });
+    const client = await connect(runIx);
+
+    const result = (await client.callTool({ name: "ix_map", arguments: {} })) as CallToolResult;
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toBeUndefined();
+    const content = result.content[0];
+    expect(content?.type).toBe("text");
+    const error = JSON.parse(content?.type === "text" ? content.text : "{}");
+    expect(error).toEqual({
+      error: "[ix mcp] output exceeded 100 bytes and was truncated",
+      tool: "ix_map",
+    });
   });
 
   it("exposes the filtered smell candidates as structuredContent", async () => {

--- a/ix-cli/src/mcp/runner.ts
+++ b/ix-cli/src/mcp/runner.ts
@@ -468,7 +468,7 @@ async function executeInProcess(
     }
   }
 
-  const ok = failure === null && (commandExitCode === undefined || commandExitCode === 0);
+  const ok = !run.truncated && failure === null && (commandExitCode === undefined || commandExitCode === 0);
   return {
     ok,
     stdout: run.stdout.join(""),

--- a/ix-cli/src/mcp/runner.ts
+++ b/ix-cli/src/mcp/runner.ts
@@ -26,6 +26,9 @@ export const DEFAULT_TIMEOUT_MS = 30_000;
  */
 const MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
 
+/** How much of a thrown error's text to keep once the output cap has fired. */
+const FAILURE_DETAIL_CHARS = 2 * 1024;
+
 export interface IxRunResult {
   ok: boolean;
   stdout: string;
@@ -422,7 +425,16 @@ async function executeInProcess(
   } finally {
     commandExitCode = commandExitCode ?? (exitCodeIsOurs ? process.exitCode : undefined);
     process.exitCode = callerExitCode;
-    if (failure !== null) appendChunk(run, "stderr", failure);
+    if (failure !== null) {
+      if (run.truncated) {
+        // appendChunk is a no-op once the cap has fired, but *why* the command
+        // threw is the one thing an operator still needs — otherwise a crash is
+        // reported as nothing but "output exceeded N bytes". Keep a bounded copy.
+        run.stderr.push(`\n[ix mcp] command failed: ${failure.slice(0, FAILURE_DETAIL_CHARS)}\n`);
+      } else {
+        appendChunk(run, "stderr", failure);
+      }
+    }
     run.closed = true;
     activeRun = null;
 

--- a/ix-cli/src/mcp/runner.ts
+++ b/ix-cli/src/mcp/runner.ts
@@ -422,6 +422,7 @@ async function executeInProcess(
   } finally {
     commandExitCode = commandExitCode ?? (exitCodeIsOurs ? process.exitCode : undefined);
     process.exitCode = callerExitCode;
+    if (failure !== null) appendChunk(run, "stderr", failure);
     run.closed = true;
     activeRun = null;
 
@@ -472,7 +473,7 @@ async function executeInProcess(
   return {
     ok,
     stdout: run.stdout.join(""),
-    stderr: run.stderr.join("") + (failure ?? ""),
+    stderr: run.stderr.join(""),
   };
 }
 


### PR DESCRIPTION
Carries **@Hiro-Chiba's #426 and #436** plus one review fix. Landing it here closes both as merged.

> ⚠️ **Merge with a merge commit, not squash** — this branch contains two of Hiro-Chiba's commits alongside mine.

## Their changes

- `5e2bdcf` (#426) — a run whose captured output blew the byte cap now reports `ok: false`, so the MCP layer returns an `isError` result instead of a successful empty `structuredContent`. Verified this removes a divergence rather than creating one: the subprocess path already behaved this way via `maxBuffer`.
- `033181f` (#436) — routes thrown error text through the bounded-output collector so a crash can't blow the cap.

## My fix (`1f49d9f`)

`appendChunk` starts with `if (run.truncated) return;`, so routing thrown text through it means the text is **dropped outright** once the cap has fired. A command that floods and *then* throws reaches the client as:

```json
{"error": "[ix mcp] output exceeded N bytes and was truncated"}
```

for what was actually a crash. Before #436, `stderr: run.stderr.join("") + (failure ?? "")` appended it unconditionally — so this is a regression against main, in the one case where an operator most needs the reason. Keeps a bounded 2 KiB copy.

The normal path is untouched: a throw with no prior output still goes through `appendChunk` and is capped, which their existing test pins (verified unchanged — `run.truncated` is still false at that point).

## Verification

Mutation-tested: collapse the branch back to a bare `appendChunk` call and the new test goes red. ix-cli 932 passed, 1 skipped; `typecheck` and `knip` clean.

The security pass over the combined tree cleared this area specifically: truncation-to-error is strictly safer (it can only flip `ok` true→false, never mask a failure as success), and the failure detail is a single capped `stderr.push` in one `finally`, not repeatable within a run.