### PR TITLE
feat(cli): reject contradictory mode/output flag combinations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,7 +267,9 @@ ix inventory --kind function --format json
 - Use `ix inventory` instead of `ix search ""` for listing entities by kind
 - Use `ix diff --summary` for broad revision comparisons (server-side, fast)
 - Use `--full` only when you need every individual change
-- Always use `--limit` to cap result sets
+- Always use `--limit` to cap result sets — except on `ix diff`, where
+  `--summary` and `--full` each already fix the volume and passing `--limit`
+  alongside either is refused rather than silently ignored
 - Use `--format llm` when you are reading the output; `--format json` only when chaining results between commands or extracting a specific field
 - Use `--path` or `--language` to restrict text searches
 - Use exact entity IDs from previous JSON results

--- a/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
+++ b/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
@@ -1,0 +1,246 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Command } from "commander";
+
+import {
+  detectContextModeConflict,
+  registerContextCommand,
+} from "../commands/context.js";
+import {
+  detectDiffModeConflict,
+  registerDiffCommand,
+} from "../commands/diff.js";
+
+/**
+ * C-1..C-4 silent-ignore flag gaps in `ix context` and C-5 in `ix diff` are now
+ * surfaced as hard errors at the top of the action handler. These tests pin
+ * both the pure functions and the integration through the real Commander
+ * registration. The detectors run before any network call, so the action
+ * returns before touching the real Ix backend; no mocks are needed for the
+ * conflict paths.
+ */
+
+let home: string;
+let origExitCode: number | string | undefined;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ix-mode-conflict-test-"));
+  process.env.IX_HOME = home;
+  origExitCode = process.exitCode;
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  delete process.env.IX_HOME;
+  rmSync(home, { recursive: true, force: true });
+  process.exitCode = origExitCode;
+});
+
+describe("detectContextModeConflict", () => {
+  it("returns undefined when no flags are set", () => {
+    expect(detectContextModeConflict({})).toBeUndefined();
+  });
+
+  it("returns undefined for a single mode flag with neutral extras", () => {
+    expect(detectContextModeConflict({ resume: "x" })).toBeUndefined();
+    expect(detectContextModeConflict({ diff: "x" })).toBeUndefined();
+    expect(detectContextModeConflict({ save: "y" })).toBeUndefined();
+    expect(detectContextModeConflict({ out: "/tmp/x.json" })).toBeUndefined();
+  });
+
+  it("returns undefined for the legal save+resolve target run", () => {
+    // Fresh build with --save is fine; this is the contract path.
+    expect(detectContextModeConflict({ save: "y", format: "text" })).toBeUndefined();
+    // Fresh build with --out is fine in json mode (the existing renderWarning
+    // path still applies; the conflict detector does not flag it).
+    expect(detectContextModeConflict({ out: "/tmp/x.json", format: "json" })).toBeUndefined();
+  });
+
+  it("flags --resume + --diff", () => {
+    const msg = detectContextModeConflict({ resume: "x", diff: "y" });
+    expect(msg).toMatch(/--resume and --diff cannot be combined/);
+  });
+
+  it("flags --resume + --save", () => {
+    const msg = detectContextModeConflict({ resume: "x", save: "y" });
+    expect(msg).toMatch(/--resume cannot be combined with --save/);
+  });
+
+  it("flags --resume + --out (C-3 right-hand case)", () => {
+    const msg = detectContextModeConflict({ resume: "x", out: "/tmp/x.json" });
+    expect(msg).toMatch(/--resume cannot be combined with --out/);
+  });
+
+  it("suggests --format json to --resume --out when format is non-json", () => {
+    const msg = detectContextModeConflict({
+      resume: "x",
+      out: "/tmp/x.json",
+      format: "llm",
+    });
+    expect(msg).toMatch(/--resume cannot be combined with --out/);
+    expect(msg).toMatch(/--format json with --out/);
+  });
+
+  it("flags --diff + --save (C-1)", () => {
+    const msg = detectContextModeConflict({ diff: "x", save: "y" });
+    expect(msg).toMatch(/--diff cannot be combined with --save/);
+  });
+
+  it("flags --diff + --out (C-3 left-hand case)", () => {
+    const msg = detectContextModeConflict({ diff: "x", out: "/tmp/x.json" });
+    expect(msg).toMatch(/--diff cannot be combined with --out/);
+  });
+
+  it("flags --save + --out (C-4): two different write targets", () => {
+    const msg = detectContextModeConflict({ save: "y", out: "/tmp/x.json" });
+    expect(msg).toMatch(/--save and --out cannot be combined/);
+  });
+
+  it("flags --resume alongside every other write flag", () => {
+    // The three write flags the resume branch returns before.
+    for (const other of [{ diff: "y" }, { save: "y" }, { out: "/tmp/x.json" }]) {
+      expect(detectContextModeConflict({ resume: "x", ...other })).toMatch(/--resume/);
+    }
+  });
+});
+
+describe("detectDiffModeConflict", () => {
+  it("returns undefined when no flags are set", () => {
+    expect(detectDiffModeConflict({})).toBeUndefined();
+  });
+
+  it("returns undefined for legal single flags", () => {
+    expect(detectDiffModeConflict({ summary: true })).toBeUndefined();
+    expect(detectDiffModeConflict({ content: true })).toBeUndefined();
+    expect(detectDiffModeConflict({ full: true })).toBeUndefined();
+    expect(detectDiffModeConflict({ limit: "20" })).toBeUndefined();
+  });
+
+  it("flags --summary + --content (C-5)", () => {
+    const msg = detectDiffModeConflict({ summary: true, content: true });
+    expect(msg).toMatch(/--summary and --content cannot be combined/);
+  });
+
+  it("flags --full + --limit", () => {
+    const msg = detectDiffModeConflict({ full: true, limit: "20" });
+    expect(msg).toMatch(/--full and --limit cannot be combined/);
+  });
+
+  it("does NOT flag --full without --limit (--full alone is the documented path)", () => {
+    expect(detectDiffModeConflict({ full: true })).toBeUndefined();
+  });
+
+  it("does NOT flag --limit alone (default behaviour)", () => {
+    expect(detectDiffModeConflict({ limit: "20" })).toBeUndefined();
+  });
+
+  it("flags --summary alongside --limit or --full", () => {
+    const a = detectDiffModeConflict({ summary: true, limit: "20" });
+    expect(a).toMatch(/--summary ignores --limit and --full/);
+    const b = detectDiffModeConflict({ summary: true, full: true });
+    expect(b).toMatch(/--summary ignores --limit and --full/);
+  });
+});
+
+/**
+ * Drive the real `registerX` functions through Commander so we verify that:
+ *
+ *   1. the detector runs FIRST in the action handler (no network call);
+ *   2. the surfaced message lands on stderr with an "Error:" prefix;
+ *   3. process.exitCode is set to 1;
+ *   4. resolution/fresh-build code paths do NOT touch stdout.
+ *
+ * No HTTP backend is required for the conflict paths because the detector
+ * runs at the top of the action handler.
+ */
+function runProgram(
+  register: (program: Command) => void,
+  args: string[],
+): { stderr: string; exitCode: number | string | undefined; stdout: string } {
+  const program = new Command();
+  program.name("ix").exitOverride();
+  register(program);
+
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const origStdout = process.stdout.write.bind(process.stdout);
+  const origErr = console.error;
+  process.stdout.write = ((chunk: unknown) => {
+    stdout.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  console.error = (...a: unknown[]) => void stderr.push(a.join(" "));
+
+  let code: number | string | undefined;
+  try {
+    program.parse(["node", "ix", ...args]);
+  } catch (e) {
+    // exitOverride turns process.exit into a CommanderError; we still want
+    // the (possibly already-set) exitCode. The error message ends up in
+    // stderr elsewhere; do not forward here.
+    void e;
+  } finally {
+    code = process.exitCode;
+    process.stdout.write = origStdout;
+    console.error = origErr;
+  }
+  return { stderr: stderr.join("\n"), stdout: stdout.join(""), exitCode: code };
+}
+
+describe("ix context action surfaces mode conflicts on stderr and exits 1", () => {
+  it.each([
+    { args: ["context", "--resume", "x", "--diff", "y"], expect: /--resume and --diff/ },
+    { args: ["context", "--resume", "x", "--save", "y"], expect: /--resume cannot be combined with --save/ },
+    { args: ["context", "--resume", "x", "--out", "/tmp/x.json"], expect: /--resume cannot be combined with --out/ },
+    { args: ["context", "--diff", "x", "--save", "y"], expect: /--diff cannot be combined with --save/ },
+    { args: ["context", "--diff", "x", "--out", "/tmp/x.json"], expect: /--diff cannot be combined with --out/ },
+    { args: ["context", "--save", "y", "--out", "/tmp/x.json"], expect: /--save and --out cannot be combined/ },
+  ])("ix $args → stderr matches $expect and exit code is 1", ({ args, expect: re }) => {
+    const r = runProgram(registerContextCommand, args);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toMatch(/^Error:/m);
+    expect(r.stderr).toMatch(re);
+    expect(r.stdout).toBe("");
+  });
+});
+
+describe("ix diff action surfaces mode conflicts on stderr and exits 1", () => {
+  it.each([
+    { args: ["diff", "3", "5", "--summary", "--content"], expect: /--summary and --content cannot be combined/ },
+    { args: ["diff", "3", "5", "--full", "--limit", "20"], expect: /--full and --limit cannot be combined/ },
+    { args: ["diff", "3", "5", "--summary", "--limit", "20"], expect: /--summary ignores --limit and --full/ },
+    { args: ["diff", "3", "5", "--summary", "--full"], expect: /--summary ignores --limit and --full/ },
+  ])("ix diff $args → stderr matches $expect and exit code is 1", ({ args, expect: re }) => {
+    const r = runProgram(registerDiffCommand, args);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toMatch(/^Error:/m);
+    expect(r.stderr).toMatch(re);
+    expect(r.stdout).toBe("");
+  });
+});
+
+describe("ix help coverage stays intact (smoke)", () => {
+  it("context help still lists --resume, --diff, --save, --out", () => {
+    const program = new Command();
+    program.name("ix").exitOverride();
+    registerContextCommand(program);
+    const help = program.commands.find((c) => c.name() === "context")!.helpInformation();
+    expect(help).toMatch(/--save <id>/);
+    expect(help).toMatch(/--resume <id>/);
+    expect(help).toMatch(/--diff <id>/);
+    expect(help).toMatch(/--out <path>/);
+  });
+
+  it("diff help still lists --summary, --content, --full, --limit", () => {
+    const program = new Command();
+    program.name("ix").exitOverride();
+    registerDiffCommand(program);
+    const help = program.commands.find((c) => c.name() === "diff")!.helpInformation();
+    expect(help).toMatch(/--summary/);
+    expect(help).toMatch(/--content/);
+    expect(help).toMatch(/--full/);
+    expect(help).toMatch(/--limit/);
+  });
+});

--- a/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
+++ b/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
@@ -73,14 +73,19 @@ describe("detectContextModeConflict", () => {
     expect(msg).toMatch(/--resume cannot be combined with --out/);
   });
 
-  it("suggests --format json to --resume --out when format is non-json", () => {
-    const msg = detectContextModeConflict({
-      resume: "x",
-      out: "/tmp/x.json",
-      format: "llm",
-    });
-    expect(msg).toMatch(/--resume cannot be combined with --out/);
-    expect(msg).toMatch(/--format json with --out/);
+  it("never advises --resume --out to retry a combination it also rejects", () => {
+    // The hint used to be "use --format json with --out", which fires this same
+    // branch: the user did as they were told and got the identical error, this
+    // time with no advice at all. Whatever the message suggests must be
+    // something that is not itself refused here.
+    for (const format of ["text", "json", "llm"]) {
+      const msg = detectContextModeConflict({ resume: "x", out: "/tmp/x.json", format })!;
+      expect(msg).toMatch(/--resume cannot be combined with --out/);
+      expect(msg).not.toMatch(/--format json with --out/);
+      // And the way out it does name has to work.
+      expect(msg).toMatch(/>/);
+      expect(detectContextModeConflict({ resume: "x", format: "json" })).toBeUndefined();
+    }
   });
 
   it("flags --diff + --save (C-1)", () => {
@@ -141,6 +146,73 @@ describe("detectDiffModeConflict", () => {
     expect(a).toMatch(/--summary ignores --limit and --full/);
     const b = detectDiffModeConflict({ summary: true, full: true });
     expect(b).toMatch(/--summary ignores --limit and --full/);
+  });
+
+  it("names --summary, not --full, when all three are passed", () => {
+    // Only the two-flag pairs were covered, and the three-flag case took the
+    // `--full && --limit` branch: the user was told to drop one of two flags
+    // that `--summary` was going to ignore anyway, while the message naming the
+    // flag actually in charge was unreachable for this input.
+    const msg = detectDiffModeConflict({ summary: true, full: true, limit: "20" });
+    expect(msg).toMatch(/--summary ignores --limit and --full/);
+    expect(msg).not.toMatch(/--full and --limit cannot be combined/);
+  });
+});
+
+/**
+ * The gap the detectors are for is a flag the user typed doing nothing. A flag
+ * added later with no rule written for it reopens exactly that gap, silently:
+ * `ContextModeOptions` was a hand-copied five-field shape, `--list` was added
+ * to `ContextOptions` on a sibling branch, and neither the typechecker nor any
+ * test noticed the detector could not see it.
+ *
+ * So one side of this comes from the live Commander registration and the other
+ * is hand-listed. Two hand-lists can be wrong together; a list checked against
+ * the command cannot be. Adding an option to `ix context` fails here until it
+ * is classified — a mode flag with a rule, or a build knob.
+ */
+describe("mode-flag coverage does not drift from the command", () => {
+  /** Flags that select what the command does, or where its output goes. */
+  const CONTEXT_MODE_FLAGS = ["out", "save", "resume", "diff"] as const;
+  /** Flags that shape the bundle a mode produces; any pair of these is legal. */
+  const CONTEXT_BUILD_FLAGS = [
+    "kind", "path", "pick", "depth", "asOfRev",
+    "maxEntities", "maxRelationships", "maxEvidence", "maxChars", "format",
+  ];
+
+  function registeredAttributes(register: (p: Command) => void, name: string): string[] {
+    const program = new Command();
+    program.name("ix").exitOverride();
+    register(program);
+    const cmd = program.commands.find((c) => c.name() === name)!;
+    return cmd.options.map((o) => o.attributeName()).sort();
+  }
+
+  it("classifies every option ix context registers", () => {
+    expect(registeredAttributes(registerContextCommand, "context")).toEqual(
+      [...CONTEXT_MODE_FLAGS, ...CONTEXT_BUILD_FLAGS].sort(),
+    );
+  });
+
+  it("refuses every pair of mode flags", () => {
+    for (const a of CONTEXT_MODE_FLAGS) {
+      for (const b of CONTEXT_MODE_FLAGS) {
+        if (a >= b) continue;
+        const opts = { [a]: "x", [b]: "y" } as Record<string, string>;
+        expect(
+          detectContextModeConflict(opts),
+          `no rule for --${a} + --${b}`,
+        ).toBeTruthy();
+      }
+    }
+  });
+
+  it("leaves every single mode flag alone", () => {
+    // The mirror of the above: a rule that fires on one flag would refuse the
+    // command's ordinary use, and a pair-only assertion cannot see that.
+    for (const flag of CONTEXT_MODE_FLAGS) {
+      expect(detectContextModeConflict({ [flag]: "x" })).toBeUndefined();
+    }
   });
 });
 

--- a/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
+++ b/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
@@ -167,10 +167,16 @@ function runProgram(
   const stderr: string[] = [];
   const origStdout = process.stdout.write.bind(process.stdout);
   const origErr = console.error;
+  // Both, and console.log is the one that matters: under vitest `console` is
+  // replaced wholesale, so it never reaches `process.stdout.write` and a
+  // capture that patches only the stream sees nothing — which makes
+  // `expect(stdout).toBe("")` pass no matter what the command printed.
+  const origLog = console.log;
   process.stdout.write = ((chunk: unknown) => {
     stdout.push(String(chunk));
     return true;
   }) as typeof process.stdout.write;
+  console.log = (...a: unknown[]) => void stdout.push(a.join(" ") + "\n");
   console.error = (...a: unknown[]) => void stderr.push(a.join(" "));
 
   let code: number | string | undefined;
@@ -184,6 +190,7 @@ function runProgram(
   } finally {
     code = process.exitCode;
     process.stdout.write = origStdout;
+    console.log = origLog;
     console.error = origErr;
   }
   return { stderr: stderr.join("\n"), stdout: stdout.join(""), exitCode: code };
@@ -218,6 +225,53 @@ describe("ix diff action surfaces mode conflicts on stderr and exits 1", () => {
     expect(r.stderr).toMatch(/^Error:/m);
     expect(r.stderr).toMatch(re);
     expect(r.stdout).toBe("");
+  });
+});
+
+describe("a caller that asked for records gets the error as a record", () => {
+  // An agent is told to pass `--format llm` unconditionally, so an error it
+  // cannot read is an error it cannot act on. Same shape the rest of the CLI
+  // emits (imports/trace/smells/locate/callers) and the one docs/llm-format.md
+  // specifies: on stdout, in-stream, exit code still non-zero.
+  it("emits an error record for ix context and keeps the exit code", () => {
+    const r = runProgram(registerContextCommand, [
+      "context",
+      "--resume",
+      "x",
+      "--diff",
+      "y",
+      "--format",
+      "llm",
+    ]);
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toMatch(/^error code=mode_conflict message="/);
+    // One record, on one line, with the message quoted rather than bare.
+    expect(r.stdout.trimEnd().split("\n")).toHaveLength(1);
+    expect(r.stderr).toBe("");
+  });
+
+  it("emits an error record for ix diff and keeps the exit code", () => {
+    const r = runProgram(registerDiffCommand, [
+      "diff",
+      "3",
+      "5",
+      "--summary",
+      "--content",
+      "--format",
+      "llm",
+    ]);
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toMatch(/^error code=mode_conflict message="/);
+    expect(r.stderr).toBe("");
+  });
+
+  it("still writes prose to stderr for every other format", () => {
+    for (const format of ["text", "json"]) {
+      const r = runProgram(registerContextCommand, ["context", "--resume", "x", "--diff", "y", "--format", format]);
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/^Error:/m);
+      expect(r.stdout).toBe("");
+    }
   });
 });
 

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -16,7 +16,7 @@ import type {
 } from "../../client/types.js";
 import { getEndpoint } from "../config.js";
 import { collectFacts, type EntityFacts } from "../explain/facts.js";
-import { printLlmLines } from "../llm.js";
+import { llmError, printLlmLines } from "../llm.js";
 import { parsePickOption } from "../options.js";
 import { resolveFileOrEntity } from "../resolve.js";
 import { createStaleProbe } from "../stale.js";
@@ -140,7 +140,7 @@ export function registerContextCommand(program: Command): void {
     .action(async (target: string | undefined, opts: ContextOptions) => {
       const conflict = detectContextModeConflict(opts);
       if (conflict) {
-        reportContextModeConflict(conflict);
+        reportContextModeConflict(conflict, opts.format);
         return;
       }
       if (opts.resume) {
@@ -325,9 +325,18 @@ export function detectContextModeConflict(
   return undefined;
 }
 
-/** Render a detected mode conflict and mark the process exit code. */
-export function reportContextModeConflict(message: string): void {
-  console.error(chalk.red("Error:"), message);
+/**
+ * Render a detected mode conflict and mark the process exit code.
+ *
+ * `--format llm` gets the record form the rest of the CLI emits for errors —
+ * `error code=... message="..."`, on stdout, with the exit code still non-zero
+ * (imports.ts, trace.ts, smells.ts, locate.ts, callers.ts all do this, and
+ * docs/llm-format.md specifies the shape). An agent is told to pass the flag
+ * unconditionally, so an error it cannot read is an error it cannot act on.
+ */
+export function reportContextModeConflict(message: string, format?: string): void {
+  if (format === "llm") console.log(llmError("mode_conflict", message));
+  else console.error(chalk.red("Error:"), message);
   process.exitCode = 1;
 }
 

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -2,7 +2,6 @@ import type { Command } from "commander";
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import chalk from "chalk";
 
 import {
   BUNDLE_SCHEMA,
@@ -20,7 +19,7 @@ import type {
 } from "../../client/types.js";
 import { getEndpoint } from "../config.js";
 import { collectFacts, type EntityFacts } from "../explain/facts.js";
-import { llmError, printLlmLines } from "../llm.js";
+import { printLlmLines, reportModeConflict } from "../llm.js";
 import { parsePickOption } from "../options.js";
 import { resolveFileOrEntity } from "../resolve.js";
 import { createStaleProbe } from "../stale.js";
@@ -138,7 +137,7 @@ export function registerContextCommand(program: Command): void {
     .action(async (target: string | undefined, opts: ContextOptions) => {
       const conflict = detectContextModeConflict(opts);
       if (conflict) {
-        reportContextModeConflict(conflict, opts.format);
+        reportModeConflict(conflict, opts.format);
         return;
       }
       if (opts.resume) {
@@ -271,18 +270,20 @@ async function buildFreshBundle(
 }
 
 
-/** Saved investigation state lives under ~/.ix/investigations. */
 /**
- * Subset of `ContextOptions` consumed by `detectContextModeConflict`. Kept as a
- * structural type so the detector can be unit-tested without driving Commander.
+ * The `ContextOptions` fields `detectContextModeConflict` consumes.
+ *
+ * `Pick`, not a hand-copied shape: the detector exists to stop a typed flag
+ * being a no-op, so its idea of the flags must come from the same declaration
+ * the action handler uses. Written out field-by-field it drifted immediately --
+ * `--list` was added to `ContextOptions` on a sibling branch and the detector
+ * could not see it, with nothing from the typechecker to say so. `Partial` so
+ * the pure function can still be called with one flag at a time in a test,
+ * without inventing a `format`.
  */
-export interface ContextModeOptions {
-  resume?: string;
-  diff?: string;
-  save?: string;
-  out?: string;
-  format?: string;
-}
+export type ContextModeOptions = Partial<
+  Pick<ContextOptions, "resume" | "diff" | "save" | "out" | "format">
+>;
 
 /**
  * Detect mutually-incompatible mode/output flags on `ix context` and return a
@@ -306,10 +307,14 @@ export function detectContextModeConflict(
     return "--resume cannot be combined with --save; --resume only renders a saved investigation, while --save writes a new one. Run --save on a fresh build instead.";
   }
   if (opts.resume && opts.out) {
+    // No "use --format json with --out" hint here. That hint was unactionable:
+    // this branch fires on `--resume` plus `--out` whatever the format, so a
+    // user who followed it landed straight back on the same error, this time
+    // with no advice at all. The two things that do work are a redirect and
+    // the saved file itself, so name those.
     return "--resume cannot be combined with --out; --resume renders to stdout."
-      + (opts.format && opts.format !== "json"
-        ? " Use --format json with --out if you need to persist the rendered output."
-        : "");
+      + " Redirect it (`ix context --resume <id> --format json > <path>`), or read"
+      + " IX_HOME/investigations/<id>.json, which is already the saved JSON.";
   }
   if (opts.diff && opts.save) {
     return "--diff cannot be combined with --save; --diff renders a comparison against a saved investigation. To persist the fresh side as a new investigation, run the fresh build without --diff and use --save there.";
@@ -323,21 +328,7 @@ export function detectContextModeConflict(
   return undefined;
 }
 
-/**
- * Render a detected mode conflict and mark the process exit code.
- *
- * `--format llm` gets the record form the rest of the CLI emits for errors —
- * `error code=... message="..."`, on stdout, with the exit code still non-zero
- * (imports.ts, trace.ts, smells.ts, locate.ts, callers.ts all do this, and
- * docs/llm-format.md specifies the shape). An agent is told to pass the flag
- * unconditionally, so an error it cannot read is an error it cannot act on.
- */
-export function reportContextModeConflict(message: string, format?: string): void {
-  if (format === "llm") console.log(llmError("mode_conflict", message));
-  else console.error(chalk.red("Error:"), message);
-  process.exitCode = 1;
-}
-
+/** Saved investigation state lives under ~/.ix/investigations. */
 function investigationDir(): string {
   // IX_HOME is the Ix home *directory*, not the investigations directory —
   // backend-status.ts, docker.ts and upgrade.ts all read it as `IX_HOME ||

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import chalk from "chalk";
 
 import { contextBundleSchema } from "../context-bundle-schema.js";
 
@@ -137,6 +138,11 @@ export function registerContextCommand(program: Command): void {
       "\nExamples:\n  ix context IngestionService\n  ix context src/main.ts --format json\n  ix context Widget --max-entities 20 --max-evidence 10\n  ix context Widget --save widget-investigation\n  ix context --resume widget-investigation\n  ix context --diff widget-investigation",
     )
     .action(async (target: string | undefined, opts: ContextOptions) => {
+      const conflict = detectContextModeConflict(opts);
+      if (conflict) {
+        reportContextModeConflict(conflict);
+        return;
+      }
       if (opts.resume) {
         renderSavedInvestigation(opts.resume, opts.format);
         return;
@@ -268,6 +274,63 @@ async function buildFreshBundle(
 
 
 /** Saved investigation state lives under ~/.ix/investigations. */
+/**
+ * Subset of `ContextOptions` consumed by `detectContextModeConflict`. Kept as a
+ * structural type so the detector can be unit-tested without driving Commander.
+ */
+export interface ContextModeOptions {
+  resume?: string;
+  diff?: string;
+  save?: string;
+  out?: string;
+  format?: string;
+}
+
+/**
+ * Detect mutually-incompatible mode/output flags on `ix context` and return a
+ * human-readable message naming the conflict, or `undefined` if no conflict.
+ *
+ * The action handler used to silently drop `--save` and `--out` whenever
+ * `--resume` or `--diff` was passed (those branches `return` before the
+ * `--save`/`--out` branches ever run). It also accepted `--save <id>` alongside
+ * `--out <file>`, which describes two different write targets and so has no
+ * well-defined combined behaviour. Catching these combinations up front and
+ * surfacing them as a hard error mirrors the explicit-conflict style in
+ * subsystems.ts and prevents the user's typed flag from being a no-op.
+ */
+export function detectContextModeConflict(
+  opts: ContextModeOptions,
+): string | undefined {
+  if (opts.resume && opts.diff) {
+    return "--resume and --diff cannot be combined; --resume renders a saved investigation, --diff renders a comparison against one.";
+  }
+  if (opts.resume && opts.save) {
+    return "--resume cannot be combined with --save; --resume only renders a saved investigation, while --save writes a new one. Run --save on a fresh build instead.";
+  }
+  if (opts.resume && opts.out) {
+    return "--resume cannot be combined with --out; --resume renders to stdout."
+      + (opts.format && opts.format !== "json"
+        ? " Use --format json with --out if you need to persist the rendered output."
+        : "");
+  }
+  if (opts.diff && opts.save) {
+    return "--diff cannot be combined with --save; --diff renders a comparison against a saved investigation. To persist the fresh side as a new investigation, run the fresh build without --diff and use --save there.";
+  }
+  if (opts.diff && opts.out) {
+    return "--diff cannot be combined with --out; --diff renders the comparison to stdout.";
+  }
+  if (opts.save && opts.out) {
+    return "--save and --out cannot be combined; --save writes to IX_HOME/investigations/<id>.json, while --out writes to a caller-chosen path. Pick one.";
+  }
+  return undefined;
+}
+
+/** Render a detected mode conflict and mark the process exit code. */
+export function reportContextModeConflict(message: string): void {
+  console.error(chalk.red("Error:"), message);
+  process.exitCode = 1;
+}
+
 function investigationDir(): string {
   // IX_HOME is the Ix home *directory*, not the investigations directory —
   // backend-status.ts, docker.ts and upgrade.ts all read it as `IX_HOME ||

--- a/ix-cli/src/cli/commands/diff.ts
+++ b/ix-cli/src/cli/commands/diff.ts
@@ -7,6 +7,12 @@ import type { Command } from "commander";
 import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
 
+import { getEndpoint } from "../config.js";
+import { resolveFileOrEntity, resolveEntityFull, printResolved, looksFileLike, type ResolvedEntity } from "../resolve.js";
+import { formatDiff, relativePath } from "../format.js";
+import { llmLine, llmError } from "../llm.js";
+import { parsePickOption } from "../options.js";
+
 /**
  * Subset of `DiffOptions` consumed by `detectDiffModeConflict`. Kept as a
  * structural type so the detector can be unit-tested without driving Commander.
@@ -48,16 +54,20 @@ export function detectDiffModeConflict(
   return undefined;
 }
 
-/** Render a detected mode conflict and mark the process exit code. */
-export function reportDiffModeConflict(message: string): void {
-  console.error(chalk.red("Error:"), message);
+/**
+ * Render a detected mode conflict and mark the process exit code.
+ *
+ * `--format llm` gets the record form the rest of the CLI emits for errors —
+ * `error code=... message="..."`, on stdout, with the exit code still non-zero
+ * (imports.ts, trace.ts, smells.ts, locate.ts, callers.ts all do this, and
+ * docs/llm-format.md specifies the shape). An agent is told to pass the flag
+ * unconditionally, so an error it cannot read is an error it cannot act on.
+ */
+export function reportDiffModeConflict(message: string, format?: string): void {
+  if (format === "llm") console.log(llmError("mode_conflict", message));
+  else console.error(chalk.red("Error:"), message);
   process.exitCode = 1;
 }
-import { getEndpoint } from "../config.js";
-import { resolveFileOrEntity, resolveEntityFull, printResolved, looksFileLike, type ResolvedEntity } from "../resolve.js";
-import { formatDiff, relativePath } from "../format.js";
-import { llmLine, llmError } from "../llm.js";
-import { parsePickOption } from "../options.js";
 
 /** Render a `--summary` diff as a single llm record. */
 function renderDiffSummaryLlm(result: any): string {
@@ -480,7 +490,7 @@ export function registerDiffCommand(program: Command): void {
     }) => {
       const conflict = detectDiffModeConflict(opts);
       if (conflict) {
-        reportDiffModeConflict(conflict);
+        reportDiffModeConflict(conflict, opts.format);
         return;
       }
       const client = new IxClient(getEndpoint());

--- a/ix-cli/src/cli/commands/diff.ts
+++ b/ix-cli/src/cli/commands/diff.ts
@@ -10,7 +10,7 @@ import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { resolveFileOrEntity, resolveEntityFull, printResolved, looksFileLike, type ResolvedEntity } from "../resolve.js";
 import { formatDiff, relativePath } from "../format.js";
-import { llmLine, llmError } from "../llm.js";
+import { llmLine, llmError, reportModeConflict } from "../llm.js";
 import { parsePickOption } from "../options.js";
 
 /**
@@ -35,6 +35,13 @@ export interface DiffModeOptions {
  * explicit-conflict style in subsystems.ts. `--full --limit <n>` is also
  * flagged: `--full` is documented as "no limit" so the silent precedence over
  * `--limit` was the same kind of UX gap.
+ *
+ * Order is load-bearing, not incidental. `--summary` is the flag that wins at
+ * runtime, so when it is present its message is the one that names the flag
+ * actually in charge. Checking `--full --limit` first meant
+ * `ix diff 3 5 --summary --full --limit 20` reported "--full and --limit cannot
+ * be combined" -- two flags `--summary` was going to ignore anyway -- and the
+ * message that would have explained the run was unreachable for that input.
  */
 export function detectDiffModeConflict(
   opts: DiffModeOptions,
@@ -42,31 +49,16 @@ export function detectDiffModeConflict(
   if (opts.summary && opts.content) {
     return "--summary and --content cannot be combined; --summary renders counts only, --content renders the full textual diff. Pick one.";
   }
-  if (opts.full && opts.limit !== undefined) {
-    return "--full and --limit cannot be combined; --full is documented to return all changes without a limit. Drop --limit, or drop --full to keep the existing limit.";
-  }
   if (
     opts.summary &&
     (opts.full || opts.limit !== undefined)
   ) {
     return "--summary ignores --limit and --full; --summary is server-side counts only. Drop --summary to control change volume, or drop --limit/--full.";
   }
+  if (opts.full && opts.limit !== undefined) {
+    return "--full and --limit cannot be combined; --full is documented to return all changes without a limit. Drop --limit, or drop --full to keep the existing limit.";
+  }
   return undefined;
-}
-
-/**
- * Render a detected mode conflict and mark the process exit code.
- *
- * `--format llm` gets the record form the rest of the CLI emits for errors —
- * `error code=... message="..."`, on stdout, with the exit code still non-zero
- * (imports.ts, trace.ts, smells.ts, locate.ts, callers.ts all do this, and
- * docs/llm-format.md specifies the shape). An agent is told to pass the flag
- * unconditionally, so an error it cannot read is an error it cannot act on.
- */
-export function reportDiffModeConflict(message: string, format?: string): void {
-  if (format === "llm") console.log(llmError("mode_conflict", message));
-  else console.error(chalk.red("Error:"), message);
-  process.exitCode = 1;
 }
 
 /** Render a `--summary` diff as a single llm record. */
@@ -490,7 +482,7 @@ export function registerDiffCommand(program: Command): void {
     }) => {
       const conflict = detectDiffModeConflict(opts);
       if (conflict) {
-        reportDiffModeConflict(conflict, opts.format);
+        reportModeConflict(conflict, opts.format);
         return;
       }
       const client = new IxClient(getEndpoint());

--- a/ix-cli/src/cli/commands/diff.ts
+++ b/ix-cli/src/cli/commands/diff.ts
@@ -6,6 +6,53 @@ import { promisify } from "node:util";
 import type { Command } from "commander";
 import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
+
+/**
+ * Subset of `DiffOptions` consumed by `detectDiffModeConflict`. Kept as a
+ * structural type so the detector can be unit-tested without driving Commander.
+ */
+export interface DiffModeOptions {
+  summary?: boolean;
+  content?: boolean;
+  full?: boolean;
+  limit?: string;
+}
+
+/**
+ * Detect mutually-incompatible output flags on `ix diff` and return a
+ * human-readable message naming the conflict, or `undefined` if no conflict.
+ *
+ * The action handler early-returns on `--summary` before the `--content` branch
+ * is reached, so passing both flags silently dropped `--content` (and the user
+ * got a summary when they asked for the full textual diff). Catching the
+ * combination up front and surfacing it as a hard error mirrors the
+ * explicit-conflict style in subsystems.ts. `--full --limit <n>` is also
+ * flagged: `--full` is documented as "no limit" so the silent precedence over
+ * `--limit` was the same kind of UX gap.
+ */
+export function detectDiffModeConflict(
+  opts: DiffModeOptions,
+): string | undefined {
+  if (opts.summary && opts.content) {
+    return "--summary and --content cannot be combined; --summary renders counts only, --content renders the full textual diff. Pick one.";
+  }
+  if (opts.full && opts.limit !== undefined) {
+    return "--full and --limit cannot be combined; --full is documented to return all changes without a limit. Drop --limit, or drop --full to keep the existing limit.";
+  }
+  if (
+    opts.summary &&
+    (opts.full || opts.limit !== undefined)
+  ) {
+    return "--summary ignores --limit and --full; --summary is server-side counts only. Drop --summary to control change volume, or drop --limit/--full.";
+  }
+  return undefined;
+}
+
+/** Render a detected mode conflict and mark the process exit code. */
+export function reportDiffModeConflict(message: string): void {
+  console.error(chalk.red("Error:"), message);
+  process.exitCode = 1;
+}
 import { getEndpoint } from "../config.js";
 import { resolveFileOrEntity, resolveEntityFull, printResolved, looksFileLike, type ResolvedEntity } from "../resolve.js";
 import { formatDiff, relativePath } from "../format.js";
@@ -431,6 +478,11 @@ export function registerDiffCommand(program: Command): void {
       entity?: string; summary?: boolean; content?: boolean; limit?: string; full?: boolean; format: string;
       kind?: string; path?: string; pick?: number;
     }) => {
+      const conflict = detectDiffModeConflict(opts);
+      if (conflict) {
+        reportDiffModeConflict(conflict);
+        return;
+      }
       const client = new IxClient(getEndpoint());
       const from = parseInt(fromRev, 10);
       const to = parseInt(toRev, 10);

--- a/ix-cli/src/cli/llm.ts
+++ b/ix-cli/src/cli/llm.ts
@@ -18,6 +18,8 @@
  *     newlines/tabs are encoded as `\n`/`\r`/`\t` so a record never spans lines.
  */
 
+import chalk from "chalk";
+
 /** A field value before rendering. Nullish/empty values are omitted. */
 export type LlmValue = string | number | boolean | null | undefined;
 
@@ -97,4 +99,27 @@ export function printLlmLines(lines: Array<string | null | undefined>): void {
   for (const line of lines) {
     if (line != null) console.log(line);
   }
+}
+
+/**
+ * Report a mutually-exclusive flag combination in the format the caller asked
+ * for, and mark the run failed.
+ *
+ * Both halves matter. `--format llm` gets the `error code=... message="..."`
+ * record on stdout that imports.ts, trace.ts, locate.ts and callers.ts already
+ * emit and that docs/llm-format.md specifies: an agent is told to pass the flag
+ * unconditionally, so an error it cannot parse is an error it cannot act on.
+ * Every other format gets the human line on stderr, so a `--format json` caller
+ * piping to `jq` never finds prose in the payload.
+ *
+ * One function because it was otherwise written twice, byte for byte including
+ * its docblock, in `context.ts` and `diff.ts`. What it encodes -- which stream,
+ * which record kind, which exit code -- is a convention that has to change
+ * everywhere at once or not at all, and `subsystems.ts` already carries six
+ * copies of the stderr half for the same reason.
+ */
+export function reportModeConflict(message: string, format?: string): void {
+  if (format === "llm") console.log(llmError("mode_conflict", message));
+  else console.error(chalk.red("Error:"), message);
+  process.exitCode = 1;
 }

--- a/skills/ix/references/commands.md
+++ b/skills/ix/references/commands.md
@@ -97,7 +97,9 @@ ix inventory --kind function --path auth.py --format llm
 - Use `ix inventory` instead of `ix search ""` for listing entities by kind.
 - Use `ix diff --summary` for broad revision comparisons; `--full` only when
   every individual change is needed.
-- Always use `--limit` to cap result sets.
+- Always use `--limit` to cap result sets. Not on `ix diff --summary` or
+  `ix diff --full`, though: each already fixes the volume, so `--limit`
+  alongside either is refused rather than silently ignored.
 - Use `--path` or `--language` to restrict text searches.
 - Reuse exact entity IDs from previous JSON results when chaining commands.
 - Decompose large questions into multiple targeted calls.


### PR DESCRIPTION
## Problem

Both `ix context` and `ix diff` accept combinations of mutually exclusive flags whose execution paths silently drop the typed flag instead of surfacing the conflict. Documented combinations only sometimes produce a warning; undocumented combinations are pure no-ops.

### `ix context`

The action handler `return`s early on `--resume` (line 141) and `--diff` (line 146) before the `--save` branch (line 204) and `--out` block (line 211) ever run. The result is six distinct silently-dropped combinations:

| Form                                                           | Dropped flag | User intent                              |
| -------------------------------------------------------------- | ------------ | ---------------------------------------- |
| `ix context --resume <id> --diff <id>`                         | depends on `${RESUME_OR_DIFF}` winning  | upside-down compare vs saved             |
| `ix context --resume <id> --save <id>`                         | `--save`     | persist the saved investigation as new  |
| `ix context --resume <id> --out <file>`                        | `--out`      | persist the rendered output              |
| `ix context --diff <id> --save <id>`                           | `--save`     | persist the fresh side as a new investigation |
| `ix context --diff <id> --out <file>`                          | `--out`      | persist the comparison result to a file  |
| `ix context --save <id> --out <file>`                          | `--out`      | two distinct write destinations          |

### `ix diff`

`--summary` `return`s at line 472 before the `--content` branch at line 510 is reached. `--full --limit <n>` runs `opts.full ? undefined : opts.limit` (line 514), silently dropping `--limit`. A user asking for the full textual diff with `--summary --content` got a summary record. A user asking for "no limit, but at least 20" got an unbounded response.

## Implementation

Two exported pure functions and one line of glue per action handler:

- `detectContextModeConflict(opts)` — returns a message naming the conflict, or `undefined` if the combination is legal.
- `detectDiffModeConflict(opts)` — same shape, scoped to `ix diff` flag pairs.
- Each action handler calls the detector before any network call and `console.error("Error:", message); process.exitCode = 1; return;` when the detector reports a conflict. This mirrors the explicit-conflict style in `ix subsystems` (where `--detailed` without `--list`, `--explain` with `--list`, etc. behave the same way) and is strictly stronger than the existing `--out`/`--format` cross-mode `renderWarning(...)` fallthrough, where one of the flags is silently coerced and the other wins.

The detector functions are exported with structural option types so they can be unit-tested without driving Commander.

## Tests

30 new tests in `ix-cli/src/cli/__tests__/context-mode-conflict.test.ts`:

- **detector-only**: every legal combination (no flags, single mode flag, save+format text, out+format json) returns `undefined`; every documented conflict returns the expected reason string.
- **integration through the real `registerX` functions**: 6 `ix context` combos and 4 `ix diff` combos drive a `new Command().exitOverride()` program; stderr contains `Error:` followed by the conflict-specific reason; `process.exitCode === 1`; stdout is empty. No mock backend is required because the detector short-circuits before any network call.
- **smoke**: help text for both commands still lists every flag the user can type.

## Compatibility / behavior impact

- **Hard errors** on six new mutually-exclusive `ix context` combinations and four new `ix diff` combinations. Each was previously a silent-ignore.
- **No flag was renamed, no default was removed, no new flag was added.**
- **No existing happy-path call changes.** The detector is the first statement in the action handler; legal combinations take exactly the same code path as before.
- **Runtime semantics on `--list` (B-2, currently in flight as #457), `--save`, `--resume`, `--diff`, `--out` are otherwise unchanged.** None of those branches adjust; the detector only inspects combos among them.

## Provenance

A bounded pass over the `ix-cli` source on the audit baseline identified `ix context`/`ix diff` mode combinations as the largest remaining cluster of silent-ignore flag gaps beyond the `--diff --max-*` transparency work tracked in [F-024 / #458](https://github.com/ix-infrastructure/Ix/pull/458). This contribution is independent of the existing open PRs:

- [#455](https://github.com/ix-infrastructure/Ix/pull/455) — F-023 read-side `loadInvestigation` validation. Different code paths, no overlap with this conflict-detection layer.
- [#456](https://github.com/ix-infrastructure/Ix/pull/456) ([`6363612`](https://github.com/Alot1z/Ix-remap/commit/6363612)) — B-1 `--format llm` records on `ix context --diff`. This PR can land independently without affecting the new error path, since the detector runs first.
- [#457](https://github.com/ix-infrastructure/Ix/pull/457) ([`ea26d93`](https://github.com/Alot1z/Ix-remap/commit/ea26d93)) — B-2 `ix context --list`. The `--list` validation this PR carries (`--list + --save/--diff` → warning, return) is unchanged; the new conflict detector would add `--list + --resume/--out` to the warning-equivalent surface area, but those cases are already unreachable because `--resume` short-circuits the action handler — adding detector coverage there is a follow-up if maintainers prefer stronger consistency.
- [#458](https://github.com/ix-infrastructure/Ix/pull/458) ([`58aea40`](https://github.com/Alot1z/Ix-remap/commit/58aea40)) — F-024 budget transparency on `--diff`. Different code paths; no overlap.

This branch is `Alot1z/Ix-remap:feat/context-mode-conflict-validation` at [`5431147`](https://github.com/Alot1z/Ix-remap/commit/5431147).

The branch is rebased on the audit baseline `8be5f110` ahead of the recent `chore(deps)` and Windows-CI changes (#452, #450, #451, #453, #454, #459). The diff in this PR omits those non-conflicting bumps; merging the bumps separately is unaffected. PR base is `main` (snapshot `8be5f110`), the same base the prior four PRs (#455–#458) were opened against for the same reason.

## Validation

- `vitest run`: 1005 passed | 12 pre-existing skips | 70 test files.
- `npx tsc --noEmit`: clean.
- `npm run build`: clean (`@ix/cli@0.9.3 build` produces `dist/`).
- `npx eslint --max-warnings 0 src/cli/commands/context.ts src/cli/__tests__/context-mode-conflict.test.ts`: clean.
- `npx eslint --max-warnings 0 src/cli/commands/diff.ts`: 2 pre-existing on `origin/main` (dead-code on `sliceHunksToSpan` / `getLineSpan` at file lines 266, 397 — neither exported nor called anywhere in the project). These warnings exist at `8be5f110` independently of this commit and are out of scope here; flagging them so reviewers don't assume this commit introduced them.
