### PR TITLE
fix(view): time the /v1 proxy out instead of hanging for ever

### DIFF
--- a/ix-cli/src/cli/__tests__/view-server.test.ts
+++ b/ix-cli/src/cli/__tests__/view-server.test.ts
@@ -344,4 +344,30 @@ describe("view server (/__ix/remap)", () => {
     expect(res.status).toBe(200);
     expect(await res.text()).toContain("fake compass");
   });
+
+  it("answers 504 when the backend accepts and never replies", async () => {
+    // The failure this closes: node puts no timeout on an outgoing request, so
+    // a backend that accepts the socket and then goes quiet left the browser
+    // waiting for ever. Compass recorded neither a result nor a failure, and
+    // the region sat at "loading …" with nothing to tell a slow map from a
+    // dead one. A 504 is a state the client can render.
+    const hung = http.createServer(() => {
+      /* accept the connection and never answer */
+    });
+    await new Promise<void>((resolve) => hung.listen(0, "127.0.0.1", () => resolve()));
+    const hungPort = (hung.address() as { port: number }).port;
+
+    try {
+      await startServer(
+        { IX_VIEW_PROXY_TIMEOUT_MS: "300" },
+        mapRoot,
+        { backendUrl: `http://127.0.0.1:${hungPort}` },
+      );
+      const res = await fetch(`http://127.0.0.1:${port}/v1/health`);
+      expect(res.status).toBe(504);
+      expect(await res.text()).toMatch(/timed out/i);
+    } finally {
+      await new Promise<void>((resolve) => hung.close(() => resolve()));
+    }
+  }, 20000);
 });

--- a/ix-cli/src/cli/commands/view.ts
+++ b/ix-cli/src/cli/commands/view.ts
@@ -256,6 +256,16 @@ const { execFile } = require("child_process");
 
 const DIST = process.argv[2];
 const PORT = Number(process.argv[3]);
+// How long to wait on the backend before answering 504. Generous, because it
+// must not fire on a legitimately slow read: /v1/map rebuilds the whole map on
+// every call and has been measured at 276s on a large graph. Overridable only
+// under NODE_ENV=test, like the seams below, so a shipped install cannot be
+// given a short timeout through the environment — and so the timeout itself
+// can be tested without a ten-minute test.
+const PROXY_TIMEOUT_MS = (process.env.NODE_ENV === "test" && process.env.IX_VIEW_PROXY_TIMEOUT_MS)
+  ? Number(process.env.IX_VIEW_PROXY_TIMEOUT_MS)
+  : 600000;
+
 const BACKEND = (process.env.NODE_ENV === "test" && process.env.IX_VIEW_BACKEND_URL)
   ? process.env.IX_VIEW_BACKEND_URL
   : ${JSON.stringify(BACKEND_URL)};
@@ -328,9 +338,26 @@ const server = http.createServer((req, res) => {
       res.writeHead(proxyRes.statusCode, proxyRes.headers);
       proxyRes.pipe(res);
     });
-    proxyReq.on("error", () => {
-      res.writeHead(502, { "Content-Type": "text/plain" });
-      res.end("Backend unavailable");
+    // A backend that accepts the socket and then never answers used to hang
+    // here for ever: node puts no timeout on an outgoing request, so the
+    // browser waited indefinitely, Compass recorded neither a result nor a
+    // failure, and the region sat at "loading …" with nothing to distinguish a
+    // slow map from a dead one. Answering 504 turns that into a state the
+    // client can render and a user can act on.
+    //
+    // Generous, because it must not fire on a legitimately slow read: /v1/map
+    // rebuilds the whole map on every call and has been measured at 276s on a
+    // large graph. This is the point past which silence is a fault rather than
+    // patience.
+    proxyReq.setTimeout(PROXY_TIMEOUT_MS, () => {
+      proxyReq.destroy(new Error("backend timed out"));
+    });
+    proxyReq.on("error", (err) => {
+      // Whatever went wrong, the client is still waiting; say something.
+      if (res.headersSent) { res.destroy(); return; }
+      const timedOut = err && err.message === "backend timed out";
+      res.writeHead(timedOut ? 504 : 502, { "Content-Type": "text/plain" });
+      res.end(timedOut ? "Backend timed out" : "Backend unavailable");
     });
     req.pipe(proxyReq);
     return;


### PR DESCRIPTION
Node puts **no timeout on an outgoing request**, so a backend that accepted the socket and then never answered left the proxy — and the browser behind it — waiting indefinitely.

That state is invisible to Compass: it records neither a result nor a `failed` mark, so the region sits at `loading …` for ever, with nothing to tell a slow map from a dead one. It is half of why the "stuck loading" report took several rounds to place — there was no way for the reporter, or for me, to distinguish the two.

`504` turns it into a state the client can render and a person can act on.

## Why 600s

It must never fire on a legitimately slow read. `/v1/map` rebuilds the whole map on every call and has been measured at **276s** on a large graph. Ten minutes is the point past which silence is a fault rather than patience.

The error handler also stops assuming it can still write a response — once headers are sent, a late error can only destroy the socket.

## Testable without a ten-minute test

The timeout is overridable only under `NODE_ENV=test`, matching the `IX_VIEW_BACKEND_URL` and `IX_VIEW_MAP_MAIN` seams beside it, so a shipped install cannot be given a short timeout through the environment.

The new case stands up a server that accepts connections and never replies, points the proxy at it with a 300ms timeout, and asserts `504`. **Removing the timeout makes that test hang for its full 20s budget and fail** — which is exactly the shape of the bug it closes.

986 ix-cli tests pass.
