### PR TITLE
fix(php): capture grouped use imports

### DIFF
--- a/core-ingestion/src/__tests__/queries.php.test.ts
+++ b/core-ingestion/src/__tests__/queries.php.test.ts
@@ -22,6 +22,58 @@ use Vendor\\Contracts\\DomainService;
     });
   });
 
+  it('captures every member of a grouped namespace use', () => {
+    const result = parseFile(
+      '/repo/UseCase.php',
+      `<?php
+namespace App;
+
+use Vendor\\Contracts\\{DomainService, Repo};
+      `,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.relationships).toContainEqual({
+      srcName: 'UseCase.php',
+      dstName: 'DomainService',
+      predicate: 'IMPORTS',
+      importRaw: 'Vendor\\Contracts\\DomainService',
+    });
+    expect(result!.relationships).toContainEqual({
+      srcName: 'UseCase.php',
+      dstName: 'Repo',
+      predicate: 'IMPORTS',
+      importRaw: 'Vendor\\Contracts\\Repo',
+    });
+  });
+
+  it('captures grouped use members with the shared prefix, never the alias', () => {
+    const result = parseFile(
+      '/repo/UseCase.php',
+      `<?php
+namespace App;
+
+use Vendor\\Contracts\\{DomainService as DS, Repo};
+      `,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.relationships).toContainEqual({
+      srcName: 'UseCase.php',
+      dstName: 'DomainService',
+      predicate: 'IMPORTS',
+      importRaw: 'Vendor\\Contracts\\DomainService',
+    });
+    expect(result!.relationships).toContainEqual({
+      srcName: 'UseCase.php',
+      dstName: 'Repo',
+      predicate: 'IMPORTS',
+      importRaw: 'Vendor\\Contracts\\Repo',
+    });
+    // The `as DS` alias is a local name, never an imported symbol.
+    expect(result!.relationships.filter((r) => r.predicate === 'IMPORTS' && r.dstName === 'DS')).toEqual([]);
+  });
+
   it('resolves calls through typed properties and method parameters', () => {
     const result = parseFile(
       '/repo/UseCase.php',

--- a/core-ingestion/src/__tests__/resolveEdges.test.ts
+++ b/core-ingestion/src/__tests__/resolveEdges.test.ts
@@ -256,6 +256,36 @@ describe('resolveEdges', () => {
     });
   });
 
+  it('resolves imports from a grouped PHP use statement', () => {
+    const consumer = parseFile(
+      '/repo/UseCase.php',
+      `<?php
+namespace App;
+
+use Vendor\\Contracts\\{DomainService, Repo};
+
+final class UseCase
+{
+    public function make(): void
+    {
+        $svc = new DomainService();
+    }
+}
+      `,
+    )!;
+    const provider = parseFile(
+      '/repo/DomainService.php',
+      '<?php namespace Vendor\\Contracts; class DomainService {}',
+    )!;
+
+    const resolved = resolveEdges([consumer, provider]);
+    expect(
+      resolved.filter(
+        (e) => e.predicate === 'IMPORTS' && e.dstFilePath === '/repo/DomainService.php',
+      ),
+    ).toHaveLength(1);
+  });
+
   it('resolves a TypeScript call when the imported definition is outside the parse batch', () => {
     const caller = fileResult(
       '/repo/consumer.ts',

--- a/core-ingestion/src/index.ts
+++ b/core-ingestion/src/index.ts
@@ -2419,6 +2419,27 @@ export function parseFile(filePath: string, source: string): FileParseResult | n
         continue;
       }
 
+      // PHP grouped use: `use Vendor\Package\{A, B};` (also `use function` /
+      // `use const`). Each member is its own namespace_use_clause under the
+      // group; the shared prefix arrives via @import.prefix. The clause's FIRST
+      // name child is the imported symbol (a second one is an `as` alias and
+      // must never become an import), so rebuild the FQCN from prefix + first
+      // name, matching the single-clause form's modName/importRaw shape.
+      const phpGroupPrefix = match.captures.find((c: any) => c.name === 'import.prefix')?.node.text;
+      const phpGroupClauses = match.captures.filter((c: any) => c.name === 'import.clause');
+      if (language === SupportedLanguages.PHP && phpGroupClauses.length > 0) {
+        for (const clause of phpGroupClauses) {
+          const firstName = clause.node.namedChildren.find((c: any) => c.type === 'name');
+          if (!firstName) continue;
+          const fqcn = phpGroupPrefix ? `${phpGroupPrefix}\\${firstName.text}` : firstName.text;
+          const modName = normalizeCapturedImport(fqcn, language);
+          const importRaw = unwrapImportSpecifier(fqcn);
+          entities.push({ name: modName, kind: 'module', lineStart: firstName.startPosition.row + 1, lineEnd: firstName.startPosition.row + 1, language });
+          relationships.push({ srcName: fileName, dstName: modName, predicate: 'IMPORTS', importRaw });
+        }
+        continue;
+      }
+
       // Import captures (JS/TS/Python path-based)
       const importSource = match.captures.find((c: any) => c.name === 'import.source');
       if (importSource) {

--- a/core-ingestion/src/queries.ts
+++ b/core-ingestion/src/queries.ts
@@ -1030,6 +1030,16 @@ export const PHP_QUERIES = `
   (namespace_use_clause
     (qualified_name) @import.source)) @import
 
+; Grouped: use App\\Models\\{User, Repo};
+; The shared prefix is a namespace_name; each member is its own
+; namespace_use_clause carrying the bare member name (and optionally an
+; 'as' alias). The clause is captured whole so the handler can take the
+; FIRST name child as the imported symbol and skip the alias.
+(namespace_use_declaration
+  (namespace_name) @import.prefix
+  (namespace_use_group
+    (namespace_use_clause) @import.clause)) @import
+
 ; ── Function/method calls ────────────────────────────────────────────────────
 ; Regular function call: foo()
 (function_call_expression


### PR DESCRIPTION
## Summary

PHP grouped `use` statements — `use Vendor\Package\{A, B};`, plus the `use function` / `use const` variants — never produced `IMPORTS` relationships, so calls like `new A()` through a grouped import went unresolved.

## Bug

The PHP query only matched `(namespace_use_clause (qualified_name) @import.source)`. A grouped `use` has a different tree-sitter shape: the shared prefix is a separate `namespace_name` and each member is a bare `(namespace_use_clause (name))` under a `namespace_use_group`. Because neither matched, every member import was silently dropped:

```php
use Vendor\Contracts\{DomainService, Repo};
$svc = new DomainService(); // resolves to nothing
```

while the comma-separated equivalent `use Vendor\Contracts\DomainService, Vendor\Contracts\Repo;` resolves correctly — a real gap, not a theoretical one.

## Fix

- **`core-ingestion/src/queries.ts`** — add a grouped-use pattern capturing the shared prefix as `@import.prefix` and each member clause as `@import.clause`.
- **`core-ingestion/src/index.ts`** — rebuild each member's FQCN from prefix + the clause's **first** `name` child. A second `name` child is an `as` alias (`{DomainService as DS, ...}`) and must never become an import. The emitted `modName`/`importRaw` match the single-clause form, so grouped imports resolve exactly like their comma-separated equivalents.

## Regression tests

- per-member capture for `{DomainService, Repo}`
- alias exclusion for `{DomainService as DS, Repo}`
- end-to-end resolution of a grouped import through `resolveEdges`

All three fail on `main` and pass after the fix.

## Verification

- New tests: fail-before on `main` (3 failures), pass-after
- `queries.php` + `resolveEdges` + `patchBuilder.resolution`: 86/86 pass
- `tsc --noEmit` clean, `git diff --check` clean
- Full suite: only pre-existing SAS/environmental failures, identical on pristine `main`
- No duplicate PR, issue, or upstream commit found for grouped PHP use handling

## Relationship to existing PRs

Independent of #446 (PHP namespace resolution) — that PR does not touch the use-import query. This fix is based on current `main` (`043bc68`).
