### PR TITLE
test(install): run install.ps1 on Windows in CI

### DIFF
--- a/.github/workflows/windows-install.yml
+++ b/.github/workflows/windows-install.yml
@@ -1,0 +1,152 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Windows installer smoke test
+#
+# Every Windows install bug this project has shipped got through because
+# nothing ever ran `install.ps1`. The release job packages the CLI on a Windows
+# runner and stops there, so what was verified each time was the *artifact* —
+# never the script that unpacks it. The three bugs found by hand on v0.9.0-rc.1
+# (archive nesting, upgrade re-nesting, the IE-parse prompt) were all in that
+# gap, and each was reported by a user rather than by CI.
+#
+# So this runs the real script, on a real Windows runner, and asserts the shape
+# of what it leaves behind. Every check below is a bug that actually shipped.
+#
+# `IX_SKIP_BACKEND=1` is what makes it possible at all: the runner has no Linux
+# Docker, and `Write-Err` exits, so without the skip the run dies at the Docker
+# check having never unpacked the CLI — the part that keeps breaking.
+# ─────────────────────────────────────────────────────────────────────────────
+name: Windows install
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "scripts/install/install.ps1"
+      - ".github/workflows/windows-install.yml"
+  # A published release is the moment the installer's inputs change, and the
+  # only moment a real user is about to run it against them.
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to install (e.g. 0.10.0-rc.10). Blank = latest stable."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-install-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  install:
+    name: install.ps1 on Windows
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      # A path with a space, deliberately: #349 was a profile at `C:\Users\Win 10`,
+      # where Windows handed the installer an 8.3 short TEMP path and the run died
+      # after extraction. A test on a space-free path would not have caught it.
+      - name: Install
+        shell: pwsh
+        env:
+          IX_SKIP_BACKEND: "1"
+          IX_VERSION: ${{ inputs.version || (github.event_name == 'release' && github.event.release.tag_name) || '' }}
+        run: |
+          $env:IX_HOME = Join-Path $env:RUNNER_TEMP 'ix home'
+          # The tag carries a leading v; IX_VERSION does not.
+          if ($env:IX_VERSION) { $env:IX_VERSION = $env:IX_VERSION -replace '^v', '' }
+          Write-Host "IX_HOME=$env:IX_HOME  IX_VERSION=$($env:IX_VERSION -replace '^$','(latest stable)')"
+          & .\scripts\install\install.ps1
+          if ($LASTEXITCODE -ne 0) { throw "install.ps1 exited $LASTEXITCODE" }
+          "IX_HOME=$env:IX_HOME" >> $env:GITHUB_ENV
+
+      - name: Layout is flat
+        shell: pwsh
+        run: |
+          $cli = Join-Path $env:IX_HOME 'cli'
+          $names = (Get-ChildItem -LiteralPath $cli -Name) -join ', '
+          Write-Host "cli\ contains: $names"
+
+          # The canonical layout is flat. `findCompassDist` and `COMPASS_DIR`
+          # read $IX_HOME\cli\compass and nothing else, so anything nested here
+          # breaks `ix view` — which is exactly what Expand-Archive did, having
+          # no --strip-components to match what install.sh does with tar.
+          $nested = Get-ChildItem -LiteralPath $cli -Directory |
+                    Where-Object { $_.Name -match '^ix-.*-windows-amd64$' }
+          if ($nested) { throw "archive is nested under $($nested.Name) — flat layout expected" }
+
+          foreach ($entry in 'cli', 'compass', 'core-ingestion', 'ix.cmd') {
+            if (-not (Test-Path -LiteralPath (Join-Path $cli $entry))) {
+              throw "missing $entry in $cli (found: $names)"
+            }
+          }
+
+      - name: Launcher runs
+        shell: pwsh
+        run: |
+          # By absolute path, not through PATH: a shim that resolves only because
+          # the session happens to have the right PATH is not a working install.
+          $shim = Join-Path $env:IX_HOME 'bin\ix.cmd'
+          if (-not (Test-Path -LiteralPath $shim)) { throw "no launcher at $shim" }
+          $out = & $shim --version 2>&1 | Out-String
+          if ($LASTEXITCODE -ne 0) { throw "ix --version exited $LASTEXITCODE`n$out" }
+          Write-Host $out.Trim()
+
+      - name: Compass is present and stamped
+        shell: pwsh
+        run: |
+          $compass = Join-Path $env:IX_HOME 'cli\compass'
+          if (-not (Test-Path -LiteralPath (Join-Path $compass 'index.html'))) {
+            throw "no compass bundle — 'ix view' would exit with 'Compass UI not found'"
+          }
+          # An unstamped bundle reads as version 0.0.0, which made `ix upgrade`
+          # treat "none -> x" as an upgrade and replace a current Compass with an
+          # older dist build. A bundle that ships must declare its own version.
+          $stamp = Join-Path $compass '.version'
+          if (-not (Test-Path -LiteralPath $stamp)) { throw "compass has no .version stamp" }
+          $v = (Get-Content -LiteralPath $stamp -Raw).Trim()
+          if (-not $v) { throw "compass .version is empty" }
+          Write-Host "compass: $v"
+
+      # Re-running is the common case — it is how a user upgrades — and it is a
+      # path a first install can never exercise. It is also where the installer
+      # has historically re-nested the tree it had just laid out flat.
+      - name: Re-run is idempotent
+        shell: pwsh
+        env:
+          IX_SKIP_BACKEND: "1"
+          IX_VERSION: ${{ inputs.version || (github.event_name == 'release' && github.event.release.tag_name) || '' }}
+        run: |
+          if ($env:IX_VERSION) { $env:IX_VERSION = $env:IX_VERSION -replace '^v', '' }
+          & .\scripts\install\install.ps1
+          if ($LASTEXITCODE -ne 0) { throw "second install.ps1 exited $LASTEXITCODE" }
+
+          $cli = Join-Path $env:IX_HOME 'cli'
+          $nested = Get-ChildItem -LiteralPath $cli -Directory |
+                    Where-Object { $_.Name -match '^ix-.*-windows-amd64$' }
+          if ($nested) { throw "re-install re-nested the tree under $($nested.Name)" }
+
+          $out = & (Join-Path $env:IX_HOME 'bin\ix.cmd') --version 2>&1 | Out-String
+          if ($LASTEXITCODE -ne 0) { throw "ix --version broken after re-install`n$out" }
+          Write-Host "after re-install: $($out.Trim())"
+
+      # Leaving scratch behind is how #349 was found: the installer used to work
+      # in TEMP, and the failure it produced there was unreadable.
+      - name: No scratch left behind
+        shell: pwsh
+        run: |
+          $leftovers = Get-ChildItem -LiteralPath $env:IX_HOME -Filter '.cli-*' -Force -ErrorAction SilentlyContinue
+          if ($leftovers) {
+            throw "installer scratch left in IX_HOME: $(($leftovers | Select-Object -ExpandProperty Name) -join ', ')"
+          }

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -13,3 +13,10 @@ rules:
       # setup-node's npm cache for build speed; the cache key is lockfile-pinned.
       # Accepted for the release workflow only.
       - release.yml
+      # windows-install.yml runs on `release: published`, which zizmor treats as
+      # a privileged context, and the finding is raised against setup-node on
+      # that basis alone. This one passes no `cache:` input, so setup-node
+      # neither restores nor saves a cache — there is nothing to poison, and the
+      # job publishes no artifact. It installs a already-published release and
+      # asserts the layout. Reported by zizmor at low confidence.
+      - windows-install.yml

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -5,6 +5,7 @@
 #   $env:IX_VERSION = "0.9.0-rc.1"   Install a specific release (default: latest
 #                                    stable; required for a release candidate)
 #   $env:IX_HOME    = "C:\ix"        Install root (default: $env:USERPROFILE\.ix)
+#   $env:IX_SKIP_BACKEND = "1"       Install the CLI only, no Docker backend
 # ─────────────────────────────────────────────────────────────────────────────
 
 $ErrorActionPreference = "Stop"
@@ -241,24 +242,43 @@ if ($node) {
 }
 
 # ── Docker ──
+#
+# `IX_SKIP_BACKEND` is not new: install.sh has honoured it since it was written,
+# and it is the very thing install.sh *tells a Windows user to do* when it
+# declines to install Docker for them ("To install the CLI only (no backend):
+# IX_SKIP_BACKEND=1 sh install.sh"). This script never implemented it, so the
+# advice pointed at a flag that did nothing here and there was no way to install
+# the CLI against a memory layer that already exists — a remote endpoint, a
+# backend on another host, or a machine where Docker is managed separately.
+#
+# Both sections are gated, not just the second: `Write-Err` exits, so an absent
+# Docker ends the run before the CLI is ever unpacked.
+$SkipBackend = $env:IX_SKIP_BACKEND -eq "1"
+
 Write-Host "`n-- Docker --"
 
-if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
-    Write-Err "Docker not installed"
+if ($SkipBackend) {
+    Write-Host "  (skipped via IX_SKIP_BACKEND=1)"
+} else {
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+        Write-Err "Docker not installed"
+    }
+
+    Write-Ok "Docker installed"
+
+    if (-not (Test-DockerRunning)) {
+        Write-Err "Docker not running"
+    }
+
+    Write-Ok "Docker running"
 }
-
-Write-Ok "Docker installed"
-
-if (-not (Test-DockerRunning)) {
-    Write-Err "Docker not running"
-}
-
-Write-Ok "Docker running"
 
 # ── Backend ──
 Write-Host "`n-- Backend --"
 
-if (Test-Healthy) {
+if ($SkipBackend) {
+    Write-Host "  (skipped via IX_SKIP_BACKEND=1)"
+} elseif (Test-Healthy) {
     Write-Ok "Backend already running"
 } else {
     New-Item -ItemType Directory -Force -Path $ComposeDir | Out-Null


### PR DESCRIPTION
## The hole

Every Windows install bug this project has shipped got through the same one:
**nothing has ever run `install.ps1`.** The release job packages the CLI on a
Windows runner and stops there, so what each release verified was the
*artifact* — never the script that unpacks it.

Archive nesting, upgrade re-nesting, and the IE-parse prompt were all in that
gap. All three were found by a person installing by hand on v0.9.0-rc.1, and
all three were reported by a user rather than by CI. "A genuinely fresh Windows
install" has been on the pre-GA list ever since, as a manual step, every release.

## Why it could not be tested — `IX_SKIP_BACKEND`

`install.sh` has honoured `IX_SKIP_BACKEND=1` since it was written.
`skills/ix/scripts/bootstrap.sh` honours it. `references/troubleshooting.md`
documents it. And `install.sh` is the script that **tells a Windows user to use
it** when it declines to install Docker for them:

```
  To install the CLI only (no backend):
    IX_SKIP_BACKEND=1 sh install.sh
```

`install.ps1` never implemented it. So that advice pointed at a flag that did
nothing on Windows, and there was no supported way to install the CLI against a
memory layer that already exists — a remote endpoint, a backend on another host,
or a machine where Docker is managed separately.

This adds it, gating **both** the Docker and Backend sections rather than just
the second: `Write-Err` exits, so an absent Docker ended the run before the CLI
was ever unpacked — precisely the part that keeps breaking.

## The test

With the skip in place, CI can run the real script on a real Windows runner.
Every assertion is a bug that actually shipped:

| check | the bug it catches |
|---|---|
| tree is flat, no `ix-<version>-windows-amd64` wrapper | `Expand-Archive` has no `--strip-components` to match install.sh's `tar`; the nested tree breaks `ix view`, which reads `$IX_HOME\cli\compass` and nothing else |
| `bin\ix.cmd` runs, by **absolute path** | a shim that resolves only because the session's PATH happens to be right is not a working install |
| Compass present **and stamped** | an unstamped bundle reads as `0.0.0`, which made `ix upgrade` treat `none -> x` as an upgrade and replace a current Compass with an older dist build |
| the whole thing **again** | re-running is how a user upgrades, and it is the path a first install can never exercise — it is also where the installer historically re-nested the tree it had just laid out flat |
| no `.cli-*` scratch left in `IX_HOME` | #392/#349 moved the scratch out of TEMP; nothing checked that it gets cleaned up |

`IX_HOME` is a path **containing a space**, deliberately: #349 was a profile at
`C:\Users\Win 10`, where Windows handed the installer an 8.3 short path and the
run died after extraction. A test on a space-free path would not have caught it.

## When it runs

- **PRs touching `install.ps1`** — including this one, so the test proves itself
  on a real Windows runner before it merges.
- **On release publish** — the moment the installer's inputs change, and the
  only moment a real user is about to run it against them.
- **On demand**, with a version input, for checking a specific RC.

## What it does not cover

- The **GA re-nesting path** still cannot be reached from a prerelease:
  `/releases/latest` excludes prereleases, so `ix upgrade` correctly declines
  and never re-lays the tree. That check remains manual, immediately after
  tagging GA and before announcing.
- `Test-Healthy`'s IE-parse prompt is skipped along with the backend. It already
  carries `-UseBasicParsing`, so there is nothing live to catch — but this test
  would not notice if that were removed.
- The **backend leg** of the installer is untested here; a Windows runner has no
  Linux Docker.