### PR TITLE
fix(ingest): resolve tsconfig module mappings, with authority + security fixes

### DIFF
--- a/core-ingestion/src/__tests__/resolveEdges.test.ts
+++ b/core-ingestion/src/__tests__/resolveEdges.test.ts
@@ -287,6 +287,115 @@ describe('resolveEdges', () => {
     });
   });
 
+  it('prefers configured JS/TS module targets over unrelated stem matches', () => {
+    const consumer = parseFile(
+      '/repo/src/consumer.ts',
+      'import { execute } from "@core";\nexport function run() { return execute(); }\n',
+    )!;
+    const intended = parseFile(
+      '/repo/src/adapters/worker.ts',
+      'export function execute() { return "worker"; }\n',
+    )!;
+    const unrelated = parseFile(
+      '/repo/legacy/core.ts',
+      'export function execute() { return "legacy"; }\n',
+    )!;
+
+    const resolved = resolveEdges([consumer, intended, unrelated], undefined, undefined, {
+      resolveModuleSpecifier: (_source, specifier) =>
+        specifier === '@core' ? ['/repo/src/adapters/worker.ts'] : undefined,
+    });
+
+    expect(resolved).toContainEqual(expect.objectContaining({
+      srcFilePath: '/repo/src/consumer.ts',
+      dstFilePath: '/repo/src/adapters/worker.ts',
+      predicate: 'IMPORTS',
+      confidence: 0.9,
+    }));
+    expect(resolved).toContainEqual(expect.objectContaining({
+      srcFilePath: '/repo/src/consumer.ts',
+      dstFilePath: '/repo/src/adapters/worker.ts',
+      predicate: 'CALLS',
+      confidence: 0.9,
+    }));
+    expect(resolved.some(edge => edge.dstFilePath === '/repo/legacy/core.ts')).toBe(false);
+  });
+
+  it('uses mapped runtime files for calls and declaration files for references', () => {
+    const consumer = parseFile(
+      '/repo/src/consumer.ts',
+      'import { run, type Foo } from "@pkg";\n'
+        + 'export function call() { return run(); }\n'
+        + 'export function use(value: Foo) { return value; }\n',
+    )!;
+    const runtime = parseFile('/repo/lib/index.js', 'export function run() { return 1; }\n')!;
+    const declarations = parseFile('/repo/lib/index.d.ts', 'export interface Foo { id: string; }\n')!;
+
+    const resolved = resolveEdges([consumer, runtime, declarations], undefined, undefined, {
+      resolveModuleSpecifier: (_source, _specifier, kind) =>
+        kind === 'types' ? ['/repo/lib/index.d.ts'] : ['/repo/lib/index.js'],
+    });
+
+    expect(resolved).toContainEqual(expect.objectContaining({
+      dstFilePath: '/repo/lib/index.js',
+      predicate: 'CALLS',
+      confidence: 0.9,
+    }));
+    expect(resolved).toContainEqual(expect.objectContaining({
+      dstFilePath: '/repo/lib/index.d.ts',
+      predicate: 'REFERENCES',
+      confidence: 0.9,
+    }));
+  });
+
+  it('does not fall back to a stem when a configured JS/TS import is unresolved', () => {
+    const consumer = parseFile(
+      '/repo/src/consumer.ts',
+      'import { execute } from "@core";\nexport function run() { return execute(); }\n',
+    )!;
+    const unrelated = parseFile(
+      '/repo/legacy/core.ts',
+      'export function execute() { return "legacy"; }\n',
+    )!;
+
+    expect(resolveEdges([consumer, unrelated], undefined, undefined, {
+      resolveModuleSpecifier: () => [],
+    })).toEqual([]);
+  });
+
+  it('keeps transitive resolution when a configured module target is a barrel', () => {
+    const consumer = parseFile(
+      '/repo/app/consumer.ts',
+      'import { execute } from "@pkg";\nexport function run() { return execute(); }\n',
+    )!;
+    const barrel = parseFile(
+      '/repo/pkg/index.ts',
+      'export { execute } from "./worker.js";\n',
+    )!;
+    const worker = parseFile(
+      '/repo/pkg/worker.ts',
+      'export function execute() { return "worker"; }\n',
+    )!;
+
+    const resolved = resolveEdges([consumer, barrel, worker], undefined, undefined, {
+      resolveModuleSpecifier: (_source, specifier) =>
+        specifier === '@pkg' ? ['/repo/pkg/index.ts'] : undefined,
+    });
+
+    expect(resolved).toContainEqual(expect.objectContaining({
+      srcFilePath: '/repo/app/consumer.ts',
+      dstFilePath: '/repo/pkg/index.ts',
+      predicate: 'IMPORTS',
+      confidence: 0.9,
+    }));
+    expect(resolved).toContainEqual(expect.objectContaining({
+      srcFilePath: '/repo/app/consumer.ts',
+      dstFilePath: '/repo/pkg/worker.ts',
+      predicate: 'CALLS',
+      confidence: 0.8,
+    }));
+  });
+
   it('resolves a call through a provider export alias', () => {
     const provider = parseFile(
       '/repo/provider.ts',

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -3165,6 +3165,14 @@ export function resolveEdges(
     // cross-repo gate so genuine edges survive even where import-to-package matching
     // can't bridge the gap (e.g. Java's Maven artifactId vs `import com.google...`).
     declaredRepoDeps?: Record<string, string[]>;
+    // Workspace-aware JS/TS module resolution supplied by the CLI. `undefined`
+    // preserves the existing fallback; an empty array is authoritative and
+    // prevents a configured import from falling through to an unrelated stem.
+    resolveModuleSpecifier?: (
+      srcFilePath: string,
+      specifier: string,
+      kind?: 'runtime' | 'types',
+    ) => string[] | undefined;
   },
 ): ResolvedEdge[] {
   // Provide a default no-op stats bag when caller passes none (backward compat).
@@ -3690,13 +3698,25 @@ export function resolveEdges(
     srcLanguage: SupportedLanguages,
     modName: unknown,
     importRaw?: unknown,
+    kind: 'runtime' | 'types' = 'runtime',
   ): string[] {
+    const configuredMatches =
+      (srcLanguage === SupportedLanguages.JavaScript || srcLanguage === SupportedLanguages.TypeScript) &&
+      typeof importRaw === 'string' &&
+      !importRaw.startsWith('./') &&
+      !importRaw.startsWith('../')
+        ? opts?.resolveModuleSpecifier?.(srcFilePath, importRaw, kind)
+        : undefined;
+    const indexedConfiguredMatches = configuredMatches?.flatMap(filePath =>
+      normalizedPathToFiles.get(normalizedPathKey(filePath)) ?? []
+    ).filter(filePath => normalizedPathKey(filePath) !== normalizedPathKey(srcFilePath));
     // fileLanguage only covers the current parse batch; cross-batch candidates
     // come from the global stem index, so fall back to the extension-derived
     // language (always available) — otherwise an undefined dst language would
     // slip cross-language matches (e.g. a Python import -> a Rust/Elixir file).
-    const importMatches = (resolveRelativeImportTargets(srcFilePath, srcLanguage, importRaw) ??
-      modNameToFiles(modName, srcFilePath))
+    const importMatches = (configuredMatches === undefined
+      ? resolveRelativeImportTargets(srcFilePath, srcLanguage, importRaw) ?? modNameToFiles(modName, srcFilePath)
+      : indexedConfiguredMatches ?? [])
       .filter(fp => importLanguageCompatible(srcLanguage, fileLanguage.get(fp) ?? languageFromPath(fp)));
     if (srcLanguage !== SupportedLanguages.Go || importMatches.length <= 1) return importMatches;
     return narrowGoImportCandidates(srcFilePath, modName, importMatches, files => {
@@ -3968,6 +3988,16 @@ export function resolveEdges(
       const binding = rel.importBinding === false
         ? undefined
         : importBindingsByLocal.get(srcFilePath)?.get(origDstName);
+      const configuredBindingTargets = binding &&
+        (srcLanguage === SupportedLanguages.JavaScript || srcLanguage === SupportedLanguages.TypeScript) &&
+        !binding.pkg.startsWith('./') &&
+        !binding.pkg.startsWith('../')
+          ? opts?.resolveModuleSpecifier?.(
+              srcFilePath,
+              binding.pkg,
+              rel.predicate === 'CALLS' ? 'runtime' : 'types',
+            )
+          : undefined;
 
       // Tier 1: same-file — already correct in buildPatch, skip here. Check the
       // call-site name before any import binding rewrite so a local shadow wins.
@@ -3986,7 +4016,28 @@ export function resolveEdges(
             srcLanguage,
             binding.pkg,
             binding.pkg,
+            rel.predicate === 'CALLS' ? 'runtime' : 'types',
           ))];
+          if (
+            configuredBindingTargets !== undefined &&
+            providerFiles.length === 1 &&
+            fileHasSymbol.get(providerFiles[0])?.has(binding.imported)
+          ) {
+            const fp = providerFiles[0];
+            const dstQualifiedKey = bestQKey(fileQKeys, fp, binding.imported);
+            if (dstQualifiedKey !== null) {
+              resolved.push({
+                srcFilePath,
+                srcName,
+                dstFilePath: fp,
+                dstName: origDstName,
+                dstQualifiedKey,
+                predicate: rel.predicate,
+                confidence: 0.9,
+              });
+              continue;
+            }
+          }
           const publicMatches: Array<{ fp: string; local: string }> = [];
           for (const fp of providerFiles.length === 1 ? providerFiles : []) {
             const local = filePublicNames.get(fp)?.get(binding.imported);
@@ -4120,6 +4171,7 @@ export function resolveEdges(
         resolved.push({ srcFilePath, srcName, dstFilePath: fp, dstName: origDstName, dstQualifiedKey, predicate: rel.predicate, confidence: 0.8 });
         continue;
       }
+      if (configuredBindingTargets?.length === 0) continue;
       if (rel.predicate === 'CALLS' && relativeCallBindings.get(srcFilePath)?.has(origDstName)) {
         stats.skippedAmbiguous++;
         continue;

--- a/ix-cli/knip.json
+++ b/ix-cli/knip.json
@@ -3,5 +3,5 @@
   "entry": ["src/cli/main.ts", "src/index.ts", "test/parser.smoke.mjs"],
   "project": ["src/**/*.ts"],
   "ignore": ["test/fixtures/**", "test/parser.stress.mjs"],
-  "ignoreBinaries": ["ix", "cygpath", "tar", "start", "xdg-open"]
+  "ignoreBinaries": ["ix", "cygpath", "tar", "start", "xdg-open", "mkfifo"]
 }

--- a/ix-cli/src/cli/__tests__/ts-module-resolution.test.ts
+++ b/ix-cli/src/cli/__tests__/ts-module-resolution.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, relative, sep } from "node:path";
@@ -224,6 +225,72 @@ describe("createTypeScriptModuleResolver", () => {
       expect(resolve("src/consumer.ts", "@core")).toBeUndefined();
     },
   );
+
+  it.skipIf(process.platform === "win32")(
+    "refuses an extends that reaches a FIFO without blocking on the open",
+    () => {
+      // The guard that rejects non-regular files runs *after* the open, and
+      // opening a FIFO for reading blocks until a writer appears — so without
+      // O_NONBLOCK the open never returns and no later check can save it. The
+      // /dev/zero case does not cover this: a character device opens fine.
+      const root = workspace();
+      const fifo = join(root, "piped.json");
+      try {
+        execFileSync("mkfifo", [fifo]);
+      } catch {
+        return; // no mkfifo available — nothing to assert
+      }
+      const config = write(root, "tsconfig.json", JSON.stringify({ extends: "./piped.json" }));
+      const consumer = write(root, "src/consumer.ts");
+      const resolve = createTypeScriptModuleResolver(root, [config, consumer, fifo]);
+
+      expect(resolve("src/consumer.ts", "@core")).toBeUndefined();
+    },
+  );
+
+  it("accepts a sibling directory whose name begins with dots", () => {
+    // Containment must compare path segments: `..shared` is inside the
+    // workspace, but a bare startsWith("..") reads it as an escape.
+    const root = workspace();
+    write(
+      root,
+      "..shared/tsconfig.json",
+      JSON.stringify({ compilerOptions: { paths: { "@core": ["src/worker"] } } }),
+    );
+    const config = write(root, "tsconfig.json", JSON.stringify({ extends: "./..shared" }));
+    const consumer = write(root, "src/consumer.ts");
+    const worker = write(root, "..shared/src/worker.ts");
+    const resolve = createTypeScriptModuleResolver(root, [config, consumer, worker]);
+
+    expect(resolve("src/consumer.ts", "@core")).toEqual(["..shared/src/worker.ts"]);
+  });
+
+  it("does not claim authority when an out-of-scope extends was dropped", () => {
+    // A scoped ingest roots containment at the ingest path, so a shared base
+    // config above it is dropped. Half-loading the remainder is worse than main:
+    // the local `paths` rule matches, fails against the missing baseUrl, and
+    // returns an authoritative [] that deletes an edge main resolves.
+    const outer = workspace();
+    writeFileSync(
+      join(outer, "tsconfig.base.json"),
+      JSON.stringify({ compilerOptions: { baseUrl: "." } }),
+    );
+    const scoped = join(outer, "packages", "web");
+    mkdirSync(scoped, { recursive: true });
+    const config = write(
+      scoped,
+      "tsconfig.json",
+      JSON.stringify({
+        extends: "../../tsconfig.base.json",
+        compilerOptions: { paths: { "@app/*": ["src/*"] } },
+      }),
+    );
+    const consumer = write(scoped, "src/consumer.ts");
+    const resolve = createTypeScriptModuleResolver(scoped, [config, consumer]);
+
+    // undefined ("no opinion") lets the stem fallback run; [] would delete the edge.
+    expect(resolve("src/consumer.ts", "@app/missing")).toBeUndefined();
+  });
 
   it("follows a relative extends that names a directory", () => {
     // Previously an existsSync probe stopped at the directory itself and never

--- a/ix-cli/src/cli/__tests__/ts-module-resolution.test.ts
+++ b/ix-cli/src/cli/__tests__/ts-module-resolution.test.ts
@@ -207,6 +207,35 @@ describe("createTypeScriptModuleResolver", () => {
     expect(resolve("src/consumer.js", "services/worker")).toEqual(["src/services/worker.js"]);
   });
 
+  it("does not serve one caller's language preference to another in the same directory", () => {
+    // Guards the memo key: results are cached, and callers in the same folder
+    // share a config but not a preference order. Keying on the directory alone
+    // would hand the .js answer to the .ts caller, or whichever ran first.
+    const root = workspace();
+    const config = write(
+      root,
+      "jsconfig.json",
+      JSON.stringify({ compilerOptions: { baseUrl: "src" } }),
+    );
+    const jsConsumer = write(root, "src/consumer.js");
+    const tsConsumer = write(root, "src/consumer.ts");
+    const javascript = write(root, "src/services/worker.js");
+    const typescript = write(root, "src/services/worker.ts");
+    const resolve = createTypeScriptModuleResolver(root, [
+      config,
+      jsConsumer,
+      tsConsumer,
+      javascript,
+      typescript,
+    ]);
+
+    // Order matters: whichever runs first would poison a directory-only key.
+    expect(resolve("src/consumer.js", "services/worker")).toEqual(["src/services/worker.js"]);
+    expect(resolve("src/consumer.ts", "services/worker")).toEqual(["src/services/worker.ts"]);
+    // And repeated asks, which is what the cache exists for, stay stable.
+    expect(resolve("src/consumer.js", "services/worker")).toEqual(["src/services/worker.js"]);
+  });
+
   it("matches mapped paths case-insensitively on case-insensitive filesystems", () => {
     const root = workspace();
     const config = write(

--- a/ix-cli/src/cli/__tests__/ts-module-resolution.test.ts
+++ b/ix-cli/src/cli/__tests__/ts-module-resolution.test.ts
@@ -96,7 +96,10 @@ describe("createTypeScriptModuleResolver", () => {
     expect(resolve("src/consumer.ts", "services/worker")).toEqual(["src/services/worker.ts"]);
   });
 
-  it("treats an unresolved baseUrl module as authoritative", () => {
+  it("does not treat an unresolved baseUrl module as authoritative", () => {
+    // `baseUrl` matches every bare specifier, so its miss carries no information.
+    // Returning [] here tells the resolver "definitively not local", which drops
+    // the edge; `undefined` means "no opinion" and lets the stem fallback run.
     const root = workspace();
     const config = write(
       root,
@@ -109,7 +112,77 @@ describe("createTypeScriptModuleResolver", () => {
     const unrelated = write(root, "legacy/missing.ts");
     const resolve = createTypeScriptModuleResolver(root, [config, consumer, unrelated]);
 
-    expect(resolve("src/consumer.ts", "services/missing")).toEqual([]);
+    expect(resolve("src/consumer.ts", "services/missing")).toBeUndefined();
+  });
+
+  it("keeps third-party specifiers unresolved rather than authoritative under baseUrl", () => {
+    // The regression this guards: `baseUrl: "."` is the default in Next.js, CRA
+    // and most monorepo templates. Claiming authority over `react` there erased
+    // every third-party import edge in the graph.
+    const root = workspace();
+    const config = write(
+      root,
+      "tsconfig.json",
+      JSON.stringify({ compilerOptions: { baseUrl: "." } }),
+    );
+    const consumer = write(root, "packages/app/index.ts");
+    const sibling = write(root, "packages/lib/index.ts");
+    const resolve = createTypeScriptModuleResolver(root, [config, consumer, sibling]);
+
+    expect(resolve("packages/app/index.ts", "react")).toBeUndefined();
+    expect(resolve("packages/app/index.ts", "@org/lib")).toBeUndefined();
+  });
+
+  it("does not treat a catch-all paths rule as authoritative", () => {
+    // `"*": ["src/*"]` matches every specifier, so it is baseUrl by another name.
+    const root = workspace();
+    const config = write(
+      root,
+      "tsconfig.json",
+      JSON.stringify({
+        compilerOptions: { paths: { "*": ["src/*"] } },
+      }),
+    );
+    const consumer = write(root, "src/consumer.ts");
+    const resolve = createTypeScriptModuleResolver(root, [config, consumer]);
+
+    expect(resolve("src/consumer.ts", "lodash")).toBeUndefined();
+  });
+
+  it("falls back to baseUrl when a matching paths rule resolves nothing", () => {
+    // TypeScript tries `paths` first, then `baseUrl`. A failed rule must not
+    // short-circuit the baseUrl lookup.
+    const root = workspace();
+    const config = write(
+      root,
+      "tsconfig.json",
+      JSON.stringify({
+        compilerOptions: { baseUrl: "src", paths: { "@core/*": ["missing/*"] } },
+      }),
+    );
+    const consumer = write(root, "src/consumer.ts");
+    const actual = write(root, "src/@core/thing.ts");
+    const resolve = createTypeScriptModuleResolver(root, [config, consumer, actual]);
+
+    expect(resolve("src/consumer.ts", "@core/thing")).toEqual(["src/@core/thing.ts"]);
+  });
+
+  it("follows a relative extends that names a directory", () => {
+    // Previously an existsSync probe stopped at the directory itself and never
+    // tried <dir>/tsconfig.json, so the parent's paths were silently dropped.
+    const root = workspace();
+    write(
+      root,
+      "cfg/tsconfig.json",
+      JSON.stringify({ compilerOptions: { paths: { "@core": ["src/worker"] } } }),
+    );
+    const config = write(root, "tsconfig.json", JSON.stringify({ extends: "./cfg" }));
+    const consumer = write(root, "src/consumer.ts");
+    // `paths` in an extended config resolve against the config that declares them.
+    const worker = write(root, "cfg/src/worker.ts");
+    const resolve = createTypeScriptModuleResolver(root, [config, consumer, worker]);
+
+    expect(resolve("src/consumer.ts", "@core")).toEqual(["cfg/src/worker.ts"]);
   });
 
   it("prefers JavaScript for extensionless imports from JavaScript files", () => {

--- a/ix-cli/src/cli/__tests__/ts-module-resolution.test.ts
+++ b/ix-cli/src/cli/__tests__/ts-module-resolution.test.ts
@@ -1,6 +1,6 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, relative, sep } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -166,6 +166,64 @@ describe("createTypeScriptModuleResolver", () => {
 
     expect(resolve("src/consumer.ts", "@core/thing")).toEqual(["src/@core/thing.ts"]);
   });
+
+  it("ignores a config larger than the size cap instead of parsing it", () => {
+    // The resolver is built before ingestion's MAX_FILE_BYTES gate, so a repo
+    // could hand it a 64 MB JSONC file and take the process out with an
+    // uncatchable OOM. Small here; the cap is what is under test.
+    const root = workspace();
+    const config = write(
+      root,
+      "tsconfig.json",
+      `{/*${"a".repeat(1024 * 1024 + 16)}*/"compilerOptions":{"paths":{"@core":["src/worker"]}}}`,
+    );
+    const consumer = write(root, "src/consumer.ts");
+    const worker = write(root, "src/worker.ts");
+    const resolve = createTypeScriptModuleResolver(root, [config, consumer, worker]);
+
+    // Config ignored entirely -> no mapping, and no opinion.
+    expect(resolve("src/consumer.ts", "@core")).toBeUndefined();
+  });
+
+  it("refuses an extends that escapes the workspace", () => {
+    // `startsWith(".")` is not containment: resolve() clamps at the filesystem
+    // root, so enough `..` segments name any absolute path.
+    const root = workspace();
+    const outside = mkdtempSync(join(tmpdir(), "ix-outside-"));
+    workspaces.push(outside);
+    writeFileSync(
+      join(outside, "tsconfig.json"),
+      JSON.stringify({ compilerOptions: { paths: { "@evil": ["target"] } } }),
+    );
+    const escape = relative(root, join(outside, "tsconfig.json")).split(sep).join("/");
+    const config = write(root, "tsconfig.json", JSON.stringify({ extends: `./${escape}` }));
+    const consumer = write(root, "src/consumer.ts");
+    const target = write(root, "target.ts");
+    const resolve = createTypeScriptModuleResolver(root, [config, consumer, target]);
+
+    expect(resolve("src/consumer.ts", "@evil")).toBeUndefined();
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "refuses an extends that reaches a device node through a symlink",
+    () => {
+      // Containment alone does not cover this: the link sits inside the
+      // workspace and only the *target* is a character device, which reports
+      // size 0 and would read forever.
+      const root = workspace();
+      const link = join(root, "linked.json");
+      try {
+        symlinkSync("/dev/zero", link);
+      } catch {
+        return; // no permission to symlink (e.g. restricted CI) — nothing to assert
+      }
+      const config = write(root, "tsconfig.json", JSON.stringify({ extends: "./linked.json" }));
+      const consumer = write(root, "src/consumer.ts");
+      const resolve = createTypeScriptModuleResolver(root, [config, consumer, link]);
+
+      expect(resolve("src/consumer.ts", "@core")).toBeUndefined();
+    },
+  );
 
   it("follows a relative extends that names a directory", () => {
     // Previously an existsSync probe stopped at the directory itself and never

--- a/ix-cli/src/cli/__tests__/ts-module-resolution.test.ts
+++ b/ix-cli/src/cli/__tests__/ts-module-resolution.test.ts
@@ -206,6 +206,66 @@ describe("createTypeScriptModuleResolver", () => {
   });
 
   it.skipIf(process.platform === "win32")(
+    "refuses an extends that leaves the workspace through a symlinked directory",
+    () => {
+      // Every segment of "./linked/tsconfig.json" is inside the workspace by
+      // path arithmetic, so a lexical containment check passes it. Only the
+      // path we actually opened shows that `linked/` is a link to elsewhere.
+      const root = workspace();
+      const outside = mkdtempSync(join(tmpdir(), "ix-outside-"));
+      workspaces.push(outside);
+      writeFileSync(
+        join(outside, "tsconfig.json"),
+        JSON.stringify({ compilerOptions: { paths: { "@evil": ["target"] } } }),
+      );
+      try {
+        symlinkSync(outside, join(root, "linked"), "dir");
+      } catch {
+        return; // no permission to symlink (e.g. restricted CI) — nothing to assert
+      }
+      const config = write(root, "tsconfig.json", JSON.stringify({ extends: "./linked/tsconfig.json" }));
+      const consumer = write(root, "src/consumer.ts");
+      const target = write(root, "target.ts");
+      const resolve = createTypeScriptModuleResolver(root, [config, consumer, target]);
+
+      expect(resolve("src/consumer.ts", "@evil")).toBeUndefined();
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "still resolves when the workspace root is itself reached through a symlink",
+    () => {
+      // Comparing a resolved file path against an unresolved root rejects every
+      // config whenever the root is a link — macOS /var -> /private/var, a home
+      // on a network mount, a ~/code symlink. No CI runner here has one, so this
+      // is the only thing standing between that and a silent no-op for those
+      // users.
+      const real = workspace();
+      const link = join(mkdtempSync(join(tmpdir(), "ix-linkroot-")), "root");
+      workspaces.push(dirname(link));
+      try {
+        symlinkSync(real, link, "dir");
+      } catch {
+        return; // no permission to symlink (e.g. restricted CI) — nothing to assert
+      }
+      write(
+        real,
+        "tsconfig.json",
+        JSON.stringify({ compilerOptions: { baseUrl: ".", paths: { "@core": ["src/worker"] } } }),
+      );
+      write(real, "src/worker.ts");
+      write(real, "src/consumer.ts");
+      const resolve = createTypeScriptModuleResolver(link, [
+        join(link, "tsconfig.json"),
+        join(link, "src/worker.ts"),
+        join(link, "src/consumer.ts"),
+      ]);
+
+      expect(resolve("src/consumer.ts", "@core")).toEqual(["src/worker.ts"]);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
     "refuses an extends that reaches a device node through a symlink",
     () => {
       // Containment alone does not cover this: the link sits inside the

--- a/ix-cli/src/cli/__tests__/ts-module-resolution.test.ts
+++ b/ix-cli/src/cli/__tests__/ts-module-resolution.test.ts
@@ -63,6 +63,22 @@ describe("createTypeScriptModuleResolver", () => {
     expect(resolve("src/consumer.ts", "@core/missing")).toEqual([]);
   });
 
+  it("substitutes wildcard text without interpreting replacement tokens", () => {
+    const root = workspace();
+    const config = write(
+      root,
+      "tsconfig.json",
+      JSON.stringify({
+        compilerOptions: { paths: { "@core/*": ["src/core/*"] } },
+      }),
+    );
+    const consumer = write(root, "src/consumer.ts");
+    const target = write(root, "src/core/$&.ts");
+    const resolve = createTypeScriptModuleResolver(root, [config, consumer, target]);
+
+    expect(resolve("src/consumer.ts", "@core/$&")).toEqual(["src/core/$&.ts"]);
+  });
+
   it("resolves baseUrl modules", () => {
     const root = workspace();
     const config = write(

--- a/ix-cli/src/cli/__tests__/ts-module-resolution.test.ts
+++ b/ix-cli/src/cli/__tests__/ts-module-resolution.test.ts
@@ -1,0 +1,154 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createTypeScriptModuleResolver } from "../ts-module-resolution.js";
+
+const workspaces: string[] = [];
+
+function workspace(): string {
+  const root = mkdtempSync(join(tmpdir(), "ix-ts-resolution-"));
+  workspaces.push(root);
+  return root;
+}
+
+function write(root: string, relativePath: string, content = ""): string {
+  const filePath = join(root, relativePath);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content);
+  return filePath;
+}
+
+afterEach(() => {
+  for (const root of workspaces.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("createTypeScriptModuleResolver", () => {
+  it("resolves tsconfig paths before an unrelated same-stem file", () => {
+    const root = workspace();
+    const config = write(
+      root,
+      "tsconfig.json",
+      `{
+      // JSONC comments and trailing commas are valid in tsconfig files.
+      "compilerOptions": {
+        "baseUrl": ".",
+        "paths": { "@core": ["src/adapters/worker"], },
+      },
+    }`,
+    );
+    const consumer = write(root, "src/consumer.ts");
+    const worker = write(root, "src/adapters/worker.ts");
+    const unrelated = write(root, "legacy/core.ts");
+    const resolve = createTypeScriptModuleResolver(root, [config, consumer, worker, unrelated]);
+
+    expect(resolve("src/consumer.ts", "@core")).toEqual(["src/adapters/worker.ts"]);
+  });
+
+  it("treats an unresolved matching paths rule as authoritative", () => {
+    const root = workspace();
+    const config = write(
+      root,
+      "tsconfig.json",
+      JSON.stringify({
+        compilerOptions: { paths: { "@core/*": ["src/core/*"] } },
+      }),
+    );
+    const consumer = write(root, "src/consumer.ts");
+    const unrelated = write(root, "legacy/missing.ts");
+    const resolve = createTypeScriptModuleResolver(root, [config, consumer, unrelated]);
+
+    expect(resolve("src/consumer.ts", "@core/missing")).toEqual([]);
+  });
+
+  it("resolves baseUrl modules", () => {
+    const root = workspace();
+    const config = write(
+      root,
+      "tsconfig.json",
+      JSON.stringify({
+        compilerOptions: { baseUrl: "src" },
+      }),
+    );
+    const consumer = write(root, "src/consumer.ts");
+    const worker = write(root, "src/services/worker.ts");
+    const unrelated = write(root, "vendor/worker.ts");
+    const resolve = createTypeScriptModuleResolver(root, [config, consumer, worker, unrelated]);
+
+    expect(resolve("src/consumer.ts", "services/worker")).toEqual(["src/services/worker.ts"]);
+  });
+
+  it("treats an unresolved baseUrl module as authoritative", () => {
+    const root = workspace();
+    const config = write(
+      root,
+      "tsconfig.json",
+      JSON.stringify({
+        compilerOptions: { baseUrl: "src" },
+      }),
+    );
+    const consumer = write(root, "src/consumer.ts");
+    const unrelated = write(root, "legacy/missing.ts");
+    const resolve = createTypeScriptModuleResolver(root, [config, consumer, unrelated]);
+
+    expect(resolve("src/consumer.ts", "services/missing")).toEqual([]);
+  });
+
+  it("prefers JavaScript for extensionless imports from JavaScript files", () => {
+    const root = workspace();
+    const config = write(
+      root,
+      "jsconfig.json",
+      JSON.stringify({
+        compilerOptions: { baseUrl: "src" },
+      }),
+    );
+    const consumer = write(root, "src/consumer.js");
+    const javascript = write(root, "src/services/worker.js");
+    const typescript = write(root, "src/services/worker.ts");
+    const resolve = createTypeScriptModuleResolver(root, [
+      config,
+      consumer,
+      javascript,
+      typescript,
+    ]);
+
+    expect(resolve("src/consumer.js", "services/worker")).toEqual(["src/services/worker.js"]);
+  });
+
+  it("matches mapped paths case-insensitively on case-insensitive filesystems", () => {
+    const root = workspace();
+    const config = write(
+      root,
+      "tsconfig.json",
+      JSON.stringify({ compilerOptions: { paths: { "@utils": ["src/utils"] } } }),
+    );
+    const consumer = write(root, "src/consumer.ts");
+    const actual = write(root, "src/Utils.ts");
+    const resolve = createTypeScriptModuleResolver(root, [config, consumer, actual], {
+      caseSensitive: false,
+    });
+
+    expect(resolve("src/consumer.ts", "@utils")).toEqual(["src/Utils.ts"]);
+  });
+
+  it("selects runtime and declaration targets for mapped JavaScript paths", () => {
+    const root = workspace();
+    const config = write(
+      root,
+      "tsconfig.json",
+      JSON.stringify({
+        compilerOptions: { paths: { "@sample/tool": ["lib/index.js"] } },
+      }),
+    );
+    const consumer = write(root, "apps/client.ts");
+    const declarations = write(root, "lib/index.d.ts");
+    const runtime = write(root, "lib/index.js");
+    const resolve = createTypeScriptModuleResolver(root, [config, consumer, declarations, runtime]);
+
+    expect(resolve("apps/client.ts", "@sample/tool", "runtime")).toEqual(["lib/index.js"]);
+    expect(resolve("apps/client.ts", "@sample/tool", "types")).toEqual(["lib/index.d.ts"]);
+  });
+});

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -20,6 +20,7 @@ import { detectSystem, repoWorkspaceIdFor, lookupPackage, readPackageNames, read
 import { CLIENT_EXPECTED_SCHEMA_VERSION } from '../backend-status.js';
 import { SUPPORTED_EXTENSIONS } from '../supported-extensions.js';
 import { canRenderProgress } from '../stderr.js';
+import { createTypeScriptModuleResolver } from '../ts-module-resolution.js';
 import {
   deterministicId,
   transformIssue,
@@ -770,7 +771,7 @@ export async function ingestFiles(
   const packageRegistry = detectedSystem?.packageRegistry ?? {};
   const packageOf = (mod: string): string | undefined => lookupPackage(packageRegistry, mod);
   const declaredRepoDeps = detectedSystem?.repoDeps;
-  const resolveOpts = systemId ? { repoOf, packageOf, declaredRepoDeps } : undefined;
+  const crossRepoResolveOpts = systemId ? { repoOf, packageOf, declaredRepoDeps } : undefined;
 
   // ── Path-2 separate-ingest stitcher (Ix#225 Half A) ──────────────────
   // Co-ingest already forms cross-repo edges in-batch, so the stitcher only runs
@@ -1043,6 +1044,10 @@ export async function ingestFiles(
         ? (isSupportedSourceFile(resolvedPath) ? [resolvedPath] : [])
         : (tryGitLsFiles(resolvedPath, opts.recursive ?? true) ?? Array.from(walkFiles(resolvedPath, opts.recursive ?? true))),
     );
+    const resolveOpts = {
+      ...crossRepoResolveOpts,
+      resolveModuleSpecifier: createTypeScriptModuleResolver(workspaceRoot, filePaths),
+    };
 
     filesDiscovered = filePaths.length;
     const discovered = performance.now();

--- a/ix-cli/src/cli/ts-module-resolution.ts
+++ b/ix-cli/src/cli/ts-module-resolution.ts
@@ -140,7 +140,50 @@ function parseJsonc(text: string): unknown {
  */
 const MAX_CONFIG_BYTES = 1024 * 1024;
 
-function readObject(filePath: string): Record<string, unknown> | undefined {
+/**
+ * True when the file we are *holding open* lives inside the workspace.
+ *
+ * The lexical check in {@link isWithinWorkspace} cannot see through a symlinked
+ * directory: every segment of `./linked/tsconfig.json` is inside the workspace
+ * by path arithmetic even when `linked/` points somewhere else entirely. Only
+ * the resolved path shows that, so resolve it and re-check.
+ *
+ * Resolving the name a second time reopens the question of whether it still
+ * denotes the file we hold, so the resolved path is confirmed to be the same
+ * inode as the open handle. Without that, swapping the symlink between the open
+ * and the resolve would let an outside file be read under an inside name.
+ * (`ino` is 0 on filesystems that do not report one — chiefly some Windows
+ * configurations — where this degrades to the plain resolved-path check.)
+ *
+ * The ROOT is resolved too, and that is not symmetry for its own sake: a
+ * resolved file compared against an unresolved root rejects every config
+ * whenever the workspace is itself reached through a link — macOS `/var` ->
+ * `/private/var`, a home directory on a network mount, a `~/code` symlink. That
+ * would silently switch tsconfig resolution off for those users, and no CI
+ * runner here has a symlinked root to notice it.
+ */
+function openedWithinWorkspace(
+  workspaceRoot: string,
+  filePath: string,
+  opened: fs.Stats,
+): boolean {
+  try {
+    const resolved = fs.realpathSync(filePath);
+    const viaResolved = fs.statSync(resolved);
+    if (viaResolved.dev !== opened.dev || viaResolved.ino !== opened.ino) return false;
+    let resolvedRoot: string;
+    try {
+      resolvedRoot = fs.realpathSync(workspaceRoot);
+    } catch {
+      resolvedRoot = workspaceRoot; // unreadable root: fall back to the lexical check
+    }
+    return isWithinWorkspace(resolvedRoot, resolved);
+  } catch {
+    return false;
+  }
+}
+
+function readObject(workspaceRoot: string, filePath: string): Record<string, unknown> | undefined {
   try {
     // Open once and fstat the same handle so the checks and the read observe the
     // same inode — no stat-then-read window (CodeQL js/file-system-race). This is
@@ -161,6 +204,7 @@ function readObject(filePath: string): Record<string, unknown> | undefined {
       // and no EOF) — neither of which a size check catches, since both
       // report size 0.
       if (!stats.isFile() || stats.size > MAX_CONFIG_BYTES) return undefined;
+      if (!openedWithinWorkspace(workspaceRoot, filePath, stats)) return undefined;
       text = fs.readFileSync(handle, "utf8");
     } finally {
       fs.closeSync(handle);
@@ -215,7 +259,7 @@ function loadConfig(
   if (loading.has(absoluteConfig)) return undefined;
   loading.add(absoluteConfig);
 
-  const raw = readObject(absoluteConfig);
+  const raw = readObject(workspaceRoot, absoluteConfig);
   if (!raw) {
     cache.set(absoluteConfig, undefined);
     loading.delete(absoluteConfig);

--- a/ix-cli/src/cli/ts-module-resolution.ts
+++ b/ix-cli/src/cli/ts-module-resolution.ts
@@ -132,9 +132,33 @@ function parseJsonc(text: string): unknown {
   return JSON.parse(normalized);
 }
 
+/**
+ * Config files are read while the resolver is built, which happens *before*
+ * ingestion's own size gate, so they need their own. Mirrors `MAX_FILE_BYTES`
+ * in `ingest.ts`: anything larger is not a tsconfig, and parsing one is how a
+ * 64 MB JSONC file takes the process out with an uncatchable OOM.
+ */
+const MAX_CONFIG_BYTES = 1024 * 1024;
+
 function readObject(filePath: string): Record<string, unknown> | undefined {
   try {
-    const parsed = parseJsonc(fs.readFileSync(filePath, "utf8"));
+    // Open once and fstat the same handle so the checks and the read observe the
+    // same inode — no stat-then-read window (CodeQL js/file-system-race). This is
+    // the pattern ingest.ts already uses.
+    const handle = fs.openSync(filePath, "r");
+    let text: string;
+    try {
+      const stats = fs.fstatSync(handle);
+      // `openSync` follows symlinks, so fstat describes the *target*. Refusing
+      // anything that is not a regular file is what stops a link to /dev/zero
+      // (unbounded read) or a FIFO (blocks the event loop forever) — neither of
+      // which a size check catches, since both report size 0.
+      if (!stats.isFile() || stats.size > MAX_CONFIG_BYTES) return undefined;
+      text = fs.readFileSync(handle, "utf8");
+    } finally {
+      fs.closeSync(handle);
+    }
+    const parsed = parseJsonc(text);
     return parsed && typeof parsed === "object" && !Array.isArray(parsed)
       ? (parsed as Record<string, unknown>)
       : undefined;
@@ -149,10 +173,21 @@ function readObject(filePath: string): Record<string, unknown> | undefined {
  * reads each one and `readObject` already reports an unreadable file as
  * `undefined`, so there is no check-then-use window (CodeQL js/file-system-race).
  */
-function resolveExtends(configPath: string, value: unknown): string[] {
+function resolveExtends(workspaceRoot: string, configPath: string, value: unknown): string[] {
   if (typeof value !== "string" || !value.startsWith(".")) return [];
   const unresolved = nodePath.resolve(nodePath.dirname(configPath), value);
-  return [unresolved, `${unresolved}.json`, nodePath.join(unresolved, "tsconfig.json")];
+  return [unresolved, `${unresolved}.json`, nodePath.join(unresolved, "tsconfig.json")].filter(
+    // `startsWith(".")` is not containment: `nodePath.resolve` clamps at the
+    // filesystem root, so "../../../../../../.." names any absolute path from
+    // any depth. The config is repo content, so without this an ingested repo
+    // chooses which files on the machine get read.
+    (candidate) => isWithinWorkspace(workspaceRoot, candidate),
+  );
+}
+
+function isWithinWorkspace(workspaceRoot: string, candidate: string): boolean {
+  const relative = nodePath.relative(nodePath.resolve(workspaceRoot), candidate);
+  return relative !== "" && !relative.startsWith("..") && !nodePath.isAbsolute(relative);
 }
 
 function loadConfig(
@@ -174,7 +209,7 @@ function loadConfig(
   }
 
   let parent: LoadedConfig | undefined;
-  for (const candidate of resolveExtends(absoluteConfig, raw.extends)) {
+  for (const candidate of resolveExtends(workspaceRoot, absoluteConfig, raw.extends)) {
     parent = loadConfig(workspaceRoot, candidate, cache, loading);
     if (parent) break;
   }

--- a/ix-cli/src/cli/ts-module-resolution.ts
+++ b/ix-cli/src/cli/ts-module-resolution.ts
@@ -386,7 +386,7 @@ export function createTypeScriptModuleResolver(
       nodePath.posix.extname(normalizedSource).toLowerCase(),
       specifier,
       kind,
-    ].join(" ");
+    ].join("\x00");
     if (resolutionCache.has(cacheKey)) return resolutionCache.get(cacheKey);
     const result = resolveUncached(sourcePath, normalizedSource, specifier, kind);
     resolutionCache.set(cacheKey, result);

--- a/ix-cli/src/cli/ts-module-resolution.ts
+++ b/ix-cli/src/cli/ts-module-resolution.ts
@@ -143,11 +143,16 @@ function readObject(filePath: string): Record<string, unknown> | undefined {
   }
 }
 
-function resolveExtends(configPath: string, value: unknown): string | undefined {
-  if (typeof value !== "string" || !value.startsWith(".")) return undefined;
+/**
+ * Candidate paths a relative `extends` may name, in TypeScript's own order.
+ * Returns every candidate rather than probing with `existsSync`: the caller
+ * reads each one and `readObject` already reports an unreadable file as
+ * `undefined`, so there is no check-then-use window (CodeQL js/file-system-race).
+ */
+function resolveExtends(configPath: string, value: unknown): string[] {
+  if (typeof value !== "string" || !value.startsWith(".")) return [];
   const unresolved = nodePath.resolve(nodePath.dirname(configPath), value);
-  const candidates = [unresolved, `${unresolved}.json`, nodePath.join(unresolved, "tsconfig.json")];
-  return candidates.find((candidate) => fs.existsSync(candidate));
+  return [unresolved, `${unresolved}.json`, nodePath.join(unresolved, "tsconfig.json")];
 }
 
 function loadConfig(
@@ -168,8 +173,11 @@ function loadConfig(
     return undefined;
   }
 
-  const parentPath = resolveExtends(absoluteConfig, raw.extends);
-  const parent = parentPath ? loadConfig(workspaceRoot, parentPath, cache, loading) : undefined;
+  let parent: LoadedConfig | undefined;
+  for (const candidate of resolveExtends(absoluteConfig, raw.extends)) {
+    parent = loadConfig(workspaceRoot, candidate, cache, loading);
+    if (parent) break;
+  }
   const configDir = nodePath.dirname(absoluteConfig);
   const compilerOptions =
     raw.compilerOptions && typeof raw.compilerOptions === "object"
@@ -287,6 +295,12 @@ export function createTypeScriptModuleResolver(
     if (!specifier || specifier.startsWith(".") || specifier.startsWith("/")) return undefined;
     const normalizedSource = normalizePath(sourcePath);
     const config = configs.find((candidate) => isWithinDir(normalizedSource, candidate.dir));
+    // Only an *explicit* `paths` mapping licenses an authoritative "no match".
+    // A bare `baseUrl` — and a catch-all `"*"` rule, which is the same thing
+    // spelled differently — matches `react` exactly as readily as `@app/thing`,
+    // so treating its miss as authoritative would delete every third-party
+    // import edge in any repo that sets one.
+    let mappedExplicitly = false;
     if (config) {
       for (const rule of config.paths) {
         const star = matchPathPattern(rule.pattern, specifier);
@@ -299,8 +313,11 @@ export function createTypeScriptModuleResolver(
           );
           if (matches.length > 0) return matches;
         }
-        return [];
+        mappedExplicitly = rule.pattern !== "*";
+        break;
       }
+      // TypeScript tries `paths` first and then falls back to `baseUrl`, so a
+      // failed rule must not short-circuit the baseUrl lookup.
       if (config.baseUrl) {
         const matches = resolveCandidate(
           nodePath.resolve(config.baseUrl, specifier),
@@ -310,6 +327,6 @@ export function createTypeScriptModuleResolver(
         if (matches.length > 0) return matches;
       }
     }
-    return config?.baseUrl ? [] : undefined;
+    return mappedExplicitly ? [] : undefined;
   };
 }

--- a/ix-cli/src/cli/ts-module-resolution.ts
+++ b/ix-cli/src/cli/ts-module-resolution.ts
@@ -145,14 +145,21 @@ function readObject(filePath: string): Record<string, unknown> | undefined {
     // Open once and fstat the same handle so the checks and the read observe the
     // same inode — no stat-then-read window (CodeQL js/file-system-race). This is
     // the pattern ingest.ts already uses.
-    const handle = fs.openSync(filePath, "r");
+    //
+    // O_NONBLOCK is load-bearing, not tidiness: opening a FIFO for reading
+    // *blocks until a writer appears*, so without it the open never returns and
+    // no later check can help. It is the one case a guard placed after the open
+    // cannot cover. Undefined on Windows, where `|` with undefined degrades to
+    // a plain read — and Windows has no FIFO to open this way.
+    const handle = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
     let text: string;
     try {
       const stats = fs.fstatSync(handle);
       // `openSync` follows symlinks, so fstat describes the *target*. Refusing
       // anything that is not a regular file is what stops a link to /dev/zero
-      // (unbounded read) or a FIFO (blocks the event loop forever) — neither of
-      // which a size check catches, since both report size 0.
+      // (an unbounded read) and a FIFO (which would otherwise deliver no data
+      // and no EOF) — neither of which a size check catches, since both
+      // report size 0.
       if (!stats.isFile() || stats.size > MAX_CONFIG_BYTES) return undefined;
       text = fs.readFileSync(handle, "utf8");
     } finally {
@@ -187,7 +194,14 @@ function resolveExtends(workspaceRoot: string, configPath: string, value: unknow
 
 function isWithinWorkspace(workspaceRoot: string, candidate: string): boolean {
   const relative = nodePath.relative(nodePath.resolve(workspaceRoot), candidate);
-  return relative !== "" && !relative.startsWith("..") && !nodePath.isAbsolute(relative);
+  // Compare path *segments*: a bare `..startsWith` also rejects a legitimate
+  // sibling directory whose name merely begins with dots, e.g. `..shared/`.
+  return (
+    relative !== "" &&
+    relative !== ".." &&
+    !relative.startsWith(`..${nodePath.sep}`) &&
+    !nodePath.isAbsolute(relative)
+  );
 }
 
 function loadConfig(
@@ -208,10 +222,24 @@ function loadConfig(
     return undefined;
   }
 
+  const extendsCandidates = resolveExtends(workspaceRoot, absoluteConfig, raw.extends);
   let parent: LoadedConfig | undefined;
-  for (const candidate of resolveExtends(workspaceRoot, absoluteConfig, raw.extends)) {
+  for (const candidate of extendsCandidates) {
     parent = loadConfig(workspaceRoot, candidate, cache, loading);
     if (parent) break;
+  }
+
+  // A scoped run (`ix map ./packages/web`) roots containment at the ingest path,
+  // so a monorepo's shared `tsconfig.base.json` one level up is dropped. Half-
+  // loading what remains is worse than not loading it: this config's own `paths`
+  // would still match, fail to resolve against the missing `baseUrl`, and return
+  // an *authoritative* empty — which suppresses the stem fallback and deletes an
+  // edge main resolves fine. Treat the config as unusable instead, which is
+  // exactly main's behaviour.
+  if (typeof raw.extends === "string" && raw.extends.startsWith(".") && !parent) {
+    cache.set(absoluteConfig, undefined);
+    loading.delete(absoluteConfig);
+    return undefined;
   }
   const configDir = nodePath.dirname(absoluteConfig);
   const compilerOptions =

--- a/ix-cli/src/cli/ts-module-resolution.ts
+++ b/ix-cli/src/cli/ts-module-resolution.ts
@@ -1,0 +1,315 @@
+import * as fs from "node:fs";
+import * as nodePath from "node:path";
+
+interface PathRule {
+  pattern: string;
+  targets: string[];
+  baseDir: string;
+}
+
+interface LoadedConfig {
+  dir: string;
+  baseUrl?: string;
+  paths: PathRule[];
+}
+
+export type TypeScriptModuleResolver = (
+  sourcePath: string,
+  specifier: string,
+  kind?: "runtime" | "types",
+) => string[] | undefined;
+
+const SOURCE_SUFFIXES = [".ts", ".tsx", ".d.ts", ".js", ".jsx", ".mjs", ".cjs"];
+
+function normalizePath(value: string): string {
+  return nodePath.posix.normalize(value.replace(/\\/g, "/"));
+}
+
+function isWithinDir(filePath: string, dir: string): boolean {
+  return dir === "." || filePath === dir || filePath.startsWith(`${dir}/`);
+}
+
+function toggleFirstAsciiCase(value: string): string | undefined {
+  const index = value.search(/[A-Za-z]/);
+  if (index === -1) return undefined;
+  const char = value[index];
+  const toggled = char === char.toLowerCase() ? char.toUpperCase() : char.toLowerCase();
+  return value.slice(0, index) + toggled + value.slice(index + 1);
+}
+
+function isCaseSensitiveFilesystem(workspaceRoot: string, absoluteFilePaths: string[]): boolean {
+  for (const candidate of [...absoluteFilePaths, workspaceRoot]) {
+    const basename = nodePath.basename(candidate);
+    const toggled = toggleFirstAsciiCase(basename);
+    if (!toggled || toggled === basename) continue;
+    const alternate = nodePath.join(nodePath.dirname(candidate), toggled);
+    try {
+      return fs.realpathSync.native(candidate) !== fs.realpathSync.native(alternate);
+    } catch {
+      return true;
+    }
+  }
+  return true;
+}
+
+function parseJsonc(text: string): unknown {
+  let output = "";
+  let inString = false;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i];
+    const next = text[i + 1];
+    if (lineComment) {
+      if (char === "\n") {
+        lineComment = false;
+        output += char;
+      } else {
+        output += " ";
+      }
+      continue;
+    }
+    if (blockComment) {
+      if (char === "*" && next === "/") {
+        output += "  ";
+        blockComment = false;
+        i += 1;
+      } else {
+        output += char === "\n" ? "\n" : " ";
+      }
+      continue;
+    }
+    if (inString) {
+      output += char;
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      output += char;
+    } else if (char === "/" && next === "/") {
+      lineComment = true;
+      output += "  ";
+      i += 1;
+    } else if (char === "/" && next === "*") {
+      blockComment = true;
+      output += "  ";
+      i += 1;
+    } else {
+      output += char;
+    }
+  }
+
+  let normalized = "";
+  inString = false;
+  escaped = false;
+  for (let i = 0; i < output.length; i += 1) {
+    const char = output[i];
+    if (inString) {
+      normalized += char;
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      normalized += char;
+      continue;
+    }
+    if (char === ",") {
+      let next = i + 1;
+      while (/\s/.test(output[next] ?? "")) next += 1;
+      if (output[next] === "}" || output[next] === "]") continue;
+    }
+    normalized += char;
+  }
+
+  return JSON.parse(normalized);
+}
+
+function readObject(filePath: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = parseJsonc(fs.readFileSync(filePath, "utf8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveExtends(configPath: string, value: unknown): string | undefined {
+  if (typeof value !== "string" || !value.startsWith(".")) return undefined;
+  const unresolved = nodePath.resolve(nodePath.dirname(configPath), value);
+  const candidates = [unresolved, `${unresolved}.json`, nodePath.join(unresolved, "tsconfig.json")];
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+function loadConfig(
+  workspaceRoot: string,
+  configPath: string,
+  cache: Map<string, LoadedConfig | undefined>,
+  loading = new Set<string>(),
+): LoadedConfig | undefined {
+  const absoluteConfig = nodePath.resolve(configPath);
+  if (cache.has(absoluteConfig)) return cache.get(absoluteConfig);
+  if (loading.has(absoluteConfig)) return undefined;
+  loading.add(absoluteConfig);
+
+  const raw = readObject(absoluteConfig);
+  if (!raw) {
+    cache.set(absoluteConfig, undefined);
+    loading.delete(absoluteConfig);
+    return undefined;
+  }
+
+  const parentPath = resolveExtends(absoluteConfig, raw.extends);
+  const parent = parentPath ? loadConfig(workspaceRoot, parentPath, cache, loading) : undefined;
+  const configDir = nodePath.dirname(absoluteConfig);
+  const compilerOptions =
+    raw.compilerOptions && typeof raw.compilerOptions === "object"
+      ? (raw.compilerOptions as Record<string, unknown>)
+      : {};
+  const ownBaseUrl =
+    typeof compilerOptions.baseUrl === "string"
+      ? nodePath.resolve(configDir, compilerOptions.baseUrl)
+      : undefined;
+  const baseUrl = ownBaseUrl ?? parent?.baseUrl;
+  let paths = parent?.paths ?? [];
+  if (compilerOptions.paths && typeof compilerOptions.paths === "object") {
+    const pathBase = baseUrl ?? configDir;
+    paths = Object.entries(compilerOptions.paths as Record<string, unknown>)
+      .filter(
+        (entry): entry is [string, string[]] =>
+          Array.isArray(entry[1]) && entry[1].every((target) => typeof target === "string"),
+      )
+      .map(([pattern, targets]) => ({ pattern, targets, baseDir: pathBase }))
+      .sort((a, b) => {
+        const aStar = a.pattern.indexOf("*");
+        const bStar = b.pattern.indexOf("*");
+        if (aStar === -1 || bStar === -1) return aStar === -1 ? -1 : 1;
+        return bStar - aStar;
+      });
+  }
+
+  const relativeDir = normalizePath(nodePath.relative(workspaceRoot, configDir) || ".");
+  const loaded = { dir: relativeDir, baseUrl, paths };
+  cache.set(absoluteConfig, loaded);
+  loading.delete(absoluteConfig);
+  return loaded;
+}
+
+function matchPathPattern(pattern: string, specifier: string): string | undefined {
+  const star = pattern.indexOf("*");
+  if (star === -1) return pattern === specifier ? "" : undefined;
+  if (pattern.indexOf("*", star + 1) !== -1) return undefined;
+  const prefix = pattern.slice(0, star);
+  const suffix = pattern.slice(star + 1);
+  return specifier.startsWith(prefix) && specifier.endsWith(suffix)
+    ? specifier.slice(prefix.length, specifier.length - suffix.length)
+    : undefined;
+}
+
+export function createTypeScriptModuleResolver(
+  workspaceRoot: string,
+  absoluteFilePaths: string[],
+  options: { caseSensitive?: boolean } = {},
+): TypeScriptModuleResolver {
+  const root = nodePath.resolve(workspaceRoot);
+  const caseSensitive =
+    options.caseSensitive ?? isCaseSensitiveFilesystem(root, absoluteFilePaths);
+  const pathKey = (value: string): string => {
+    const normalized = normalizePath(value);
+    return caseSensitive ? normalized : normalized.toLowerCase();
+  };
+  const indexed = new Map(
+    absoluteFilePaths.map((filePath) => {
+      const relativePath = normalizePath(nodePath.relative(root, nodePath.resolve(filePath)));
+      return [pathKey(relativePath), relativePath];
+    }),
+  );
+
+  const resolveCandidate = (
+    absoluteTarget: string,
+    sourcePath: string,
+    kind: "runtime" | "types",
+  ): string[] => {
+    const relativeTarget = normalizePath(nodePath.relative(root, absoluteTarget));
+    const extension = nodePath.posix.extname(relativeTarget).toLowerCase();
+    const base = extension ? relativeTarget.slice(0, -extension.length) : relativeTarget;
+    const sourceExtension = nodePath.posix.extname(normalizePath(sourcePath)).toLowerCase();
+    const preferJavaScript = [".js", ".jsx", ".mjs", ".cjs"].includes(sourceExtension);
+    const extensionlessSuffixes =
+      kind === "types"
+        ? SOURCE_SUFFIXES
+        : preferJavaScript
+          ? [".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".d.ts"]
+          : [".ts", ".tsx", ".js", ".jsx", ".d.ts", ".mjs", ".cjs"];
+    const candidates =
+      extension === ".js"
+        ? kind === "types"
+          ? [base + ".ts", base + ".tsx", base + ".d.ts", relativeTarget, base + ".jsx"]
+          : preferJavaScript
+            ? [relativeTarget, base + ".jsx", base + ".ts", base + ".tsx", base + ".d.ts"]
+            : [base + ".ts", base + ".tsx", relativeTarget, base + ".jsx", base + ".d.ts"]
+        : extension === ".jsx"
+          ? kind === "types"
+            ? [base + ".tsx", base + ".d.ts", relativeTarget]
+            : preferJavaScript
+              ? [relativeTarget, base + ".tsx", base + ".d.ts"]
+              : [base + ".tsx", relativeTarget, base + ".d.ts"]
+          : extension
+            ? [relativeTarget]
+            : [
+                ...extensionlessSuffixes.map((suffix) => relativeTarget + suffix),
+                ...extensionlessSuffixes.map((suffix) =>
+                  nodePath.posix.join(relativeTarget, "index" + suffix),
+                ),
+              ];
+    const match = candidates.map((candidate) => indexed.get(pathKey(candidate))).find(Boolean);
+    return match ? [match] : [];
+  };
+
+  const configCache = new Map<string, LoadedConfig | undefined>();
+  const configs = absoluteFilePaths
+    .filter((filePath) => /(?:^|[/\\])(?:tsconfig|jsconfig)\.json$/i.test(filePath))
+    .map((filePath) => loadConfig(root, filePath, configCache))
+    .filter((config): config is LoadedConfig => config !== undefined)
+    .sort((a, b) => b.dir.length - a.dir.length);
+
+  return (sourcePath: string, rawSpecifier: string, kind = "runtime"): string[] | undefined => {
+    const specifier = rawSpecifier.split(/[?#]/, 1)[0];
+    if (!specifier || specifier.startsWith(".") || specifier.startsWith("/")) return undefined;
+    const normalizedSource = normalizePath(sourcePath);
+    const config = configs.find((candidate) => isWithinDir(normalizedSource, candidate.dir));
+    if (config) {
+      for (const rule of config.paths) {
+        const star = matchPathPattern(rule.pattern, specifier);
+        if (star === undefined) continue;
+        for (const target of rule.targets) {
+          const matches = resolveCandidate(
+            nodePath.resolve(rule.baseDir, target.replace("*", star)),
+            sourcePath,
+            kind,
+          );
+          if (matches.length > 0) return matches;
+        }
+        return [];
+      }
+      if (config.baseUrl) {
+        const matches = resolveCandidate(
+          nodePath.resolve(config.baseUrl, specifier),
+          sourcePath,
+          kind,
+        );
+        if (matches.length > 0) return matches;
+      }
+    }
+    return config?.baseUrl ? [] : undefined;
+  };
+}

--- a/ix-cli/src/cli/ts-module-resolution.ts
+++ b/ix-cli/src/cli/ts-module-resolution.ts
@@ -290,10 +290,17 @@ export function createTypeScriptModuleResolver(
     .filter((config): config is LoadedConfig => config !== undefined)
     .sort((a, b) => b.dir.length - a.dir.length);
 
-  return (sourcePath: string, rawSpecifier: string, kind = "runtime"): string[] | undefined => {
-    const specifier = rawSpecifier.split(/[?#]/, 1)[0];
-    if (!specifier || specifier.startsWith(".") || specifier.startsWith("/")) return undefined;
-    const normalizedSource = normalizePath(sourcePath);
+  // Ingestion asks the same question repeatedly: resolution runs per bound
+  // relationship, and index.ts issues two full lookups of the same triple for
+  // each one. Only three things about a call change the answer — see the key.
+  const resolutionCache = new Map<string, string[] | undefined>();
+
+  const resolveUncached = (
+    sourcePath: string,
+    normalizedSource: string,
+    specifier: string,
+    kind: "runtime" | "types",
+  ): string[] | undefined => {
     const config = configs.find((candidate) => isWithinDir(normalizedSource, candidate.dir));
     // Only an *explicit* `paths` mapping licenses an authoritative "no match".
     // A bare `baseUrl` — and a catch-all `"*"` rule, which is the same thing
@@ -328,5 +335,26 @@ export function createTypeScriptModuleResolver(
       }
     }
     return mappedExplicitly ? [] : undefined;
+  };
+
+  return (sourcePath: string, rawSpecifier: string, kind = "runtime"): string[] | undefined => {
+    const specifier = rawSpecifier.split(/[?#]/, 1)[0];
+    if (!specifier || specifier.startsWith(".") || specifier.startsWith("/")) return undefined;
+    const normalizedSource = normalizePath(sourcePath);
+    // Config selection reads only the source *directory*; candidate ordering
+    // additionally reads the source *extension* (a .js caller prefers .js over
+    // .ts). Nothing else about the path is consulted, so this key is exact —
+    // keying on the directory alone would serve a .js caller's answer to a .ts
+    // caller in the same folder and silently flip the preference order.
+    const cacheKey = [
+      nodePath.posix.dirname(normalizedSource),
+      nodePath.posix.extname(normalizedSource).toLowerCase(),
+      specifier,
+      kind,
+    ].join(" ");
+    if (resolutionCache.has(cacheKey)) return resolutionCache.get(cacheKey);
+    const result = resolveUncached(sourcePath, normalizedSource, specifier, kind);
+    resolutionCache.set(cacheKey, result);
+    return result;
   };
 }

--- a/ix-cli/src/cli/ts-module-resolution.ts
+++ b/ix-cli/src/cli/ts-module-resolution.ts
@@ -293,7 +293,7 @@ export function createTypeScriptModuleResolver(
         if (star === undefined) continue;
         for (const target of rule.targets) {
           const matches = resolveCandidate(
-            nodePath.resolve(rule.baseDir, target.replace("*", star)),
+            nodePath.resolve(rule.baseDir, target.split("*").join(star)),
             sourcePath,
             kind,
           );


### PR DESCRIPTION
Carries **@Hiro-Chiba's #440** plus three review fixes, two of them security. Landing it here closes #440 as merged.

> ⚠️ **Merge with a merge commit, not squash** — contains Hiro-Chiba's two commits alongside mine.

## Their change (`7d83423`, `bf7a4b4`)

Resolves local TS/JS imports through `tsconfig.json`/`jsconfig.json` `paths`/`baseUrl` before the filename-stem fallback. New 360-line module. The follow-up commit fixes `$`-token expansion in wildcard substitution — **the CodeQL alert on #440 is stale** and can be dismissed after a re-scan (its multi-star rationale is unreachable: `matchPathPattern` rejects a second `*` before substitution).

## My fixes

**1. `795ec2c` — `baseUrl` claimed authority over every bare specifier.** `return config?.baseUrl ? [] : undefined` — but `[]` means *definitively not local*, and `baseUrl` matches every non-relative specifier. On any repo that sets it (the default in Next.js, CRA, Nest, most monorepo templates) every third-party import including `react` became an authoritative miss and its IMPORTS/CALLS edges were silently dropped. Authority now requires an *explicit* `paths` pattern; a bare `baseUrl` and a catch-all `"*"` rule return "no opinion". This **replaces their `treats an unresolved baseUrl module as authoritative` test** — that behaviour is the defect. Their explicit-`paths` authority test is untouched and still passes.

**2. `9e58df1` — three security holes on the config-reading path.** All reachable from repo content, and all *before* ingestion's size gate (the resolver is built at `ingest.ts:1049`, 51 lines ahead of the `MAX_FILE_BYTES` check):
- **No size cap.** A 64 MB JSONC file — which git packs to a ~95 KB repo — gives `FatalProcessOutOfMemory`, signal 6, uncatchable. main skips it as `tooLarge`, so this was the first pre-gate whole-file read and it bypassed an existing control.
- **Device nodes and FIFOs.** `openSync` follows symlinks, so a link committed in the repo pointing at `/dev/zero` read forever (**exit 134, core dumped**); a FIFO blocked the event loop. Both report size 0, so a size check alone doesn't help. Under MCP the in-process runner means `withTimeout` can never fire and the server wedges uncancellably.
- **No containment.** `resolveExtends` only checked `startsWith(".")`, which isn't containment — `resolve` clamps at `/`, so enough `..` segments name any absolute path.

Fixed by opening once and fstat-ing the same handle (no stat-then-read window — CodeQL `js/file-system-race`, the pattern `ingest.ts` already uses), rejecting non-regular files and anything over 1 MB, and filtering `extends` candidates to inside the workspace. No content ever escaped — `resolveCandidate` only consults an in-memory Map built from the caller's file list.

**3. `c43303e` — memoization.** 24.87 µs → 3.38 µs per call, ~7.4x. Note the trap: the obvious `dirname` key is **wrong**, because `resolveCandidate` also reads the source *extension* (a `.js` caller prefers `.js`); keying on the directory alone serves one caller's answer to another. There's a test that runs both orders.

## Verification

Every fix mutation-tested individually. ix-cli 944 passed, 1 skipped; `typecheck`, `lint` (0 errors), `knip` clean.