### PR TITLE
fix(php): resolve imports by namespace, with clause-scoping and DoS fixes

### DIFF
--- a/core-ingestion/src/__tests__/patchBuilder.resolution.test.ts
+++ b/core-ingestion/src/__tests__/patchBuilder.resolution.test.ts
@@ -109,6 +109,32 @@ describe('buildPatchWithResolution', () => {
     }));
   });
 
+  it('keeps same-named PHP constructor and function calls distinct', () => {
+    const consumer = parseFile(
+      '/repo/Consumer.php',
+      `<?php
+use Vendor\\Package\\Helper;
+function Helper(): void {}
+function run(): void { new Helper(); Helper(); }
+      `,
+    )!;
+    const provider = parseFile(
+      '/repo/Vendor/Package/Helper.php',
+      '<?php namespace Vendor\\Package; class Helper {}',
+    )!;
+    const resolved = resolveEdges([consumer, provider]);
+    const patch = buildPatchWithResolution(consumer, 'hash', '', resolved);
+    const callEdges = patch.ops.filter(op => op.type === 'UpsertEdge' && op.predicate === 'CALLS');
+
+    expect(callEdges).toHaveLength(2);
+    expect(callEdges).toContainEqual(expect.objectContaining({
+      dst: nodeId('/repo/Vendor/Package/Helper.php', 'Helper'),
+    }));
+    expect(callEdges).toContainEqual(expect.objectContaining({
+      dst: nodeId('/repo/Consumer.php', 'Helper'),
+    }));
+  });
+
   it('materialises external stub node for unresolved :: package calls', () => {
     const file = '/repo/model.R';
     const externalNodeId = nodeId('external://dplyr', 'dplyr::filter');

--- a/core-ingestion/src/__tests__/patchBuilder.resolution.test.ts
+++ b/core-ingestion/src/__tests__/patchBuilder.resolution.test.ts
@@ -452,4 +452,24 @@ function handler(): void { log(); Logger::log(); }
 
     expect(callEdges).toHaveLength(1);
   });
+
+  it('emits one claim when two PHP call kinds name the same callee', () => {
+    // Same root cause as the edge case above, and it fires on ordinary untyped
+    // PHP: `handle()` and `$obj->handle()` are two relationships once
+    // phpCallKind splits the key, but a claim carries no kind, so the two ops
+    // are byte-identical.
+    const consumer = parseFile(
+      '/repo/Caller.php',
+      `<?php
+function handler($obj): void { handle(); $obj->handle(); }
+`,
+    )!;
+
+    const patch = buildPatchWithResolution(consumer, 'hash', '', []);
+    const claims = patch.ops.filter(
+      (op) => op.type === 'AssertClaim' && op.field === 'calls:handle',
+    );
+
+    expect(claims).toHaveLength(1);
+  });
 });

--- a/core-ingestion/src/__tests__/patchBuilder.resolution.test.ts
+++ b/core-ingestion/src/__tests__/patchBuilder.resolution.test.ts
@@ -427,4 +427,29 @@ describe('multi-repo co-ingest identity convergence', () => {
 
     expect(callsDst).toBe(svcbUtilNode);
   });
+
+  it('emits one edge when two PHP call kinds resolve to the same node', () => {
+    // `log()` and `Logger::log()` are two relationships once phpCallKind splits
+    // the dedup key. Both resolve to the same member here, so salting the edge
+    // id by call kind would mint two ids for one edge — and the dedup
+    // downstream keys on id, so both would commit.
+    const consumer = parseFile(
+      '/repo/Caller.php',
+      `<?php
+use Vendor\\Package\\Logger;
+function handler(): void { log(); Logger::log(); }
+`,
+    )!;
+    const logger = parseFile(
+      '/repo/Vendor/Package/Logger.php',
+      '<?php namespace Vendor\\Package; class Logger { public static function log(): void {} }',
+    )!;
+
+    const patch = buildPatchWithResolution(consumer, 'hash', '', resolveEdges([consumer, logger]));
+    const callEdges = patch.ops.filter(
+      (op) => op.type === 'UpsertEdge' && op.predicate === 'CALLS',
+    );
+
+    expect(callEdges).toHaveLength(1);
+  });
 });

--- a/core-ingestion/src/__tests__/queries.php.test.ts
+++ b/core-ingestion/src/__tests__/queries.php.test.ts
@@ -259,4 +259,46 @@ final class Union
       phpCallKind: 'member',
     });
   });
+
+  it(
+    'scopes every declaration in a large file without rescanning the top level',
+    { timeout: 10_000 },
+    () => {
+      // Resolving each definition's namespace by rescanning the file's top-level
+      // nodes is O(definitions x nodes). This file is ordinary, valid PSR-12 and
+      // well under the 1 MB ingest cap, but took ~13s to parse that way against
+      // ~150ms now — and a 16k-declaration file took over three minutes, which
+      // pins a parse worker with no per-file timeout.
+      const count = 4_000;
+      let source = '<?php\nnamespace App\\Support;\n';
+      for (let i = 0; i < count; i += 1) source += `function helper${i}($a) { return $a; }\n`;
+
+      const result = parseFile('/repo/big.php', source)!;
+
+      const scoped = result.entities.filter((e) => e.packageScope === 'App\\Support');
+      expect(scoped).toHaveLength(count);
+    },
+  );
+
+  it('scopes declarations by the nearest preceding unbraced namespace', () => {
+    // The binary search must land on the *last* declaration starting before the
+    // node, not the first or the nearest by distance.
+    const result = parseFile(
+      '/repo/Sequential.php',
+      `<?php
+namespace First;
+function alpha() {}
+namespace Second;
+function beta() {}
+namespace Third;
+function gamma() {}
+`,
+    )!;
+
+    const scopeOf = (name: string) =>
+      result.entities.find((e) => e.name === name)?.packageScope;
+    expect(scopeOf('alpha')).toBe('First');
+    expect(scopeOf('beta')).toBe('Second');
+    expect(scopeOf('gamma')).toBe('Third');
+  });
 });

--- a/core-ingestion/src/__tests__/queries.php.test.ts
+++ b/core-ingestion/src/__tests__/queries.php.test.ts
@@ -22,6 +22,83 @@ use Vendor\\Contracts\\DomainService;
     });
   });
 
+  it('records PHP namespace scope for semicolon and braced declarations', () => {
+    const result = parseFile(
+      '/repo/Types.php',
+      `<?php
+namespace First\\Space;
+class FirstType {}
+namespace Second\\Space;
+class SecondType {}
+      `,
+    );
+    const braced = parseFile(
+      '/repo/Braced.php',
+      `<?php
+namespace Vendor\\Package { class User {} }
+namespace { class GlobalThing {} }
+      `,
+    );
+
+    expect(result?.entities.find(entity => entity.name === 'FirstType')?.packageScope).toBe('First\\Space');
+    expect(result?.entities.find(entity => entity.name === 'SecondType')?.packageScope).toBe('Second\\Space');
+    expect(braced?.entities.find(entity => entity.name === 'User')?.packageScope).toBe('Vendor\\Package');
+    expect(braced?.entities.find(entity => entity.name === 'GlobalThing')?.packageScope).toBe('');
+  });
+
+  it('distinguishes function and constant imports from class imports', () => {
+    const result = parseFile(
+      '/repo/Imports.php',
+      `<?php
+use Vendor\\Package\\User;
+use function Vendor\\Package\\helper;
+use const Vendor\\Package\\FLAG;
+      `,
+    );
+
+    expect(result?.relationships.filter(rel => rel.predicate === 'IMPORTS')).toEqual([
+      {
+        srcName: 'Imports.php',
+        dstName: 'User',
+        predicate: 'IMPORTS',
+        importRaw: 'Vendor\\Package\\User',
+      },
+      {
+        srcName: 'Imports.php',
+        dstName: 'helper',
+        predicate: 'IMPORTS',
+        importRaw: 'Vendor\\Package\\helper',
+        importKind: 'function',
+      },
+      {
+        srcName: 'Imports.php',
+        dstName: 'FLAG',
+        predicate: 'IMPORTS',
+        importRaw: 'Vendor\\Package\\FLAG',
+        importKind: 'const',
+      },
+    ]);
+  });
+
+  it('distinguishes PHP constructors from function and member calls', () => {
+    const result = parseFile(
+      '/repo/Calls.php',
+      `<?php
+function run(Service $service): void {
+    new Service();
+    helper();
+    $service->execute();
+}
+      `,
+    );
+
+    expect(result?.relationships.filter(rel => rel.predicate === 'CALLS')).toEqual([
+      { srcName: 'run', dstName: 'Service', predicate: 'CALLS', phpCallKind: 'constructor' },
+      { srcName: 'run', dstName: 'helper', predicate: 'CALLS', phpCallKind: 'function' },
+      { srcName: 'run', dstName: 'Service.execute', predicate: 'CALLS', phpCallKind: 'member' },
+    ]);
+  });
+
   it('resolves calls through typed properties and method parameters', () => {
     const result = parseFile(
       '/repo/UseCase.php',
@@ -62,22 +139,24 @@ final class UseCase
     expect(result).not.toBeNull();
     expect(result!.relationships).toEqual(
       expect.arrayContaining([
-        { srcName: 'UseCase.create', dstName: 'DomainService.create', predicate: 'CALLS' },
-        { srcName: 'UseCase.create', dstName: 'Repository.create', predicate: 'CALLS' },
-        { srcName: 'UseCase.create', dstName: 'AuditLogger.write', predicate: 'CALLS' },
-        { srcName: 'UseCase.create', dstName: 'Logger.write', predicate: 'CALLS' },
-        { srcName: 'UseCase.create', dstName: 'UseCase.finish', predicate: 'CALLS' },
+        { srcName: 'UseCase.create', dstName: 'DomainService.create', predicate: 'CALLS', phpCallKind: 'member' },
+        { srcName: 'UseCase.create', dstName: 'Repository.create', predicate: 'CALLS', phpCallKind: 'member' },
+        { srcName: 'UseCase.create', dstName: 'AuditLogger.write', predicate: 'CALLS', phpCallKind: 'member' },
+        { srcName: 'UseCase.create', dstName: 'Logger.write', predicate: 'CALLS', phpCallKind: 'member' },
+        { srcName: 'UseCase.create', dstName: 'UseCase.finish', predicate: 'CALLS', phpCallKind: 'member' },
       ]),
     );
     expect(result!.relationships).not.toContainEqual({
       srcName: 'UseCase.create',
       dstName: 'create',
       predicate: 'CALLS',
+      phpCallKind: 'member',
     });
     expect(result!.relationships).not.toContainEqual({
       srcName: 'UseCase.create',
       dstName: 'UseCase.create',
       predicate: 'CALLS',
+      phpCallKind: 'member',
     });
   });
 
@@ -97,6 +176,7 @@ function run($service): void
       srcName: 'run',
       dstName: 'create',
       predicate: 'CALLS',
+      phpCallKind: 'member',
     });
   });
 
@@ -125,9 +205,9 @@ final class Nullable
     expect(result).not.toBeNull();
     expect(result!.relationships).toEqual(
       expect.arrayContaining([
-        { srcName: 'Nullable.run', dstName: 'Service.create', predicate: 'CALLS' },
-        { srcName: 'Nullable.run', dstName: 'Repository.find', predicate: 'CALLS' },
-        { srcName: 'Nullable.run', dstName: 'Logger.write', predicate: 'CALLS' },
+        { srcName: 'Nullable.run', dstName: 'Service.create', predicate: 'CALLS', phpCallKind: 'member' },
+        { srcName: 'Nullable.run', dstName: 'Repository.find', predicate: 'CALLS', phpCallKind: 'member' },
+        { srcName: 'Nullable.run', dstName: 'Logger.write', predicate: 'CALLS', phpCallKind: 'member' },
       ]),
     );
   });
@@ -149,8 +229,8 @@ function run(Service $service, ?Logger $logger): void
     expect(result).not.toBeNull();
     expect(result!.relationships).toEqual(
       expect.arrayContaining([
-        { srcName: 'run', dstName: 'Service.create', predicate: 'CALLS' },
-        { srcName: 'run', dstName: 'Logger.write', predicate: 'CALLS' },
+        { srcName: 'run', dstName: 'Service.create', predicate: 'CALLS', phpCallKind: 'member' },
+        { srcName: 'run', dstName: 'Logger.write', predicate: 'CALLS', phpCallKind: 'member' },
       ]),
     );
   });
@@ -176,6 +256,7 @@ final class Union
       srcName: 'Union.run',
       dstName: 'create',
       predicate: 'CALLS',
+      phpCallKind: 'member',
     });
   });
 });

--- a/core-ingestion/src/__tests__/queries.php.test.ts
+++ b/core-ingestion/src/__tests__/queries.php.test.ts
@@ -262,7 +262,7 @@ final class Union
 
   it(
     'scopes every declaration in a large file without rescanning the top level',
-    { timeout: 10_000 },
+    { timeout: 3_000 },
     () => {
       // Resolving each definition's namespace by rescanning the file's top-level
       // nodes is O(definitions x nodes). This file is ordinary, valid PSR-12 and

--- a/core-ingestion/src/__tests__/resolveEdges.test.ts
+++ b/core-ingestion/src/__tests__/resolveEdges.test.ts
@@ -294,6 +294,69 @@ class User { public function save(): void {} }
     expect(edges).toHaveLength(3);
   });
 
+  it('does not emit a phantom import for a PHP alias name', () => {
+    // The alias is a sibling (name) of the (qualified_name) inside the clause,
+    // so an unanchored capture treated `Admin` as a second imported module and
+    // matched it against an unrelated class of that name.
+    const consumer = parseFile(
+      '/repo/Consumer.php',
+      `<?php
+use Vendor\\Package\\User as Admin;
+function run(Admin $a): void { new Admin(); $a->save(); }
+      `,
+    )!;
+    const unrelated = parseFile(
+      '/repo/Admin.php',
+      '<?php class Admin { public function save(): void {} }',
+    )!;
+    const intended = parseFile(
+      '/repo/Vendor/Package/User.php',
+      '<?php namespace Vendor\\Package; class User { public function save(): void {} }',
+    )!;
+
+    const edges = resolveEdges([consumer, unrelated, intended]);
+
+    expect(
+      edges.filter(
+        (edge) => edge.predicate === 'IMPORTS' && edge.dstFilePath === '/repo/Admin.php',
+      ),
+    ).toEqual([]);
+    expect(
+      edges.filter((edge) => edge.dstFilePath === '/repo/Admin.php' && edge.confidence === 0.9),
+    ).toEqual([]);
+  });
+
+  it('resolves an un-aliased clause in a comma-separated PHP use statement', () => {
+    // `importAliased` was derived from the whole statement, so one alias
+    // anywhere in the list disabled FQCN resolution for every clause.
+    const consumer = parseFile(
+      '/repo/Consumer.php',
+      `<?php
+use Vendor\\One\\Alpha, Vendor\\Two\\Beta as Bee;
+function run(Alpha $a): void { new Alpha(); }
+      `,
+    )!;
+    const intended = parseFile(
+      '/repo/Vendor/One/Alpha.php',
+      '<?php namespace Vendor\\One; class Alpha {}',
+    )!;
+    const decoy = parseFile(
+      '/repo/Other/Alpha.php',
+      '<?php namespace Other\\Place; class Alpha {}',
+    )!;
+
+    const edges = resolveEdges([consumer, intended, decoy]);
+
+    expect(
+      edges.filter(
+        (edge) => edge.predicate === 'IMPORTS'
+          && edge.dstFilePath === '/repo/Vendor/One/Alpha.php'
+          && edge.confidence === 0.9,
+      ),
+    ).toHaveLength(1);
+    expect(edges.filter((edge) => edge.dstFilePath === '/repo/Other/Alpha.php')).toEqual([]);
+  });
+
   it('resolves PHP class imports, references, and calls by exact FQCN', () => {
     const consumer = parseFile(
       '/repo/Consumer.php',

--- a/core-ingestion/src/__tests__/resolveEdges.test.ts
+++ b/core-ingestion/src/__tests__/resolveEdges.test.ts
@@ -275,6 +275,25 @@ class User { public function save(): void {} }
     expect(resolveEdges([consumer, wrong])).toEqual([]);
   });
 
+  it('normalizes repeated namespace separators without regex backtracking', () => {
+    const provider = parseFile(
+      '/repo/src/Vendor/User.php',
+      '<?php namespace Vendor\\Package; class User {}',
+    )!;
+    const entity = provider.entities.find((candidate) => candidate.name === 'User')!;
+    entity.packageScope = `${'\\'.repeat(4096)}Vendor\\Package${'\\'.repeat(4096)}`;
+    const consumer = parseFile(
+      '/repo/src/Consumer.php',
+      '<?php use Vendor\\Package\\User; function run(User $user): void { new User(); }',
+    )!;
+
+    const edges = resolveEdges([consumer, provider]).filter(
+      (edge) => edge.dstFilePath === '/repo/src/Vendor/User.php',
+    );
+
+    expect(edges).toHaveLength(3);
+  });
+
   it('resolves PHP class imports, references, and calls by exact FQCN', () => {
     const consumer = parseFile(
       '/repo/Consumer.php',

--- a/core-ingestion/src/__tests__/resolveEdges.test.ts
+++ b/core-ingestion/src/__tests__/resolveEdges.test.ts
@@ -240,7 +240,7 @@ describe('resolveEdges', () => {
       new Map([
         [
           targetPath,
-          '<?php interface DomainService { public function create(): void; }',
+          '<?php namespace App\\Contracts; interface DomainService { public function create(): void; }',
         ],
       ]),
     );
@@ -254,6 +254,270 @@ describe('resolveEdges', () => {
       predicate: 'CALLS',
       confidence: 0.9,
     });
+  });
+
+  it('does not resolve an imported PHP class to the same name in another namespace', () => {
+    const consumer = parseFile(
+      '/repo/Consumer.php',
+      `<?php
+use Vendor\\Package\\User;
+function run(User $user): void { new User(); $user->save(); }
+      `,
+    )!;
+    const wrong = parseFile(
+      '/repo/App/User.php',
+      `<?php
+namespace App;
+class User { public function save(): void {} }
+      `,
+    )!;
+
+    expect(resolveEdges([consumer, wrong])).toEqual([]);
+  });
+
+  it('resolves PHP class imports, references, and calls by exact FQCN', () => {
+    const consumer = parseFile(
+      '/repo/Consumer.php',
+      `<?php
+use Vendor\\Package\\User;
+function run(User $user): void { new User(); $user->save(); }
+      `,
+    )!;
+    const intended = parseFile(
+      '/repo/Vendor/Package/User.php',
+      `<?php
+namespace Vendor\\Package;
+class User { public function save(): void {} }
+      `,
+    )!;
+    const wrong = parseFile(
+      '/repo/App/User.php',
+      `<?php
+namespace App;
+class User { public function save(): void {} }
+      `,
+    )!;
+
+    const resolved = resolveEdges([consumer, intended, wrong]);
+    expect(resolved).toContainEqual({
+      srcFilePath: '/repo/Consumer.php',
+      srcName: 'Consumer.php',
+      dstFilePath: '/repo/Vendor/Package/User.php',
+      dstName: 'User',
+      dstQualifiedKey: 'User.php',
+      predicate: 'IMPORTS',
+      confidence: 0.9,
+    });
+    expect(resolved).toContainEqual(expect.objectContaining({
+      srcFilePath: '/repo/Consumer.php',
+      dstFilePath: '/repo/Vendor/Package/User.php',
+      dstName: 'User',
+      dstQualifiedKey: 'User',
+      predicate: 'REFERENCES',
+      confidence: 0.9,
+    }));
+    expect(resolved).toContainEqual(expect.objectContaining({
+      srcFilePath: '/repo/Consumer.php',
+      dstFilePath: '/repo/Vendor/Package/User.php',
+      dstName: 'User',
+      dstQualifiedKey: 'User',
+      predicate: 'CALLS',
+      confidence: 0.9,
+    }));
+    expect(resolved).toContainEqual(expect.objectContaining({
+      srcFilePath: '/repo/Consumer.php',
+      dstFilePath: '/repo/Vendor/Package/User.php',
+      dstName: 'User.save',
+      dstQualifiedKey: 'User.save',
+      predicate: 'CALLS',
+      confidence: 0.9,
+    }));
+    expect(resolved.some(edge => edge.dstFilePath === '/repo/App/User.php')).toBe(false);
+  });
+
+  it('resolves PHP class names case-insensitively', () => {
+    const consumer = parseFile(
+      '/repo/Consumer.php',
+      `<?php
+use vendor\\package\\USER;
+function run(user $user): void { new user(); $user->save(); }
+      `,
+    )!;
+    const provider = parseFile(
+      '/repo/Vendor/Package/User.php',
+      `<?php
+namespace Vendor\\Package;
+class User { public function save(): void {} }
+      `,
+    )!;
+
+    const resolved = resolveEdges([consumer, provider]);
+    expect(resolved.filter(edge => edge.dstFilePath === '/repo/Vendor/Package/User.php')).toHaveLength(4);
+  });
+
+  it('keeps PHP function and constant imports on their existing resolution path', () => {
+    const consumer = parseFile(
+      '/repo/Consumer.php',
+      `<?php
+use function Vendor\\Package\\helper;
+use const Vendor\\Package\\FLAG;
+function run(): void { helper(); }
+      `,
+    )!;
+    const helper = parseFile(
+      '/repo/Vendor/Package/helper.php',
+      `<?php
+namespace Vendor\\Package;
+function helper(): void {}
+      `,
+    )!;
+    const flag = parseFile('/repo/Vendor/Package/FLAG.php', '<?php const FLAG = 1;')!;
+
+    const resolved = resolveEdges([consumer, helper, flag]);
+    expect(resolved).toContainEqual(expect.objectContaining({
+      dstFilePath: '/repo/Vendor/Package/helper.php',
+      predicate: 'IMPORTS',
+      confidence: 0.9,
+    }));
+    expect(resolved).toContainEqual(expect.objectContaining({
+      dstFilePath: '/repo/Vendor/Package/helper.php',
+      predicate: 'CALLS',
+      confidence: 0.9,
+    }));
+    expect(resolved).toContainEqual(expect.objectContaining({
+      dstFilePath: '/repo/Vendor/Package/FLAG.php',
+      predicate: 'IMPORTS',
+      confidence: 0.9,
+    }));
+  });
+
+  it('does not treat a namespaced function as an imported class provider', () => {
+    const consumer = parseFile(
+      '/repo/Consumer.php',
+      `<?php
+use Vendor\\Package\\User;
+function run(): void { new User(); }
+      `,
+    )!;
+    const functionOnly = parseFile(
+      '/repo/Vendor/Package/User.php',
+      `<?php
+namespace Vendor\\Package;
+function User(): void {}
+      `,
+    )!;
+
+    expect(resolveEdges([consumer, functionOnly])).toEqual([]);
+  });
+
+  it('does not resolve a same-named PHP function call as an imported constructor', () => {
+    const consumer = parseFile(
+      '/repo/Consumer.php',
+      `<?php
+use Vendor\\Package\\Helper;
+function Helper(): void {}
+function run(): void { Helper(); }
+      `,
+    )!;
+    const provider = parseFile(
+      '/repo/Vendor/Package/Helper.php',
+      '<?php namespace Vendor\\Package; class Helper {}',
+    )!;
+
+    const resolved = resolveEdges([consumer, provider]);
+    expect(resolved.some(edge =>
+      edge.predicate === 'CALLS' && edge.dstFilePath === '/repo/Vendor/Package/Helper.php'
+    )).toBe(false);
+  });
+
+  it('keeps a same-named PHP function import separate from a class import', () => {
+    const consumer = parseFile(
+      '/repo/Consumer.php',
+      `<?php
+use Vendor\\Package\\Helper;
+use function Other\\helper;
+function run(): void { helper(); }
+      `,
+    )!;
+    const typeProvider = parseFile(
+      '/repo/Vendor/Package/Helper.php',
+      '<?php namespace Vendor\\Package; class Helper {}',
+    )!;
+    const functionProvider = parseFile(
+      '/repo/Other/helper.php',
+      '<?php namespace Other; function helper(): void {}',
+    )!;
+
+    const resolved = resolveEdges([consumer, typeProvider, functionProvider]);
+    expect(resolved.filter(edge => edge.dstFilePath === '/repo/Other/helper.php')).toHaveLength(2);
+    expect(resolved.some(edge =>
+      edge.predicate === 'CALLS' && edge.dstFilePath === '/repo/Vendor/Package/Helper.php'
+    )).toBe(false);
+  });
+
+  it('resolves a PHP import from the global namespace exactly', () => {
+    const consumer = parseFile(
+      '/repo/Consumer.php',
+      `<?php
+namespace App;
+use GlobalUser;
+function run(GlobalUser $user): void { new GlobalUser(); $user->save(); }
+      `,
+    )!;
+    const intended = parseFile(
+      '/repo/GlobalUser.php',
+      '<?php class GlobalUser { public function save(): void {} }',
+    )!;
+    const wrong = parseFile(
+      '/repo/Other/GlobalUser.php',
+      '<?php namespace Other; class GlobalUser { public function save(): void {} }',
+    )!;
+
+    const resolved = resolveEdges([consumer, intended, wrong]);
+    expect(resolved.filter(edge => edge.dstFilePath === '/repo/GlobalUser.php')).toHaveLength(4);
+    expect(resolved.some(edge => edge.dstFilePath === '/repo/Other/GlobalUser.php')).toBe(false);
+  });
+
+  it('does not exact-resolve duplicate PHP type names within one file', () => {
+    const consumer = parseFile(
+      '/repo/Consumer.php',
+      '<?php use Vendor\\Package\\User; function run(): void { new User(); }',
+    )!;
+    const provider = parseFile(
+      '/repo/Types.php',
+      `<?php
+namespace Vendor\\Package { class User {} }
+namespace Other { class User {} }
+      `,
+    )!;
+
+    expect(resolveEdges([consumer, provider])).toEqual([]);
+  });
+
+  it('does not exact-resolve conflicting PHP imports scoped to different namespaces', () => {
+    const consumer = parseFile(
+      '/repo/Consumer.php',
+      `<?php
+namespace First {
+    use Vendor\\One\\User;
+    function run(User $user): void { new User(); $user->save(); }
+}
+namespace Second {
+    use Vendor\\Two\\User;
+    function execute(User $user): void { new User(); $user->save(); }
+}
+      `,
+    )!;
+    const first = parseFile(
+      '/repo/Vendor/One/User.php',
+      '<?php namespace Vendor\\One; class User { public function save(): void {} }',
+    )!;
+    const second = parseFile(
+      '/repo/Vendor/Two/User.php',
+      '<?php namespace Vendor\\Two; class User { public function save(): void {} }',
+    )!;
+
+    expect(resolveEdges([consumer, first, second])).toEqual([]);
   });
 
   it('resolves a TypeScript call when the imported definition is outside the parse batch', () => {

--- a/core-ingestion/src/__tests__/resolveEdges.test.ts
+++ b/core-ingestion/src/__tests__/resolveEdges.test.ts
@@ -357,6 +357,37 @@ function run(Alpha $a): void { new Alpha(); }
     expect(edges.filter((edge) => edge.dstFilePath === '/repo/Other/Alpha.php')).toEqual([]);
   });
 
+  it('does not leak a PHP use across braced namespace blocks', () => {
+    // `use` is scoped to its namespace block. `go` lives in namespace B, which
+    // declares its own Thing, so it must not resolve to the Thing imported by
+    // namespace A.
+    const consumer = parseFile(
+      '/repo/Multi.php',
+      `<?php
+namespace A {
+    use Vendor\\Package\\Thing;
+    function run(Thing $t): void { new Thing(); }
+}
+namespace B {
+    class Thing {}
+    function go(Thing $t): void { new Thing(); }
+}
+`,
+    )!;
+    const vendor = parseFile(
+      '/repo/Vendor/Package/Thing.php',
+      '<?php namespace Vendor\\Package; class Thing {}',
+    )!;
+
+    const edges = resolveEdges([consumer, vendor]);
+
+    expect(
+      edges.filter(
+        (edge) => edge.srcName === 'go' && edge.dstFilePath === '/repo/Vendor/Package/Thing.php',
+      ),
+    ).toEqual([]);
+  });
+
   it('resolves PHP class imports, references, and calls by exact FQCN', () => {
     const consumer = parseFile(
       '/repo/Consumer.php',

--- a/core-ingestion/src/__tests__/resolveEdges.test.ts
+++ b/core-ingestion/src/__tests__/resolveEdges.test.ts
@@ -388,6 +388,91 @@ namespace B {
     ).toEqual([]);
   });
 
+  it('does not leak a PHP use across two blocks that declare the same namespace', () => {
+    // Both blocks are `namespace A`, so every entity carries the one scope
+    // string "A". Counting distinct packageScope values sees a single scope and
+    // treats the file as safe to index per-file — but the blocks are still two
+    // separate `use` scopes, and the second declares its own Thing.
+    const consumer = parseFile(
+      '/repo/SameName.php',
+      `<?php
+namespace A {
+    use Vendor\\Package\\Thing;
+    function run(Thing $t): void { new Thing(); }
+}
+namespace A {
+    class Thing {}
+    function go(Thing $t): void { new Thing(); }
+}
+`,
+    )!;
+    const vendor = parseFile(
+      '/repo/Vendor/Package/Thing.php',
+      '<?php namespace Vendor\\Package; class Thing {}',
+    )!;
+
+    expect(consumer.phpNamespaceBlocks).toBe(2);
+    expect(
+      resolveEdges([consumer, vendor]).filter(
+        (edge) => edge.srcName === 'go' && edge.dstFilePath === '/repo/Vendor/Package/Thing.php',
+      ),
+    ).toEqual([]);
+  });
+
+  it('does not leak a PHP use out of a block that declares nothing else', () => {
+    // Namespace A holds only the `use`, so it contributes no entity and no
+    // packageScope at all. From the entity side the file looks like a plain
+    // single-namespace B file, and A's import would be applied to B — where
+    // Thing is locally declared.
+    const consumer = parseFile(
+      '/repo/UseOnly.php',
+      `<?php
+namespace A {
+    use Vendor\\Package\\Thing;
+}
+namespace B {
+    class Thing {}
+    function go(Thing $t): void { new Thing(); }
+}
+`,
+    )!;
+    const vendor = parseFile(
+      '/repo/Vendor/Package/Thing.php',
+      '<?php namespace Vendor\\Package; class Thing {}',
+    )!;
+
+    expect(consumer.phpNamespaceBlocks).toBe(2);
+    expect(
+      resolveEdges([consumer, vendor]).filter(
+        (edge) => edge.srcName === 'go' && edge.dstFilePath === '/repo/Vendor/Package/Thing.php',
+      ),
+    ).toEqual([]);
+  });
+
+  it('still indexes a single-namespace PHP file per file', () => {
+    // The guard must stay off for the overwhelmingly common shape, otherwise
+    // "skip the ambiguous file" quietly becomes "skip every file".
+    const consumer = parseFile(
+      '/repo/Single.php',
+      `<?php
+namespace A;
+use Vendor\\Package\\Thing;
+function go(Thing $t): void { new Thing(); }
+`,
+    )!;
+    const vendor = parseFile(
+      '/repo/Vendor/Package/Thing.php',
+      '<?php namespace Vendor\\Package; class Thing {}',
+    )!;
+
+    expect(consumer.phpNamespaceBlocks).toBe(1);
+    expect(
+      resolveEdges([consumer, vendor]).filter(
+        (edge) => edge.dstFilePath === '/repo/Vendor/Package/Thing.php',
+      ).length,
+    ).toBeGreaterThan(0);
+  });
+
   it('resolves PHP class imports, references, and calls by exact FQCN', () => {
     const consumer = parseFile(
       '/repo/Consumer.php',

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -1986,19 +1986,55 @@ function unwrapRustCfgMacros(source: string): string {
 // Main parse function
 // ---------------------------------------------------------------------------
 
-function phpNamespaceForNode(rootNode: any, node: any): string | undefined {
+interface PhpNamespaceSpan {
+  startIndex: number;
+  namespace: string;
+}
+
+/**
+ * Start offsets of every unbraced `namespace X;` at file top level, ascending.
+ *
+ * Built once per parse. Doing this scan per definition instead made the file
+ * cost O(definitions x top-level nodes): a valid 890 KB PSR-12 file with ~16k
+ * functions took ~197s, against ~355ms without it.
+ *
+ * A braced `namespace X { ... }` scopes by containment rather than position and
+ * is handled by the ancestor walk in {@link phpNamespaceForNode}, so it is
+ * deliberately excluded here.
+ */
+function collectPhpNamespaceSpans(rootNode: any): PhpNamespaceSpan[] {
+  const spans: PhpNamespaceSpan[] = [];
+  // `namedChildren` materializes the list in a single walk; indexing
+  // `namedChild(i)` in a loop is what made the original scan expensive.
+  for (const child of rootNode.namedChildren ?? []) {
+    if (!child || child.type !== 'namespace_definition' || child.childForFieldName?.('body')) continue;
+    spans.push({
+      startIndex: child.startIndex,
+      namespace: child.childForFieldName?.('name')?.text?.replace(/\s+/g, '') ?? '',
+    });
+  }
+  return spans;
+}
+
+function phpNamespaceForNode(node: any, spans: PhpNamespaceSpan[]): string | undefined {
   for (let current = node.parent; current; current = current.parent) {
     if (current.type === 'namespace_definition') {
       return current.childForFieldName?.('name')?.text?.replace(/\s+/g, '') ?? '';
     }
   }
 
+  // The last unbraced declaration starting before this node wins.
+  let low = 0;
+  let high = spans.length - 1;
   let active: string | undefined;
-  for (let i = 0; i < rootNode.namedChildCount; i++) {
-    const child = rootNode.namedChild(i);
-    if (!child || child.startIndex >= node.startIndex) break;
-    if (child.type !== 'namespace_definition' || child.childForFieldName?.('body')) continue;
-    active = child.childForFieldName?.('name')?.text?.replace(/\s+/g, '') ?? '';
+  while (low <= high) {
+    const mid = (low + high) >> 1;
+    if (spans[mid].startIndex < node.startIndex) {
+      active = spans[mid].namespace;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
   }
   return active;
 }
@@ -2147,6 +2183,12 @@ export function parseFile(filePath: string, source: string): FileParseResult | n
       }
     }
 
+    // Same idea for PHP: collect the file's namespace boundaries once rather
+    // than rescanning the top level for every definition.
+    const phpNamespaceSpans = language === SupportedLanguages.PHP
+      ? collectPhpNamespaceSpans(tree.rootNode)
+      : [];
+
     // --- First pass: collect definitions ---
     for (const match of pass1Matches) {
       // Definition captures: name + definition.*
@@ -2220,7 +2262,7 @@ export function parseFile(filePath: string, source: string): FileParseResult | n
           container: effectiveContainer,
           packageScope: goPackage ?? (
             language === SupportedLanguages.PHP
-              ? phpNamespaceForNode(tree.rootNode, defNode)
+              ? phpNamespaceForNode(defNode, phpNamespaceSpans)
               : undefined
           ),
         });

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -2489,6 +2489,15 @@ export function parseFile(filePath: string, source: string): FileParseResult | n
                 ? 'const' as const
                 : undefined
             : undefined;
+          // Alias detection is per *clause*, not per statement. `use A\B, C\D as E;`
+          // is one declaration with two clauses, so testing the statement text
+          // flagged the un-aliased clause too and silently disabled FQCN
+          // resolution for it. Reading the node also drops an unanchored
+          // /\s+as\s+/ over repo-controlled text, which backtracks quadratically.
+          const phpUseClause = importSource.node.parent;
+          const phpImportAliased = language === SupportedLanguages.PHP
+            && phpUseClause?.type === 'namespace_use_clause'
+            && phpUseClause.namedChildCount > 1;
           entities.push({ name: modName, kind: 'module', lineStart: importSource.node.startPosition.row + 1, lineEnd: importSource.node.startPosition.row + 1, language });
           relationships.push({
             srcName: fileName,
@@ -2496,9 +2505,7 @@ export function parseFile(filePath: string, source: string): FileParseResult | n
             predicate: 'IMPORTS',
             importRaw,
             ...(importKind ? { importKind } : {}),
-            ...(language === SupportedLanguages.PHP && /\s+as\s+/i.test(phpImportText)
-              ? { importAliased: true }
-              : {}),
+            ...(phpImportAliased ? { importAliased: true } : {}),
           });
         }
         continue;

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -134,12 +134,9 @@ export interface ParsedEntity {
   /** Direct enclosing class/interface/trait, if any (undefined for file-level entities). */
   container?: string;
   /**
-   * Package name for languages that group entities into namespaces (currently
-   * Go only). Used by downstream layers to prefix qualifiedName so the symbol
-   * table indexes entities under their fully-qualified path. Without this,
-   * bare-name resolution at edge-resolver collides between packages (e.g.
-   * kubernetes has 191 distinct `addKnownTypes` functions, one per API group)
-   * and CALL targets are picked non-deterministically.
+   * Package or namespace name for languages that group entities. Used by
+   * downstream resolution to distinguish identically named declarations and
+   * index entities under their fully-qualified path.
    */
   packageScope?: string;
 }
@@ -172,6 +169,12 @@ export interface ParsedRelationship {
   // that happens to flatten to the same stem ("core"). Absent on non-import rels
   // and on dotted/symbol imports where dstName is already the full identifier.
   importRaw?: string;
+  /** PHP namespace import category. Absent for all other languages. */
+  importKind?: 'type' | 'function' | 'const';
+  /** PHP aliases need binding metadata before exact FQCN resolution is safe. */
+  importAliased?: boolean;
+  /** PHP call shape used to distinguish constructors from same-named functions. */
+  phpCallKind?: 'constructor' | 'function' | 'member' | 'static';
   /**
    * JS/TS only: whether this identifier use is lexically bound to its matching
    * import. False means a parameter or local declaration shadows that import.
@@ -1983,6 +1986,23 @@ function unwrapRustCfgMacros(source: string): string {
 // Main parse function
 // ---------------------------------------------------------------------------
 
+function phpNamespaceForNode(rootNode: any, node: any): string | undefined {
+  for (let current = node.parent; current; current = current.parent) {
+    if (current.type === 'namespace_definition') {
+      return current.childForFieldName?.('name')?.text?.replace(/\s+/g, '') ?? '';
+    }
+  }
+
+  let active: string | undefined;
+  for (let i = 0; i < rootNode.namedChildCount; i++) {
+    const child = rootNode.namedChild(i);
+    if (!child || child.startIndex >= node.startIndex) break;
+    if (child.type !== 'namespace_definition' || child.childForFieldName?.('body')) continue;
+    active = child.childForFieldName?.('name')?.text?.replace(/\s+/g, '') ?? '';
+  }
+  return active;
+}
+
 export function parseFile(filePath: string, source: string): FileParseResult | null {
   const language = detectLanguageForSource(filePath, source);
   if (!language) return null;
@@ -2198,7 +2218,11 @@ export function parseFile(filePath: string, source: string): FileParseResult | n
           lineEnd,
           language,
           container: effectiveContainer,
-          packageScope: goPackage,
+          packageScope: goPackage ?? (
+            language === SupportedLanguages.PHP
+              ? phpNamespaceForNode(tree.rootNode, defNode)
+              : undefined
+          ),
         });
 
         pendingChunks.push({
@@ -2456,8 +2480,26 @@ export function parseFile(filePath: string, source: string): FileParseResult | n
           // Preserve the raw specifier (./core vs @nestjs/core) for the multi-repo
           // dependency gate; modName remains the flattened stem used everywhere else.
           const importRaw = unwrapImportSpecifier(importSource.node.text);
+          const importNode = match.captures.find((c: any) => c.name === 'import')?.node;
+          const phpImportText = language === SupportedLanguages.PHP ? importNode?.text ?? '' : '';
+          const importKind = language === SupportedLanguages.PHP
+            ? /^use\s+function\b/i.test(phpImportText)
+              ? 'function' as const
+              : /^use\s+const\b/i.test(phpImportText)
+                ? 'const' as const
+                : undefined
+            : undefined;
           entities.push({ name: modName, kind: 'module', lineStart: importSource.node.startPosition.row + 1, lineEnd: importSource.node.startPosition.row + 1, language });
-          relationships.push({ srcName: fileName, dstName: modName, predicate: 'IMPORTS', importRaw });
+          relationships.push({
+            srcName: fileName,
+            dstName: modName,
+            predicate: 'IMPORTS',
+            importRaw,
+            ...(importKind ? { importKind } : {}),
+            ...(language === SupportedLanguages.PHP && /\s+as\s+/i.test(phpImportText)
+              ? { importAliased: true }
+              : {}),
+          });
         }
         continue;
       }
@@ -2490,6 +2532,16 @@ export function parseFile(filePath: string, source: string): FileParseResult | n
       if (callName) {
         const callee = callName.node.text;
         if (!callee || callee.length <= 1) continue;
+        const phpCallKind = language === SupportedLanguages.PHP
+          ? callName.node.parent?.type === 'object_creation_expression'
+            ? 'constructor' as const
+            : callName.node.parent?.type === 'member_call_expression' ||
+                callName.node.parent?.type === 'nullsafe_member_call_expression'
+              ? 'member' as const
+              : callName.node.parent?.type === 'scoped_call_expression'
+                ? 'static' as const
+                : 'function' as const
+          : undefined;
 
         // If a _qualifier capture is present (field_expression / stable_identifier
         // patterns like NodeKind.Decision, or Python attribute calls like
@@ -2662,9 +2714,15 @@ export function parseFile(filePath: string, source: string): FileParseResult | n
           recordJsTsImportUse('CALLS', caller, effectiveCallee, callName.node, callee);
         }
 
-        if (!seen.has(effectiveCallee)) {
-          seen.add(effectiveCallee);
-          relationships.push({ srcName: caller, dstName: effectiveCallee, predicate: 'CALLS' });
+        const callKey = phpCallKind ? `${phpCallKind}:${effectiveCallee}` : effectiveCallee;
+        if (!seen.has(callKey)) {
+          seen.add(callKey);
+          relationships.push({
+            srcName: caller,
+            dstName: effectiveCallee,
+            predicate: 'CALLS',
+            ...(phpCallKind ? { phpCallKind } : {}),
+          });
         }
         continue;
       }
@@ -2804,6 +2862,7 @@ export interface ResolvedEdge {
   dstQualifiedKey: string;      // qualified key used for nodeId in the defining file
   predicate: string;            // "CALLS" | "EXTENDS"
   confidence: number;           // 0.9 import-scoped | 0.8 transitive | 0.5 global
+  phpCallKind?: ParsedRelationship['phpCallKind'];
 }
 
 // ---------------------------------------------------------------------------
@@ -2813,6 +2872,28 @@ export interface ResolvedEdge {
 /** Build the qualified key for an entity (mirrors buildPatch's entityQKey logic). */
 function qualifiedKey(e: ParsedEntity): string {
   return e.container ? `${e.container}.${e.name}` : e.name;
+}
+
+const PHP_TYPE_KINDS = new Set(['class', 'interface', 'trait', 'enum']);
+
+function phpTypeFqcn(entity: ParsedEntity): string | undefined {
+  if (entity.language !== SupportedLanguages.PHP || !PHP_TYPE_KINDS.has(entity.kind) || entity.container) {
+    return undefined;
+  }
+  const namespace = entity.packageScope?.replace(/^\\+|\\+$/g, '');
+  return `${namespace ? `${namespace}\\` : ''}${entity.name}`.toLowerCase();
+}
+
+function ambiguousPhpTypeNames(entities: ParsedEntity[]): Set<string> {
+  const counts = new Map<string, number>();
+  for (const entity of entities) {
+    if (entity.language !== SupportedLanguages.PHP || !PHP_TYPE_KINDS.has(entity.kind) || entity.container) {
+      continue;
+    }
+    const name = entity.name.toLowerCase();
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+  return new Set([...counts].filter(([, count]) => count > 1).map(([name]) => name));
 }
 
 /**
@@ -2831,6 +2912,24 @@ function bestQKey(
   return qks.length === 1 ? qks[0] : null;
 }
 
+function bestPhpQKey(
+  fileQKeys: Map<string, Map<string, string[]>>,
+  filePath: string,
+  plainName: string,
+  preferredQKey?: string,
+): string | null {
+  const qks = [...new Set(
+    [...(fileQKeys.get(filePath) ?? [])]
+      .filter(([name]) => name.toLowerCase() === plainName.toLowerCase())
+      .flatMap(([, keys]) => keys),
+  )];
+  if (preferredQKey) {
+    const preferred = qks.find(key => key.toLowerCase() === preferredQKey.toLowerCase());
+    if (preferred) return preferred;
+  }
+  return qks.length === 1 ? qks[0] : null;
+}
+
 // ---------------------------------------------------------------------------
 // Global resolution index — pre-scan for cross-batch edge resolution
 // ---------------------------------------------------------------------------
@@ -2845,6 +2944,7 @@ export interface GlobalResolutionIndex {
   packageToFiles:   Map<string, string[]>;
   goPkgDirToFiles:  Map<string, string[]>;
   goPkgPathToFiles: Map<string, string[]>;
+  phpFqcnToTypes?:  Map<string, Array<{ filePath: string; typeName: string }>>;
 }
 
 /**
@@ -2869,6 +2969,7 @@ export function buildGlobalResolutionIndex(
   const packageToFiles = new Map<string, string[]>();
   const goPkgDirToFiles = new Map<string, string[]>();
   const goPkgPathToFiles = new Map<string, string[]>();
+  const phpFqcnToTypes = new Map<string, Array<{ filePath: string; typeName: string }>>();
 
   for (const fp of filePaths) {
     const ext = nodePath.extname(fp);
@@ -3025,11 +3126,20 @@ export function buildGlobalResolutionIndex(
       const parsed = preParsed?.get(fp) ?? parseFile(fp, src);
       if (!parsed) continue;
       const qkMap = new Map<string, string[]>();
+      const ambiguousTypes = ambiguousPhpTypeNames(parsed.entities);
       for (const e of parsed.entities) {
         if (e.kind === 'file' || e.kind === 'module') continue;
         const list = qkMap.get(e.name) ?? [];
         list.push(qualifiedKey(e));
         qkMap.set(e.name, list);
+        const fqcn = phpTypeFqcn(e);
+        if (fqcn && !ambiguousTypes.has(e.name.toLowerCase())) {
+          const entries = phpFqcnToTypes.get(fqcn) ?? [];
+          if (!entries.some(entry => entry.filePath === fp && entry.typeName === e.name)) {
+            entries.push({ filePath: fp, typeName: e.name });
+          }
+          phpFqcnToTypes.set(fqcn, entries);
+        }
       }
       if (qkMap.size > 0) {
         fileQKeys.set(fp, qkMap);
@@ -3078,6 +3188,7 @@ export function buildGlobalResolutionIndex(
     packageToFiles,
     goPkgDirToFiles,
     goPkgPathToFiles,
+    phpFqcnToTypes,
   };
 }
 
@@ -3200,6 +3311,26 @@ export function resolveEdges(
       let m = callBindings.get(r.filePath);
       if (!m) { m = new Map(); callBindings.set(r.filePath, m); }
       if (!m.has(b.local)) m.set(b.local, b.imported);
+    }
+  }
+  const phpFqcnImportsByLocal = new Map<string, Map<string, string | null>>();
+  for (const result of results) {
+    if (result.language !== SupportedLanguages.PHP) continue;
+    for (const rel of result.relationships) {
+      if (
+        rel.predicate !== 'IMPORTS' ||
+        rel.importKind === 'function' ||
+        rel.importKind === 'const' ||
+        rel.importAliased ||
+        typeof rel.importRaw !== 'string'
+      ) continue;
+      const fqcn = rel.importRaw.replace(/^\\+/, '').toLowerCase();
+      const local = fqcn.split('\\').pop();
+      if (!local) continue;
+      const imports = phpFqcnImportsByLocal.get(result.filePath) ?? new Map<string, string | null>();
+      if (!imports.has(local)) imports.set(local, fqcn);
+      else if (imports.get(local) !== fqcn) imports.set(local, null);
+      phpFqcnImportsByLocal.set(result.filePath, imports);
     }
   }
   // Cross-repo dependency graph: repo R depends on repo D when any file in R
@@ -3337,6 +3468,24 @@ export function resolveEdges(
   const fileHasSymbol = new Map<string, Set<string>>();
   for (const [fp, qkMap] of fileQKeys) {
     fileHasSymbol.set(fp, new Set(qkMap.keys()));
+  }
+
+  const phpFqcnToTypes = new Map<string, Array<{ filePath: string; typeName: string }>>();
+  for (const [fqcn, entries] of globalIndex?.phpFqcnToTypes ?? []) {
+    phpFqcnToTypes.set(fqcn, [...entries]);
+  }
+  for (const result of results) {
+    if (result.language !== SupportedLanguages.PHP) continue;
+    const ambiguousTypes = ambiguousPhpTypeNames(result.entities);
+    for (const entity of result.entities) {
+      const fqcn = phpTypeFqcn(entity);
+      if (!fqcn || ambiguousTypes.has(entity.name.toLowerCase())) continue;
+      const entries = phpFqcnToTypes.get(fqcn) ?? [];
+      if (!entries.some(entry => entry.filePath === result.filePath && entry.typeName === entity.name)) {
+        entries.push({ filePath: result.filePath, typeName: entity.name });
+      }
+      phpFqcnToTypes.set(fqcn, entries);
+    }
   }
 
   // resultsByPath: O(1) lookup replacing results.find() in transitive import loop
@@ -3847,6 +3996,28 @@ export function resolveEdges(
     );
   }
 
+  function importedPhpType(srcFilePath: string, rel: ParsedRelationship): {
+    entries: Array<{ filePath: string; typeName: string }>;
+    memberName?: string;
+  } | undefined {
+    if (rel.predicate === 'IMPORTS' && (rel.importKind === 'function' || rel.importKind === 'const')) {
+      return undefined;
+    }
+    const parts = rel.dstName.split('.');
+    if (rel.predicate === 'CALLS' && parts.length === 1 && rel.phpCallKind !== 'constructor') {
+      return undefined;
+    }
+    const imports = phpFqcnImportsByLocal.get(srcFilePath);
+    const local = parts[0].toLowerCase();
+    if (!imports?.has(local)) return undefined;
+    const fqcn = imports.get(local);
+    if (!fqcn) return { entries: [] };
+    return {
+      entries: phpFqcnToTypes.get(fqcn) ?? [],
+      memberName: parts.length > 1 ? parts[parts.length - 1] : undefined,
+    };
+  }
+
   const resolved: ResolvedEdge[] = [];
 
   for (const result of results) {
@@ -3860,6 +4031,13 @@ export function resolveEdges(
     for (const rel of result.relationships) {
       if (rel.predicate !== 'IMPORTS') continue;
       if (pythonHasRelativeModuleImport && rel.importRaw === undefined) continue;
+      const phpType = srcLanguage === SupportedLanguages.PHP
+        ? importedPhpType(srcFilePath, rel)
+        : undefined;
+      if (phpType) {
+        for (const entry of phpType.entries) importedFilePaths.add(entry.filePath);
+        continue;
+      }
       for (const fp of resolveImportTargets(srcFilePath, srcLanguage, rel.dstName, rel.importRaw)) {
         importedFilePaths.add(fp);
       }
@@ -3888,6 +4066,27 @@ export function resolveEdges(
       // name ("ClaimId"), find files registered under that package, then find
       // the one that defines the entity.
       if (rel.predicate === 'IMPORTS') {
+        const phpType = srcLanguage === SupportedLanguages.PHP
+          ? importedPhpType(srcFilePath, rel)
+          : undefined;
+        if (phpType) {
+          if (phpType.entries.length === 1) {
+            const fp = phpType.entries[0].filePath;
+            resolved.push({
+              srcFilePath,
+              srcName: rel.srcName,
+              dstFilePath: fp,
+              dstName: rel.dstName,
+              dstQualifiedKey: fileEntityName(fp),
+              predicate: 'IMPORTS',
+              confidence: 0.9,
+            });
+            stats.resolvedImport++;
+          } else if (phpType.entries.length > 1) {
+            stats.skippedAmbiguous++;
+          }
+          continue;
+        }
         if (result.language === SupportedLanguages.Scala || result.language === SupportedLanguages.Java) {
           const dstName = rel.dstName;
           const lastDot = dstName.lastIndexOf('.');
@@ -3957,6 +4156,36 @@ export function resolveEdges(
         // symbol resolution so the edge connects to the actual class node rather than a file.
         if (srcLanguage !== SupportedLanguages.Python || !/^[A-Z]/.test(rel.dstName)) continue;
         // fall through to Tier 1b → Tier 2 → Tier 3 below
+      }
+
+      const phpType = srcLanguage === SupportedLanguages.PHP
+        ? importedPhpType(srcFilePath, rel)
+        : undefined;
+      if (phpType) {
+        if (phpType.entries.length === 1) {
+          const entry = phpType.entries[0];
+          const plainName = phpType.memberName ?? entry.typeName;
+          const preferredQKey = phpType.memberName
+            ? `${entry.typeName}.${phpType.memberName}`
+            : entry.typeName;
+          const dstQualifiedKey = bestPhpQKey(fileQKeys, entry.filePath, plainName, preferredQKey);
+          if (dstQualifiedKey !== null) {
+            resolved.push({
+              srcFilePath,
+              srcName: rel.srcName,
+              dstFilePath: entry.filePath,
+              dstName: rel.dstName,
+              dstQualifiedKey,
+              predicate: rel.predicate,
+              confidence: 0.9,
+              ...(rel.phpCallKind ? { phpCallKind: rel.phpCallKind } : {}),
+            });
+            stats.resolvedQualifier++;
+          }
+        } else if (phpType.entries.length > 1) {
+          stats.skippedAmbiguous++;
+        }
+        continue;
       }
 
       const origDstName = rel.dstName;

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -3332,6 +3332,18 @@ export function resolveEdges(
   const phpFqcnImportsByLocal = new Map<string, Map<string, string | null>>();
   for (const result of results) {
     if (result.language !== SupportedLanguages.PHP) continue;
+    // A `use` is scoped to its namespace *block*, but this index is per file.
+    // In a file with several braced namespaces, an import in one block would be
+    // applied to the others — resolving a name that a later block declares
+    // itself, and pointing it confidently at the wrong file. One namespace per
+    // file is the PSR-12 norm, so skip the rare multi-block file entirely
+    // rather than mis-resolve it; it simply keeps the pre-existing behaviour.
+    const namespaceScopes = new Set(
+      result.entities
+        .filter(entity => entity.kind !== 'file' && typeof entity.packageScope === 'string')
+        .map(entity => entity.packageScope as string),
+    );
+    if (namespaceScopes.size > 1) continue;
     for (const rel of result.relationships) {
       if (
         rel.predicate !== 'IMPORTS' ||

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -2876,11 +2876,20 @@ function qualifiedKey(e: ParsedEntity): string {
 
 const PHP_TYPE_KINDS = new Set(['class', 'interface', 'trait', 'enum']);
 
+function trimPhpNamespace(namespace: string | undefined): string {
+  if (!namespace) return '';
+  let start = 0;
+  let end = namespace.length;
+  while (start < end && namespace.charCodeAt(start) === 92) start++;
+  while (end > start && namespace.charCodeAt(end - 1) === 92) end--;
+  return namespace.slice(start, end);
+}
+
 function phpTypeFqcn(entity: ParsedEntity): string | undefined {
   if (entity.language !== SupportedLanguages.PHP || !PHP_TYPE_KINDS.has(entity.kind) || entity.container) {
     return undefined;
   }
-  const namespace = entity.packageScope?.replace(/^\\+|\\+$/g, '');
+  const namespace = trimPhpNamespace(entity.packageScope);
   return `${namespace ? `${namespace}\\` : ''}${entity.name}`.toLowerCase();
 }
 

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -218,6 +218,13 @@ export interface FileParseResult {
   importBindings?: ImportBinding[];
   /** JS/TS provider-side aliased/default public export names. */
   exportPublicNames?: ExportPublicName[];
+  /**
+   * PHP only: how many namespaces the file declares, braced or not. Consumers
+   * that key an index per FILE need this to detect the multi-namespace files
+   * where a per-file index would be wrong (a `use` is scoped to its block).
+   * Absent for non-PHP files and for PHP files in the global namespace.
+   */
+  phpNamespaceBlocks?: number;
   fileRole: RoleClassification;
 }
 
@@ -1991,29 +1998,43 @@ interface PhpNamespaceSpan {
   namespace: string;
 }
 
+interface PhpNamespaces {
+  /** Unbraced `namespace X;` declarations, ascending by start offset. */
+  spans: PhpNamespaceSpan[];
+  /** Every top-level `namespace` declaration, braced or not. */
+  blocks: number;
+}
+
 /**
- * Start offsets of every unbraced `namespace X;` at file top level, ascending.
+ * The file's namespace structure: start offsets of every unbraced
+ * `namespace X;` at top level (ascending), plus how many namespaces the file
+ * declares in total.
  *
- * Built once per parse. Doing this scan per definition instead made the file
- * cost O(definitions x top-level nodes): a valid 890 KB PSR-12 file with ~16k
- * functions took ~197s, against ~355ms without it.
+ * Built once per parse. Doing the span scan per definition instead made the
+ * file cost O(definitions x top-level nodes): a valid 890 KB PSR-12 file with
+ * ~16k functions took ~197s, against ~355ms without it. Both results come off
+ * that single walk on purpose — reading `namedChildren` a second time pays the
+ * whole node-wrapper materialization cost again, which is the dominant term.
  *
- * A braced `namespace X { ... }` scopes by containment rather than position and
- * is handled by the ancestor walk in {@link phpNamespaceForNode}, so it is
- * deliberately excluded here.
+ * A braced `namespace X { ... }` scopes by containment rather than position, so
+ * it is handled by the ancestor walk in {@link phpNamespaceForNode} and is
+ * excluded from `spans` — but it still counts towards `blocks`.
  */
-function collectPhpNamespaceSpans(rootNode: any): PhpNamespaceSpan[] {
+function collectPhpNamespaces(rootNode: any): PhpNamespaces {
   const spans: PhpNamespaceSpan[] = [];
+  let blocks = 0;
   // `namedChildren` materializes the list in a single walk; indexing
   // `namedChild(i)` in a loop is what made the original scan expensive.
   for (const child of rootNode.namedChildren ?? []) {
-    if (!child || child.type !== 'namespace_definition' || child.childForFieldName?.('body')) continue;
+    if (!child || child.type !== 'namespace_definition') continue;
+    blocks++;
+    if (child.childForFieldName?.('body')) continue;
     spans.push({
       startIndex: child.startIndex,
       namespace: child.childForFieldName?.('name')?.text?.replace(/\s+/g, '') ?? '',
     });
   }
-  return spans;
+  return { spans, blocks };
 }
 
 function phpNamespaceForNode(node: any, spans: PhpNamespaceSpan[]): string | undefined {
@@ -2185,9 +2206,9 @@ export function parseFile(filePath: string, source: string): FileParseResult | n
 
     // Same idea for PHP: collect the file's namespace boundaries once rather
     // than rescanning the top level for every definition.
-    const phpNamespaceSpans = language === SupportedLanguages.PHP
-      ? collectPhpNamespaceSpans(tree.rootNode)
-      : [];
+    const phpNamespaces: PhpNamespaces = language === SupportedLanguages.PHP
+      ? collectPhpNamespaces(tree.rootNode)
+      : { spans: [], blocks: 0 };
 
     // --- First pass: collect definitions ---
     for (const match of pass1Matches) {
@@ -2262,7 +2283,7 @@ export function parseFile(filePath: string, source: string): FileParseResult | n
           container: effectiveContainer,
           packageScope: goPackage ?? (
             language === SupportedLanguages.PHP
-              ? phpNamespaceForNode(defNode, phpNamespaceSpans)
+              ? phpNamespaceForNode(defNode, phpNamespaces.spans)
               : undefined
           ),
         });
@@ -2879,6 +2900,10 @@ export function parseFile(filePath: string, source: string): FileParseResult | n
       importAliases: Object.keys(importAliases).length > 0 ? importAliases : undefined,
       importBindings: importBindings.length > 0 ? importBindings : undefined,
       exportPublicNames: exportPublicNames.length > 0 ? exportPublicNames : undefined,
+      // Spread rather than `: undefined` so the key is absent for every non-PHP
+      // file. A key that is present-but-undefined still serializes, which would
+      // rewrite every checked-in parseFile snapshot for no behavioural reason.
+      ...(phpNamespaces.blocks > 0 ? { phpNamespaceBlocks: phpNamespaces.blocks } : {}),
       fileRole: classifyFileRole(filePath, source),
     };
   } catch (e) {
@@ -3375,17 +3400,19 @@ export function resolveEdges(
   for (const result of results) {
     if (result.language !== SupportedLanguages.PHP) continue;
     // A `use` is scoped to its namespace *block*, but this index is per file.
-    // In a file with several braced namespaces, an import in one block would be
+    // In a file with several namespaces, an import in one block would be
     // applied to the others — resolving a name that a later block declares
     // itself, and pointing it confidently at the wrong file. One namespace per
     // file is the PSR-12 norm, so skip the rare multi-block file entirely
     // rather than mis-resolve it; it simply keeps the pre-existing behaviour.
-    const namespaceScopes = new Set(
-      result.entities
-        .filter(entity => entity.kind !== 'file' && typeof entity.packageScope === 'string')
-        .map(entity => entity.packageScope as string),
-    );
-    if (namespaceScopes.size > 1) continue;
+    //
+    // The count comes from the parser's `namespace_definition` nodes, NOT from
+    // the entities' packageScope. Two things are invisible from the entity side:
+    // two blocks may declare the SAME namespace name (one distinct scope string,
+    // still two scopes), and a block containing only `use` statements declares
+    // no entities at all (no scope string, but its imports are still confined
+    // to it). Both were mis-classified as single-namespace files.
+    if ((result.phpNamespaceBlocks ?? 0) > 1) continue;
     for (const rel of result.relationships) {
       if (
         rel.predicate !== 'IMPORTS' ||

--- a/core-ingestion/src/patch-builder.ts
+++ b/core-ingestion/src/patch-builder.ts
@@ -671,7 +671,7 @@ export function buildPatchWithResolution(
     // node it instead mints two ids for one edge, and since the dedup downstream
     // keys on id, both commit. An edge is identified by (src, dst, predicate) —
     // two of those with empty attrs are indistinguishable in the graph.
-    const edgeIdentity = `${nodeId(idPath, srcKey)} ${dstNodeId} ${r.predicate}`;
+    const edgeIdentity = `${nodeId(idPath, srcKey)}\x00${dstNodeId}\x00${r.predicate}`;
     if (emittedEdgeIdentities.has(edgeIdentity)) continue;
     emittedEdgeIdentities.add(edgeIdentity);
     ops.push({

--- a/core-ingestion/src/patch-builder.ts
+++ b/core-ingestion/src/patch-builder.ts
@@ -478,7 +478,8 @@ export function buildPatchWithResolution(
   const edgeResolution = new Map<string, { dstFilePath: string; dstQualifiedKey: string }>();
   for (const edge of resolvedEdges) {
     if (edge.srcFilePath !== result.filePath) continue;
-    edgeResolution.set(`${edge.srcName}:${edge.predicate}:${edge.dstName}`, {
+    const callKind = edge.phpCallKind ? `:${edge.phpCallKind}` : '';
+    edgeResolution.set(`${edge.srcName}:${edge.predicate}:${edge.dstName}${callKind}`, {
       dstFilePath: edge.dstFilePath,
       dstQualifiedKey: edge.dstQualifiedKey,
     });
@@ -616,6 +617,11 @@ export function buildPatchWithResolution(
   }
 
   const seenExternalNodes2 = new Set<string>();
+  const relationshipShapeCounts = new Map<string, number>();
+  for (const relationship of relationships) {
+    const key = `${relationship.srcName}:${relationship.predicate}:${relationship.dstName}`;
+    relationshipShapeCounts.set(key, (relationshipShapeCounts.get(key) ?? 0) + 1);
+  }
   for (const r of relationships) {
     const srcKey = resolveKey(r.srcName);
     const dstKey = r.predicate === 'CONTAINS'
@@ -623,12 +629,18 @@ export function buildPatchWithResolution(
       : resolveKey(r.dstName);
 
     let dstNodeId: string;
-    const resolutionKey = `${r.srcName}:${r.predicate}:${r.dstName}`;
+    const baseResolutionKey = `${r.srcName}:${r.predicate}:${r.dstName}`;
+    const resolutionKey = r.phpCallKind
+      ? `${baseResolutionKey}:${r.phpCallKind}`
+      : baseResolutionKey;
+    const matchedResolutionKey = edgeResolution.has(resolutionKey)
+      ? resolutionKey
+      : baseResolutionKey;
 
-    if (edgeResolution.has(resolutionKey)) {
+    if (edgeResolution.has(matchedResolutionKey)) {
       // Cross-file resolved — use the defining file's nodeId, in the dst repo's
       // workspace namespace (matters only for cross-repo edges in a co-ingest).
-      const { dstFilePath, dstQualifiedKey } = edgeResolution.get(resolutionKey)!;
+      const { dstFilePath, dstQualifiedKey } = edgeResolution.get(matchedResolutionKey)!;
       dstNodeId = dstNodeIdInRepo(dstFilePath, dstQualifiedKey);
     } else if (r.predicate === 'CALLS' && dstKey.includes('::') && !allQKeys2.has(dstKey)) {
       const sep = dstKey.indexOf('::');
@@ -650,9 +662,12 @@ export function buildPatchWithResolution(
       dstNodeId = nodeId(idPath, dstKey);
     }
 
+    const edgeDstKey = r.phpCallKind && (relationshipShapeCounts.get(baseResolutionKey) ?? 0) > 1
+      ? `${dstKey}:${r.phpCallKind}`
+      : dstKey;
     ops.push({
       type: 'UpsertEdge',
-      id: edgeId(idPath, srcKey, dstKey, r.predicate),
+      id: edgeId(idPath, srcKey, edgeDstKey, r.predicate),
       src: nodeId(idPath, srcKey),
       dst: dstNodeId,
       predicate: r.predicate,

--- a/core-ingestion/src/patch-builder.ts
+++ b/core-ingestion/src/patch-builder.ts
@@ -366,12 +366,21 @@ export function buildPatch(
   }
 
   // AssertClaim for each relationship (feeds the confidence/conflict engine)
+  // phpCallKind splits the relationship dedup key, so `handle(); $obj->handle();`
+  // arrives as two relationships that produce byte-identical claims. The kind is
+  // not part of a claim, so nothing downstream can tell them apart.
+  const emittedClaims = new Set<string>();
   for (const r of relationships) {
     const srcKey = resolveKey(r.srcName);
+    const entityId = nodeId(idPath, srcKey);
+    const field = `${r.predicate.toLowerCase()}:${r.dstName}`;
+    const claimIdentity = `${entityId}\x00${field}`;
+    if (emittedClaims.has(claimIdentity)) continue;
+    emittedClaims.add(claimIdentity);
     ops.push({
       type: 'AssertClaim',
-      entityId: nodeId(idPath, srcKey),
-      field: `${r.predicate.toLowerCase()}:${r.dstName}`,
+      entityId,
+      field,
       value: r.dstName,
       confidence: null,
     });
@@ -684,12 +693,21 @@ export function buildPatchWithResolution(
     });
   }
 
+  // phpCallKind splits the relationship dedup key, so `handle(); $obj->handle();`
+  // arrives as two relationships that produce byte-identical claims. The kind is
+  // not part of a claim, so nothing downstream can tell them apart.
+  const emittedClaims = new Set<string>();
   for (const r of relationships) {
     const srcKey = resolveKey(r.srcName);
+    const entityId = nodeId(idPath, srcKey);
+    const field = `${r.predicate.toLowerCase()}:${r.dstName}`;
+    const claimIdentity = `${entityId}\x00${field}`;
+    if (emittedClaims.has(claimIdentity)) continue;
+    emittedClaims.add(claimIdentity);
     ops.push({
       type: 'AssertClaim',
-      entityId: nodeId(idPath, srcKey),
-      field: `${r.predicate.toLowerCase()}:${r.dstName}`,
+      entityId,
+      field,
       value: r.dstName,
       confidence: null,
     });

--- a/core-ingestion/src/patch-builder.ts
+++ b/core-ingestion/src/patch-builder.ts
@@ -617,6 +617,7 @@ export function buildPatchWithResolution(
   }
 
   const seenExternalNodes2 = new Set<string>();
+  const emittedEdgeIdentities = new Set<string>();
   const relationshipShapeCounts = new Map<string, number>();
   for (const relationship of relationships) {
     const key = `${relationship.srcName}:${relationship.predicate}:${relationship.dstName}`;
@@ -665,6 +666,14 @@ export function buildPatchWithResolution(
     const edgeDstKey = r.phpCallKind && (relationshipShapeCounts.get(baseResolutionKey) ?? 0) > 1
       ? `${dstKey}:${r.phpCallKind}`
       : dstKey;
+    // The phpCallKind salt above exists so `foo()` and `Bar::foo()` keep distinct
+    // ids when they resolve to *different* targets. When they resolve to the same
+    // node it instead mints two ids for one edge, and since the dedup downstream
+    // keys on id, both commit. An edge is identified by (src, dst, predicate) —
+    // two of those with empty attrs are indistinguishable in the graph.
+    const edgeIdentity = `${nodeId(idPath, srcKey)} ${dstNodeId} ${r.predicate}`;
+    if (emittedEdgeIdentities.has(edgeIdentity)) continue;
+    emittedEdgeIdentities.add(edgeIdentity);
     ops.push({
       type: 'UpsertEdge',
       id: edgeId(idPath, srcKey, edgeDstKey, r.predicate),

--- a/core-ingestion/src/queries.ts
+++ b/core-ingestion/src/queries.ts
@@ -1026,9 +1026,13 @@ export const PHP_QUERIES = `
 
 ; ── Imports: use statements ──────────────────────────────────────────────────
 ; Simple: use App\\Models\\User;
+; The leading anchor pins the capture to the clause's FIRST named child. In
+; "use A\\B\\C as Alias" the alias is a sibling (name) of the (qualified_name),
+; so an unanchored alternation would capture it too and emit a phantom import
+; of Alias. "use GlobalThing;" is a lone (name) child and still matches.
 (namespace_use_declaration
   (namespace_use_clause
-    [(qualified_name) (name)] @import.source)) @import
+    . [(qualified_name) (name)] @import.source)) @import
 
 ; ── Function/method calls ────────────────────────────────────────────────────
 ; Regular function call: foo()

--- a/core-ingestion/src/queries.ts
+++ b/core-ingestion/src/queries.ts
@@ -1028,7 +1028,7 @@ export const PHP_QUERIES = `
 ; Simple: use App\\Models\\User;
 (namespace_use_declaration
   (namespace_use_clause
-    (qualified_name) @import.source)) @import
+    [(qualified_name) (name)] @import.source)) @import
 
 ; ── Function/method calls ────────────────────────────────────────────────────
 ; Regular function call: foo()


### PR DESCRIPTION
Carries **@Hiro-Chiba's #442** plus three review fixes, one a DoS. Landing it here closes #442 as merged.

> ⚠️ **Merge with a merge commit, not squash** — contains Hiro-Chiba's two commits alongside mine.

## Their change (`ea79b11`, `83079ff`)

Resolves explicit PHP type imports by declared namespace instead of a repo-wide short-name match. The follow-up replaces the flagged ReDoS regex with a char-code trim — **the CodeQL alert on #442 is stale** and can be dismissed after a re-scan.

## My fixes

**1. `5c322a9` — the capture also matched the alias.** Confirmed against the grammar by dumping the parse tree: in `namespace_use_clause` the alias is a **direct `(name)` sibling** of the `qualified_name`, so `[(qualified_name) (name)]` captured both. `use Vendor\Package\User as Admin;` emitted an `IMPORTS` edge to an unrelated `Admin` class and promoted the wrong short-name matches from 0.5 to **0.9** — the opposite of this PR's purpose. Anchored to the clause's first named child; bare `use GlobalThing;` is a lone `(name)` child and still matches.

Two related bugs shared that root cause: `importAliased` was computed from the whole statement, so one alias in a comma-separated `use` disabled FQCN resolution for every clause; and that same unanchored `/\s+as\s+/` was a second ReDoS instance CodeQL missed (~3.7 s on a `use` padded with 100k spaces, which is valid PHP). Reading the clause node removes both.

**2. `663c6ce` — two regressions measured against main, not inferred.**
- A `use` leaked across braced namespace blocks: `go()` in `namespace B` resolved to the vendor file at 0.9 although `B` declares its own `Thing` two lines up. main emits no edge at all.
- Duplicate `CALLS` edges reached the graph: `phpCallKind` splits the dedup key, so `log()` and `Logger::log()` survive as two relationships; when both resolve to the same member, patch-builder salted the edge id by call kind and emitted two `UpsertEdge` ops with identical src/dst/predicate but different ids — and the dedup downstream keys on id. Measured main 1 op, this branch 2.

**3. `7c8a387` — one ordinary PHP file hung ingestion (the DoS).** `phpNamespaceForNode` rescanned the file's top-level nodes for every definition. A valid PSR-12 file — `namespace App\Support` plus ~16k functions, 890 KB, under the 1 MB cap — took **over three minutes**. `.php` is ingested by default, the minified-file skip needs a ≥20k-char line, and `ParsePool` has no per-file timeout, so one file pins a worker; PHP is also in `PARSER_DERIVED_PRESCAN`, so it's parsed twice.

| declarations | before | after |
|---|---|---|
| 2,000 | 3,245 ms | 104 ms |
| 4,000 | 13,099 ms | 151 ms |
| 8,000 | 54,408 ms | 236 ms |

Entity counts and `packageScope` values identical at every size.

Worth flagging, since it wasn't what I first assumed: mutation testing showed the binary search is *not* load-bearing, and even rebuilding the span list per definition stays fast. The dominant cost is `namedChild(i)` materializing a node wrapper per index — iterating `namedChildren` once is the real fix. The regression test times out only against the exact original.

## Known gap, not fixed here

My multi-namespace guard counts distinct `packageScope` strings, so it misses two blocks sharing a name and a `use`-only block. Cheap follow-up: count the `module` entities the parse already emits per braced block.

## Verification

Every fix mutation-tested. core-ingestion 338 passed, 6 pre-existing failures unchanged from base; `tsc --noEmit` clean.