### PR TITLE
fix(view): write the compass server as .cjs, not .js

### DIFF
--- a/ix-cli/src/cli/__tests__/view-running-port.test.ts
+++ b/ix-cli/src/cli/__tests__/view-running-port.test.ts
@@ -26,7 +26,7 @@ let originalIxHome: string | undefined;
 const pidFile = () => join(ixHome, "compass.pid");
 const scopeFile = () => join(ixHome, "compass.scope");
 const portFile = () => join(ixHome, "compass.port");
-const serverScriptFile = () => join(ixHome, "tmp", "compass-server.js");
+const serverScriptFile = () => join(ixHome, "tmp", "compass-server.cjs");
 
 beforeEach(() => {
   vi.resetModules();

--- a/ix-cli/src/cli/__tests__/view-server.test.ts
+++ b/ix-cli/src/cli/__tests__/view-server.test.ts
@@ -53,6 +53,14 @@ describe("view server (/__ix/remap)", () => {
     // A fake Compass dist: index.html is the SPA entry the fallback serves.
     distDir = mkdtempSync(join(tmpdir(), "ix view dist "));
     writeFileSync(join(distDir, "index.html"), "<h1>fake compass</h1>");
+    // The server script is CommonJS, and a `.js` file's module system is
+    // decided by the nearest package.json above it. Declaring this directory
+    // ESM makes every test below run under the condition that used to break
+    // `ix view` outright — node refusing the script with "require is not
+    // defined in ES module scope" while the CLI reported only "started … but
+    // is not yet serving". `ix-cli` is itself `"type": "module"`, so this is
+    // the ordinary case for anyone whose IX_HOME sits inside a package.
+    writeFileSync(join(distDir, "package.json"), JSON.stringify({ type: "module" }));
 
     // The workspace the server is scoped to. The endpoint maps this, not its
     // own cwd, so the test has to supply one.
@@ -67,7 +75,10 @@ describe("view server (/__ix/remap)", () => {
     // A stub `ix` CLI main: the server runs `node <MAP_MAIN> map <root> --silent`.
     // STUB_MS holds it open so overlapping requests are observable; STUB_EXIT
     // drives the failure path.
-    stubMain = join(distDir, "stub-main.js");
+    // `.cjs` for the same reason the server script is: this stub is CommonJS
+    // and the directory above it now declares ESM. (The real main it stands in
+    // for is ESM, so only the fixture needs saying.)
+    stubMain = join(distDir, "stub-main.cjs");
     writeFileSync(
       stubMain,
       [
@@ -124,7 +135,7 @@ describe("view server (/__ix/remap)", () => {
     options: StartServerOptions = {},
   ) {
     await stopServer();
-    const scriptPath = join(distDir, "compass-server.js");
+    const scriptPath = join(distDir, "compass-server.cjs");
     writeFileSync(scriptPath, serverScript());
     const spawned = spawn(process.execPath, [
       scriptPath,

--- a/ix-cli/src/cli/commands/view.ts
+++ b/ix-cli/src/cli/commands/view.ts
@@ -23,7 +23,18 @@ const PID_FILE = join(IX_HOME, "compass.pid");
 // already-running (differently-scoped) instance.
 const SCOPE_FILE = join(IX_HOME, "compass.scope");
 const PORT_FILE = join(IX_HOME, "compass.port");
-const SERVER_SCRIPT_FILE = join(IX_HOME, "tmp", "compass-server.js");
+/**
+ * `.cjs`, not `.js`.
+ *
+ * The script this writes is CommonJS — it `require`s http, fs and path. A `.js`
+ * file's module system is decided by the nearest `package.json` *above it*, so
+ * with `IX_HOME` anywhere under a directory declaring `"type": "module"`, node
+ * refuses the script with `require is not defined in ES module scope` and
+ * `ix view` reports only "started … but is not yet serving", which names
+ * neither the cause nor the fix. `.cjs` is CommonJS whatever any ancestor
+ * says. (`$HOME/package.json` is rare but real — this box has one.)
+ */
+const SERVER_SCRIPT_FILE = join(IX_HOME, "tmp", "compass-server.cjs");
 const BACKEND_URL = "http://localhost:8090";
 
 /** Resolve the compass dist directory — installed path first, then dev fallback. */


### PR DESCRIPTION
Found while verifying the 0.10.0 release candidate end to end — running the shipped tarball's `ix` with `IX_HOME` pointed at a scratch directory.

## The bug

The script `ix view` generates is CommonJS — it `require`s http, fs and path. A `.js` file's module system is decided by the nearest `package.json` **above it**, so whenever `IX_HOME` sits under a directory declaring `"type": "module"`, node refuses the script:

```
ReferenceError: require is not defined in ES module scope
```

and `ix view` reports only:

```
[!] Visualizer started (PID 197066) but is not yet serving http://localhost:8124.
```

which names neither the cause nor the fix. The script is spawned with `stdio: "ignore"`, so node's error goes nowhere — the only symptom is a visualizer that never comes up.

**Not exotic.** `ix-cli` is itself `"type": "module"`, so any `IX_HOME` inside the package hits it. And the machine I found this on has a `$HOME/package.json` — it works only because that file happens to carry no `"type"` field. One edit to an unrelated file in `$HOME` would break `ix view` for that user, with a message pointing at the compass bundle rather than at node.

`.cjs` is CommonJS whatever any ancestor says.

## The regression test

It sits in the existing server suite rather than beside it: the fake dist now declares `"type": "module"`, so **all 15 of those tests run under the condition that used to break it**. Reverting the extension fails the file with `server on port N did not start` and exit 1 — verified.

The CommonJS stub main alongside it is renamed for the same reason. The real main it stands in for is ESM, so only the fixture needed saying.

## Verified on the real artifact

On the script `ix view` actually generated, in a directory declaring ESM:

| name | result |
|---|---|
| `compass-server.js` | `ReferenceError: require is not defined in ES module scope` |
| `compass-server.cjs` | serves the compass bundle, **HTTP 200** |

858 ix-cli tests pass.
