### PR TITLE
feat(context): add `ix context --list` for discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,7 +267,9 @@ ix inventory --kind function --format json
 - Use `ix inventory` instead of `ix search ""` for listing entities by kind
 - Use `ix diff --summary` for broad revision comparisons (server-side, fast)
 - Use `--full` only when you need every individual change
-- Always use `--limit` to cap result sets
+- Always use `--limit` to cap result sets — except on `ix diff`, where
+  `--summary` and `--full` each already fix the volume and passing `--limit`
+  alongside either is refused rather than silently ignored
 - Use `--format llm` when you are reading the output; `--format json` only when chaining results between commands or extracting a specific field
 - Use `--path` or `--language` to restrict text searches
 - Use exact entity IDs from previous JSON results

--- a/docs/llm-format.md
+++ b/docs/llm-format.md
@@ -83,6 +83,21 @@ contains method=12 field=4
 item name=parseFile kind=method
 ```
 
+`ix context --list`:
+
+```
+investigations total=2 skipped=1
+investigation id=widget saved_at=2026-01-03T09:12:44.108Z target=Widget target_kind=class classification=current entities=12 relationships=20 evidence=8
+investigation id=auth-path saved_at=2026-01-02T17:03:11.882Z target=verify_token target_kind=function classification=stale stale=true entities=31 relationships=64 evidence=25 truncated_evidence=4
+```
+
+`skipped` counts saved files that did not match the contract and is present
+only when it is non-zero — it is the one thing about a listing that cannot be
+seen from the records themselves. `id` is the id `--resume` and `--diff` take,
+not the file name on disk; the two differ whenever an id contains a character
+outside `[A-Za-z0-9._-]`. The counts describe each bundle; the bundles
+themselves are not in the listing, and `ix context --resume <id>` fetches one.
+
 Error line:
 
 ```

--- a/ix-cli/src/cli/__tests__/context-investigation.test.ts
+++ b/ix-cli/src/cli/__tests__/context-investigation.test.ts
@@ -426,15 +426,87 @@ describe("ix context investigation state", () => {
   // Without it, neither humans nor agents can see what they have stored —
   // the only path was reading the JSON files directly.
   describe("listInvestigations", () => {
+    /**
+     * Run `fn` with stdout and stderr captured separately.
+     *
+     * One helper for the whole block, and multi-arg calls joined with a space
+     * the way a terminal shows them: the two ad-hoc capturers this replaces
+     * disagreed on that (one joined, one pushed each argument as its own line),
+     * so identical output produced different arrays depending on which test you
+     * happened to be reading.
+     */
+    const captureStreams = (fn: () => void) => {
+      const out: string[] = [];
+      const err: string[] = [];
+      const origLog = console.log;
+      const origErr = console.error;
+      console.log = (...a: unknown[]) => void out.push(a.join(" "));
+      console.error = (...a: unknown[]) => void err.push(a.join(" "));
+      try {
+        fn();
+      } finally {
+        console.log = origLog;
+        console.error = origErr;
+      }
+      return { out: out.join("\n"), err: err.join("\n") };
+    };
+
+    /** Restamp a saved investigation's `savedAt`, leaving everything else alone. */
+    const stampSavedAt = (id: string, savedAt: string) => {
+      const path = join(investigationsDir(), `${id}.json`);
+      const state = JSON.parse(readFileSync(path, "utf8"));
+      writeFileSync(path, JSON.stringify({ ...state, savedAt }), "utf8");
+    };
+
     it("returns saved investigations newest-first", () => {
+      // The timestamps are set explicitly because `saveInvestigation` stamps
+      // them from the clock and three writes inside one millisecond is the
+      // ordinary case, not the rare one. The previous version of this test
+      // asserted `saved[0].id === "widget-a" || saved[0].id === "widget-b"` and
+      // called `.sort()` on the ids before comparing them, so it was true for
+      // either order: inverting the comparator left every assertion green and
+      // ordering — the function's whole stated purpose — had no coverage.
       saveInvestigation("widget-a", bundleWith([makeClaim("renders to DOM", 0.9)]));
       saveInvestigation("widget-b", bundleWith([makeClaim("mounts to DOM", 0.7)]));
+      saveInvestigation("widget-c", bundleWith([makeClaim("unmounts cleanly", 0.5)]));
+      stampSavedAt("widget-a", "2026-01-02T00:00:00.000Z");
+      stampSavedAt("widget-b", "2026-01-03T00:00:00.000Z");
+      stampSavedAt("widget-c", "2026-01-01T00:00:00.000Z");
+
       const list = listInvestigations();
-      expect(list.saved.map((s) => s.id).sort()).toEqual(["widget-a", "widget-b"]);
+      expect(list.saved.map((s) => s.id)).toEqual(["widget-b", "widget-a", "widget-c"]);
       expect(list.skipped).toBe(0);
-      // savedAt differs at least by a millisecond across the two writes; even
-      // on the rare same-ms tie the id tiebreaker keeps order deterministic.
-      expect(list.saved[0].id === "widget-a" || list.saved[0].id === "widget-b").toBe(true);
+    });
+
+    it("breaks a same-millisecond tie on the id, stably", () => {
+      // The reason the comparator has a second clause at all: two saves in the
+      // same millisecond must still come back in the same order every run.
+      for (const id of ["widget-c", "widget-a", "widget-b"]) {
+        saveInvestigation(id, bundleWith([makeClaim("renders to DOM", 0.9)]));
+        stampSavedAt(id, "2026-01-01T00:00:00.000Z");
+      }
+      expect(listInvestigations().saved.map((s) => s.id)).toEqual([
+        "widget-a",
+        "widget-b",
+        "widget-c",
+      ]);
+    });
+
+    it("lists an id that --resume can actually take back", () => {
+      // `sanitizeId` is injective and deliberately not idempotent — it encodes
+      // `~` as `~7E` so a raw `~` cannot be mistaken for an escape — so the id
+      // stored on disk is the wrong thing to print next to "Resume with:".
+      // `widget/auth` was saved as `widget~2Fauth` and listed as that, and
+      // resuming it looked for `widget~7E2Fauth`, which does not exist.
+      saveInvestigation("widget/auth", bundleWith([makeClaim("renders to DOM", 0.9)]));
+      const [only] = listInvestigations().saved;
+      expect(only.id).toBe("widget~2Fauth"); // on disk, as stored
+
+      const { out } = captureStreams(() => renderInvestigationList([only], 0, "json"));
+      const listed = JSON.parse(out).investigations[0].id;
+      expect(listed).toBe("widget/auth");
+      // The whole point: the id the listing offers has to load.
+      expect(loadInvestigation(listed)?.bundle.target.name).toBe("Widget");
     });
 
     it("skips files whose envelope or bundle does not match the contract", () => {
@@ -471,36 +543,46 @@ describe("ix context investigation state", () => {
       saveInvestigation("good", bundleWith([makeClaim("renders to DOM", 0.9)]));
       const { saved } = listInvestigations();
 
-      const capture = (fn: () => void) => {
-        const out: string[] = [];
-        const err: string[] = [];
-        const origLog = console.log;
-        const origErr = console.error;
-        console.log = (...a: unknown[]) => void out.push(a.join(" "));
-        console.error = (...a: unknown[]) => void err.push(a.join(" "));
-        try {
-          fn();
-        } finally {
-          console.log = origLog;
-          console.error = origErr;
-        }
-        return { out: out.join("\n"), err: err.join("\n") };
-      };
-
-      const json = capture(() => renderInvestigationList(saved, 3, "json"));
+      const json = captureStreams(() => renderInvestigationList(saved, 3, "json"));
       expect(() => JSON.parse(json.out)).not.toThrow();
-      expect(JSON.parse(json.out)).toHaveLength(1);
+      const parsed = JSON.parse(json.out);
+      expect(parsed.investigations).toHaveLength(1);
+      // An array had nowhere to put this, so a machine caller could not tell
+      // three files had been rejected while the human saw a warning saying so.
+      expect(parsed.skipped).toBe(3);
       expect(json.err).toContain("3 saved investigation file(s)");
 
-      const llm = capture(() => renderInvestigationList(saved, 3, "llm"));
+      const llm = captureStreams(() => renderInvestigationList(saved, 3, "llm"));
       expect(llm.out.split("\n")[0]).toBe("investigations total=1 skipped=3");
       // The count is the record's business; nothing is written beside it.
       expect(llm.err).toBe("");
 
       // And with nothing skipped the field is simply absent.
-      const clean = capture(() => renderInvestigationList(saved, 0, "llm"));
+      const clean = captureStreams(() => renderInvestigationList(saved, 0, "llm"));
       expect(clean.out.split("\n")[0]).toBe("investigations total=1");
       expect(clean.err).toBe("");
+      // `skipped` is still there in json, as a zero rather than as nothing:
+      // "none were rejected" is an answer, and its absence is not.
+      const cleanJson = captureStreams(() => renderInvestigationList(saved, 0, "json"));
+      expect(JSON.parse(cleanJson.out).skipped).toBe(0);
+    });
+
+    it("returns a summary per investigation, not the bundles themselves", () => {
+      // `--list` is the discovery step. Twenty saved investigations is twenty
+      // complete bundles — up to 50 entities, 100 relationships and 12000
+      // characters of evidence each — and a caller that wants one of them asks
+      // for it by id with `--resume <id> --format json`.
+      saveInvestigation("widget", bundleWith([makeClaim("renders to DOM", 0.9)]));
+      const { saved } = listInvestigations();
+      expect(saved[0].bundle.evidence.length).toBeGreaterThan(0);
+
+      const { out } = captureStreams(() => renderInvestigationList(saved, 0, "json"));
+      const [item] = JSON.parse(out).investigations;
+      expect(Object.keys(item).sort()).toEqual(
+        ["counts", "freshness", "id", "savedAt", "target", "truncation"].sort(),
+      );
+      expect(item.counts.evidence).toBe(saved[0].bundle.evidence.length);
+      expect(out).not.toContain("renders to DOM");
     });
 
     it("prints nothing itself, whatever it finds", () => {

--- a/ix-cli/src/cli/__tests__/context-investigation.test.ts
+++ b/ix-cli/src/cli/__tests__/context-investigation.test.ts
@@ -15,6 +15,7 @@ import type { EntityFacts } from "../explain/facts.js";
 import {
   buildBundle,
   diffInvestigations,
+  listInvestigations,
   loadInvestigation,
   mergeDiffOptions,
   saveInvestigation,
@@ -264,5 +265,45 @@ describe("ix context investigation state", () => {
     }
     expect(existsSync(join(home, "..", "escape.json"))).toBe(false);
     expect(existsSync(join(home, ".version-check.json"))).toBe(false);
+  });
+
+  // `ix context --list` enumerates saved investigations for discovery.
+  // Without it, neither humans nor agents can see what they have stored —
+  // the only path was reading the JSON files directly.
+  describe("listInvestigations", () => {
+    it("returns saved investigations newest-first", () => {
+      saveInvestigation("widget-a", bundleWith([makeClaim("renders to DOM", 0.9)]));
+      saveInvestigation("widget-b", bundleWith([makeClaim("mounts to DOM", 0.7)]));
+      const list = listInvestigations();
+      expect(list.map((s) => s.id).sort()).toEqual(["widget-a", "widget-b"]);
+      // savedAt differs at least by a millisecond across the two writes; even
+      // on the rare same-ms tie the id tiebreaker keeps order deterministic.
+      expect(list[0].id === "widget-a" || list[0].id === "widget-b").toBe(true);
+    });
+
+    it("skips files whose envelope or bundle does not match the contract", () => {
+      saveInvestigation("good", bundleWith([makeClaim("renders to DOM", 0.9)]));
+      const dir = investigationsDir();
+      writeFileSync(join(dir, "corrupt-envelope.json"), JSON.stringify({ schema: "ix-investigation/9", bundle: {} }));
+      writeFileSync(join(dir, "truncated.json"), "{not json");
+      writeFileSync(join(dir, "tampered-body.json"), JSON.stringify({
+        schema: "ix-investigation/1",
+        id: "tampered-body",
+        savedAt: "2026-01-01T00:00:00Z",
+        bundle: { schema: "ix-context-bundle/1", generatedAt: "x", entities: "not-an-array" },
+      }));
+      writeFileSync(join(dir, "readme.md"), "not a state file");
+
+      const list = listInvestigations();
+      expect(list.map((s) => s.id)).toEqual(["good"]);
+      // The three corrupt files do not poison the listing.
+      expect(readdirSync(dir).filter((f) => f.endsWith(".json"))).toHaveLength(4);
+    });
+
+    it("returns an empty array when the investigations dir does not exist yet", () => {
+      expect(listInvestigations()).toEqual([]);
+      saveInvestigation("first", bundleWith([makeClaim("renders to DOM", 0.9)]));
+      expect(listInvestigations()).toHaveLength(1);
+    });
   });
 });

--- a/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
+++ b/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
@@ -109,6 +109,34 @@ describe("detectContextModeConflict", () => {
       expect(detectContextModeConflict({ resume: "x", ...other })).toMatch(/--resume/);
     }
   });
+
+  it("flags --list + --resume, which its own guard could never reach", () => {
+    // `--list`'s guard named `--resume`, but it sat below `if (opts.resume)`,
+    // which returns first. `ix context --list --resume widget` rendered one
+    // investigation, exited 0, and never said the listing had been dropped.
+    // Checked before any mode branch, that race cannot happen.
+    expect(detectContextModeConflict({ list: true, resume: "x" })).toMatch(
+      /--list and --resume cannot be combined/,
+    );
+  });
+
+  it("flags --list + --out, which nothing checked at all", () => {
+    // `ix context --list --out /tmp/list.json` listed to stdout, wrote no file,
+    // and exited 0 — the silent-ignore gap this detector exists to close, on
+    // the newest flag on the command it guards.
+    expect(detectContextModeConflict({ list: true, out: "/tmp/list.json" })).toMatch(
+      /--list cannot be combined with --out/,
+    );
+  });
+
+  it("flags a positional target alongside --list", () => {
+    // A positional is as ignorable as a flag: `ix context Widget --list`
+    // dropped the target with nothing said.
+    expect(detectContextModeConflict({ list: true }, "Widget")).toMatch(/--list takes no target/);
+    // …and a target without --list is the ordinary path.
+    expect(detectContextModeConflict({}, "Widget")).toBeUndefined();
+    expect(detectContextModeConflict({ list: true })).toBeUndefined();
+  });
 });
 
 describe("detectDiffModeConflict", () => {
@@ -173,7 +201,7 @@ describe("detectDiffModeConflict", () => {
  */
 describe("mode-flag coverage does not drift from the command", () => {
   /** Flags that select what the command does, or where its output goes. */
-  const CONTEXT_MODE_FLAGS = ["out", "save", "resume", "diff"] as const;
+  const CONTEXT_MODE_FLAGS = ["out", "save", "resume", "diff", "list"] as const;
   /** Flags that shape the bundle a mode produces; any pair of these is legal. */
   const CONTEXT_BUILD_FLAGS = [
     "kind", "path", "pick", "depth", "asOfRev",
@@ -276,6 +304,11 @@ describe("ix context action surfaces mode conflicts on stderr and exits 1", () =
     { args: ["context", "--diff", "x", "--save", "y"], expect: /--diff cannot be combined with --save/ },
     { args: ["context", "--diff", "x", "--out", "/tmp/x.json"], expect: /--diff cannot be combined with --out/ },
     { args: ["context", "--save", "y", "--out", "/tmp/x.json"], expect: /--save and --out cannot be combined/ },
+    { args: ["context", "--list", "--resume", "x"], expect: /--list and --resume cannot be combined/ },
+    { args: ["context", "--list", "--diff", "x"], expect: /--list and --diff cannot be combined/ },
+    { args: ["context", "--list", "--save", "y"], expect: /--list cannot be combined with --save/ },
+    { args: ["context", "--list", "--out", "/tmp/x.json"], expect: /--list cannot be combined with --out/ },
+    { args: ["context", "Widget", "--list"], expect: /--list takes no target/ },
   ])("ix $args → stderr matches $expect and exit code is 1", ({ args, expect: re }) => {
     const r = runProgram(registerContextCommand, args);
     expect(r.exitCode).toBe(1);

--- a/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
+++ b/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
@@ -1,0 +1,246 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Command } from "commander";
+
+import {
+  detectContextModeConflict,
+  registerContextCommand,
+} from "../commands/context.js";
+import {
+  detectDiffModeConflict,
+  registerDiffCommand,
+} from "../commands/diff.js";
+
+/**
+ * C-1..C-4 silent-ignore flag gaps in `ix context` and C-5 in `ix diff` are now
+ * surfaced as hard errors at the top of the action handler. These tests pin
+ * both the pure functions and the integration through the real Commander
+ * registration. The detectors run before any network call, so the action
+ * returns before touching the real Ix backend; no mocks are needed for the
+ * conflict paths.
+ */
+
+let home: string;
+let origExitCode: number | string | undefined;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ix-mode-conflict-test-"));
+  process.env.IX_HOME = home;
+  origExitCode = process.exitCode;
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  delete process.env.IX_HOME;
+  rmSync(home, { recursive: true, force: true });
+  process.exitCode = origExitCode;
+});
+
+describe("detectContextModeConflict", () => {
+  it("returns undefined when no flags are set", () => {
+    expect(detectContextModeConflict({})).toBeUndefined();
+  });
+
+  it("returns undefined for a single mode flag with neutral extras", () => {
+    expect(detectContextModeConflict({ resume: "x" })).toBeUndefined();
+    expect(detectContextModeConflict({ diff: "x" })).toBeUndefined();
+    expect(detectContextModeConflict({ save: "y" })).toBeUndefined();
+    expect(detectContextModeConflict({ out: "/tmp/x.json" })).toBeUndefined();
+  });
+
+  it("returns undefined for the legal save+resolve target run", () => {
+    // Fresh build with --save is fine; this is the contract path.
+    expect(detectContextModeConflict({ save: "y", format: "text" })).toBeUndefined();
+    // Fresh build with --out is fine in json mode (the existing renderWarning
+    // path still applies; the conflict detector does not flag it).
+    expect(detectContextModeConflict({ out: "/tmp/x.json", format: "json" })).toBeUndefined();
+  });
+
+  it("flags --resume + --diff", () => {
+    const msg = detectContextModeConflict({ resume: "x", diff: "y" });
+    expect(msg).toMatch(/--resume and --diff cannot be combined/);
+  });
+
+  it("flags --resume + --save", () => {
+    const msg = detectContextModeConflict({ resume: "x", save: "y" });
+    expect(msg).toMatch(/--resume cannot be combined with --save/);
+  });
+
+  it("flags --resume + --out (C-3 right-hand case)", () => {
+    const msg = detectContextModeConflict({ resume: "x", out: "/tmp/x.json" });
+    expect(msg).toMatch(/--resume cannot be combined with --out/);
+  });
+
+  it("suggests --format json to --resume --out when format is non-json", () => {
+    const msg = detectContextModeConflict({
+      resume: "x",
+      out: "/tmp/x.json",
+      format: "llm",
+    });
+    expect(msg).toMatch(/--resume cannot be combined with --out/);
+    expect(msg).toMatch(/--format json with --out/);
+  });
+
+  it("flags --diff + --save (C-1)", () => {
+    const msg = detectContextModeConflict({ diff: "x", save: "y" });
+    expect(msg).toMatch(/--diff cannot be combined with --save/);
+  });
+
+  it("flags --diff + --out (C-3 left-hand case)", () => {
+    const msg = detectContextModeConflict({ diff: "x", out: "/tmp/x.json" });
+    expect(msg).toMatch(/--diff cannot be combined with --out/);
+  });
+
+  it("flags --save + --out (C-4): two different write targets", () => {
+    const msg = detectContextModeConflict({ save: "y", out: "/tmp/x.json" });
+    expect(msg).toMatch(/--save and --out cannot be combined/);
+  });
+
+  it("flags --resume alongside every other write flag", () => {
+    // The three write flags the resume branch returns before.
+    for (const other of [{ diff: "y" }, { save: "y" }, { out: "/tmp/x.json" }]) {
+      expect(detectContextModeConflict({ resume: "x", ...other })).toMatch(/--resume/);
+    }
+  });
+});
+
+describe("detectDiffModeConflict", () => {
+  it("returns undefined when no flags are set", () => {
+    expect(detectDiffModeConflict({})).toBeUndefined();
+  });
+
+  it("returns undefined for legal single flags", () => {
+    expect(detectDiffModeConflict({ summary: true })).toBeUndefined();
+    expect(detectDiffModeConflict({ content: true })).toBeUndefined();
+    expect(detectDiffModeConflict({ full: true })).toBeUndefined();
+    expect(detectDiffModeConflict({ limit: "20" })).toBeUndefined();
+  });
+
+  it("flags --summary + --content (C-5)", () => {
+    const msg = detectDiffModeConflict({ summary: true, content: true });
+    expect(msg).toMatch(/--summary and --content cannot be combined/);
+  });
+
+  it("flags --full + --limit", () => {
+    const msg = detectDiffModeConflict({ full: true, limit: "20" });
+    expect(msg).toMatch(/--full and --limit cannot be combined/);
+  });
+
+  it("does NOT flag --full without --limit (--full alone is the documented path)", () => {
+    expect(detectDiffModeConflict({ full: true })).toBeUndefined();
+  });
+
+  it("does NOT flag --limit alone (default behaviour)", () => {
+    expect(detectDiffModeConflict({ limit: "20" })).toBeUndefined();
+  });
+
+  it("flags --summary alongside --limit or --full", () => {
+    const a = detectDiffModeConflict({ summary: true, limit: "20" });
+    expect(a).toMatch(/--summary ignores --limit and --full/);
+    const b = detectDiffModeConflict({ summary: true, full: true });
+    expect(b).toMatch(/--summary ignores --limit and --full/);
+  });
+});
+
+/**
+ * Drive the real `registerX` functions through Commander so we verify that:
+ *
+ *   1. the detector runs FIRST in the action handler (no network call);
+ *   2. the surfaced message lands on stderr with an "Error:" prefix;
+ *   3. process.exitCode is set to 1;
+ *   4. resolution/fresh-build code paths do NOT touch stdout.
+ *
+ * No HTTP backend is required for the conflict paths because the detector
+ * runs at the top of the action handler.
+ */
+function runProgram(
+  register: (program: Command) => void,
+  args: string[],
+): { stderr: string; exitCode: number | string | undefined; stdout: string } {
+  const program = new Command();
+  program.name("ix").exitOverride();
+  register(program);
+
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const origStdout = process.stdout.write.bind(process.stdout);
+  const origErr = console.error;
+  process.stdout.write = ((chunk: unknown) => {
+    stdout.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  console.error = (...a: unknown[]) => void stderr.push(a.join(" "));
+
+  let code: number | string | undefined;
+  try {
+    program.parse(["node", "ix", ...args]);
+  } catch (e) {
+    // exitOverride turns process.exit into a CommanderError; we still want
+    // the (possibly already-set) exitCode. The error message ends up in
+    // stderr elsewhere; do not forward here.
+    void e;
+  } finally {
+    code = process.exitCode;
+    process.stdout.write = origStdout;
+    console.error = origErr;
+  }
+  return { stderr: stderr.join("\n"), stdout: stdout.join(""), exitCode: code };
+}
+
+describe("ix context action surfaces mode conflicts on stderr and exits 1", () => {
+  it.each([
+    { args: ["context", "--resume", "x", "--diff", "y"], expect: /--resume and --diff/ },
+    { args: ["context", "--resume", "x", "--save", "y"], expect: /--resume cannot be combined with --save/ },
+    { args: ["context", "--resume", "x", "--out", "/tmp/x.json"], expect: /--resume cannot be combined with --out/ },
+    { args: ["context", "--diff", "x", "--save", "y"], expect: /--diff cannot be combined with --save/ },
+    { args: ["context", "--diff", "x", "--out", "/tmp/x.json"], expect: /--diff cannot be combined with --out/ },
+    { args: ["context", "--save", "y", "--out", "/tmp/x.json"], expect: /--save and --out cannot be combined/ },
+  ])("ix $args → stderr matches $expect and exit code is 1", ({ args, expect: re }) => {
+    const r = runProgram(registerContextCommand, args);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toMatch(/^Error:/m);
+    expect(r.stderr).toMatch(re);
+    expect(r.stdout).toBe("");
+  });
+});
+
+describe("ix diff action surfaces mode conflicts on stderr and exits 1", () => {
+  it.each([
+    { args: ["diff", "3", "5", "--summary", "--content"], expect: /--summary and --content cannot be combined/ },
+    { args: ["diff", "3", "5", "--full", "--limit", "20"], expect: /--full and --limit cannot be combined/ },
+    { args: ["diff", "3", "5", "--summary", "--limit", "20"], expect: /--summary ignores --limit and --full/ },
+    { args: ["diff", "3", "5", "--summary", "--full"], expect: /--summary ignores --limit and --full/ },
+  ])("ix diff $args → stderr matches $expect and exit code is 1", ({ args, expect: re }) => {
+    const r = runProgram(registerDiffCommand, args);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toMatch(/^Error:/m);
+    expect(r.stderr).toMatch(re);
+    expect(r.stdout).toBe("");
+  });
+});
+
+describe("ix help coverage stays intact (smoke)", () => {
+  it("context help still lists --resume, --diff, --save, --out", () => {
+    const program = new Command();
+    program.name("ix").exitOverride();
+    registerContextCommand(program);
+    const help = program.commands.find((c) => c.name() === "context")!.helpInformation();
+    expect(help).toMatch(/--save <id>/);
+    expect(help).toMatch(/--resume <id>/);
+    expect(help).toMatch(/--diff <id>/);
+    expect(help).toMatch(/--out <path>/);
+  });
+
+  it("diff help still lists --summary, --content, --full, --limit", () => {
+    const program = new Command();
+    program.name("ix").exitOverride();
+    registerDiffCommand(program);
+    const help = program.commands.find((c) => c.name() === "diff")!.helpInformation();
+    expect(help).toMatch(/--summary/);
+    expect(help).toMatch(/--content/);
+    expect(help).toMatch(/--full/);
+    expect(help).toMatch(/--limit/);
+  });
+});

--- a/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
+++ b/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
@@ -73,14 +73,19 @@ describe("detectContextModeConflict", () => {
     expect(msg).toMatch(/--resume cannot be combined with --out/);
   });
 
-  it("suggests --format json to --resume --out when format is non-json", () => {
-    const msg = detectContextModeConflict({
-      resume: "x",
-      out: "/tmp/x.json",
-      format: "llm",
-    });
-    expect(msg).toMatch(/--resume cannot be combined with --out/);
-    expect(msg).toMatch(/--format json with --out/);
+  it("never advises --resume --out to retry a combination it also rejects", () => {
+    // The hint used to be "use --format json with --out", which fires this same
+    // branch: the user did as they were told and got the identical error, this
+    // time with no advice at all. Whatever the message suggests must be
+    // something that is not itself refused here.
+    for (const format of ["text", "json", "llm"]) {
+      const msg = detectContextModeConflict({ resume: "x", out: "/tmp/x.json", format })!;
+      expect(msg).toMatch(/--resume cannot be combined with --out/);
+      expect(msg).not.toMatch(/--format json with --out/);
+      // And the way out it does name has to work.
+      expect(msg).toMatch(/>/);
+      expect(detectContextModeConflict({ resume: "x", format: "json" })).toBeUndefined();
+    }
   });
 
   it("flags --diff + --save (C-1)", () => {
@@ -141,6 +146,73 @@ describe("detectDiffModeConflict", () => {
     expect(a).toMatch(/--summary ignores --limit and --full/);
     const b = detectDiffModeConflict({ summary: true, full: true });
     expect(b).toMatch(/--summary ignores --limit and --full/);
+  });
+
+  it("names --summary, not --full, when all three are passed", () => {
+    // Only the two-flag pairs were covered, and the three-flag case took the
+    // `--full && --limit` branch: the user was told to drop one of two flags
+    // that `--summary` was going to ignore anyway, while the message naming the
+    // flag actually in charge was unreachable for this input.
+    const msg = detectDiffModeConflict({ summary: true, full: true, limit: "20" });
+    expect(msg).toMatch(/--summary ignores --limit and --full/);
+    expect(msg).not.toMatch(/--full and --limit cannot be combined/);
+  });
+});
+
+/**
+ * The gap the detectors are for is a flag the user typed doing nothing. A flag
+ * added later with no rule written for it reopens exactly that gap, silently:
+ * `ContextModeOptions` was a hand-copied five-field shape, `--list` was added
+ * to `ContextOptions` on a sibling branch, and neither the typechecker nor any
+ * test noticed the detector could not see it.
+ *
+ * So one side of this comes from the live Commander registration and the other
+ * is hand-listed. Two hand-lists can be wrong together; a list checked against
+ * the command cannot be. Adding an option to `ix context` fails here until it
+ * is classified — a mode flag with a rule, or a build knob.
+ */
+describe("mode-flag coverage does not drift from the command", () => {
+  /** Flags that select what the command does, or where its output goes. */
+  const CONTEXT_MODE_FLAGS = ["out", "save", "resume", "diff"] as const;
+  /** Flags that shape the bundle a mode produces; any pair of these is legal. */
+  const CONTEXT_BUILD_FLAGS = [
+    "kind", "path", "pick", "depth", "asOfRev",
+    "maxEntities", "maxRelationships", "maxEvidence", "maxChars", "format",
+  ];
+
+  function registeredAttributes(register: (p: Command) => void, name: string): string[] {
+    const program = new Command();
+    program.name("ix").exitOverride();
+    register(program);
+    const cmd = program.commands.find((c) => c.name() === name)!;
+    return cmd.options.map((o) => o.attributeName()).sort();
+  }
+
+  it("classifies every option ix context registers", () => {
+    expect(registeredAttributes(registerContextCommand, "context")).toEqual(
+      [...CONTEXT_MODE_FLAGS, ...CONTEXT_BUILD_FLAGS].sort(),
+    );
+  });
+
+  it("refuses every pair of mode flags", () => {
+    for (const a of CONTEXT_MODE_FLAGS) {
+      for (const b of CONTEXT_MODE_FLAGS) {
+        if (a >= b) continue;
+        const opts = { [a]: "x", [b]: "y" } as Record<string, string>;
+        expect(
+          detectContextModeConflict(opts),
+          `no rule for --${a} + --${b}`,
+        ).toBeTruthy();
+      }
+    }
+  });
+
+  it("leaves every single mode flag alone", () => {
+    // The mirror of the above: a rule that fires on one flag would refuse the
+    // command's ordinary use, and a pair-only assertion cannot see that.
+    for (const flag of CONTEXT_MODE_FLAGS) {
+      expect(detectContextModeConflict({ [flag]: "x" })).toBeUndefined();
+    }
   });
 });
 

--- a/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
+++ b/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
@@ -167,10 +167,16 @@ function runProgram(
   const stderr: string[] = [];
   const origStdout = process.stdout.write.bind(process.stdout);
   const origErr = console.error;
+  // Both, and console.log is the one that matters: under vitest `console` is
+  // replaced wholesale, so it never reaches `process.stdout.write` and a
+  // capture that patches only the stream sees nothing — which makes
+  // `expect(stdout).toBe("")` pass no matter what the command printed.
+  const origLog = console.log;
   process.stdout.write = ((chunk: unknown) => {
     stdout.push(String(chunk));
     return true;
   }) as typeof process.stdout.write;
+  console.log = (...a: unknown[]) => void stdout.push(a.join(" ") + "\n");
   console.error = (...a: unknown[]) => void stderr.push(a.join(" "));
 
   let code: number | string | undefined;
@@ -184,6 +190,7 @@ function runProgram(
   } finally {
     code = process.exitCode;
     process.stdout.write = origStdout;
+    console.log = origLog;
     console.error = origErr;
   }
   return { stderr: stderr.join("\n"), stdout: stdout.join(""), exitCode: code };
@@ -218,6 +225,53 @@ describe("ix diff action surfaces mode conflicts on stderr and exits 1", () => {
     expect(r.stderr).toMatch(/^Error:/m);
     expect(r.stderr).toMatch(re);
     expect(r.stdout).toBe("");
+  });
+});
+
+describe("a caller that asked for records gets the error as a record", () => {
+  // An agent is told to pass `--format llm` unconditionally, so an error it
+  // cannot read is an error it cannot act on. Same shape the rest of the CLI
+  // emits (imports/trace/smells/locate/callers) and the one docs/llm-format.md
+  // specifies: on stdout, in-stream, exit code still non-zero.
+  it("emits an error record for ix context and keeps the exit code", () => {
+    const r = runProgram(registerContextCommand, [
+      "context",
+      "--resume",
+      "x",
+      "--diff",
+      "y",
+      "--format",
+      "llm",
+    ]);
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toMatch(/^error code=mode_conflict message="/);
+    // One record, on one line, with the message quoted rather than bare.
+    expect(r.stdout.trimEnd().split("\n")).toHaveLength(1);
+    expect(r.stderr).toBe("");
+  });
+
+  it("emits an error record for ix diff and keeps the exit code", () => {
+    const r = runProgram(registerDiffCommand, [
+      "diff",
+      "3",
+      "5",
+      "--summary",
+      "--content",
+      "--format",
+      "llm",
+    ]);
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toMatch(/^error code=mode_conflict message="/);
+    expect(r.stderr).toBe("");
+  });
+
+  it("still writes prose to stderr for every other format", () => {
+    for (const format of ["text", "json"]) {
+      const r = runProgram(registerContextCommand, ["context", "--resume", "x", "--diff", "y", "--format", format]);
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/^Error:/m);
+      expect(r.stdout).toBe("");
+    }
   });
 });
 

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -137,7 +137,7 @@ export function registerContextCommand(program: Command): void {
       "\nExamples:\n  ix context IngestionService\n  ix context src/main.ts --format json\n  ix context Widget --max-entities 20 --max-evidence 10\n  ix context Widget --save widget-investigation\n  ix context --resume widget-investigation\n  ix context --diff widget-investigation\n  ix context --list",
     )
     .action(async (target: string | undefined, opts: ContextOptions) => {
-      const conflict = detectContextModeConflict(opts);
+      const conflict = detectContextModeConflict(opts, target);
       if (conflict) {
         reportModeConflict(conflict, opts.format);
         return;
@@ -147,14 +147,9 @@ export function registerContextCommand(program: Command): void {
         return;
       }
       if (opts.list) {
-        if (opts.save || opts.diff || opts.resume) {
-          // A refusal exits non-zero, the way `refuseInvestigation` does two
-          // functions down and the way the sibling commands do: a warning with
-          // a success status tells a script the listing it never got was fine.
-          renderWarning("--list cannot be combined with --save, --diff or --resume.");
-          process.exitCode = 1;
-          return;
-        }
+        // No guard of its own: every combination it used to check is refused
+        // above, before any mode branch can return first. The old one lived
+        // here, below `if (opts.resume)`, so its `--resume` arm was dead.
         const listed = listInvestigations();
         renderInvestigationList(listed.saved, listed.skipped, opts.format);
         return;
@@ -297,7 +292,7 @@ async function buildFreshBundle(
  * without inventing a `format`.
  */
 export type ContextModeOptions = Partial<
-  Pick<ContextOptions, "resume" | "diff" | "save" | "out" | "format">
+  Pick<ContextOptions, "resume" | "diff" | "save" | "out" | "list" | "format">
 >;
 
 /**
@@ -311,10 +306,37 @@ export type ContextModeOptions = Partial<
  * well-defined combined behaviour. Catching these combinations up front and
  * surfacing them as a hard error mirrors the explicit-conflict style in
  * subsystems.ts and prevents the user's typed flag from being a no-op.
+ *
+ * `--list` is checked here rather than inside the list branch, and that is the
+ * point rather than tidiness. Its own guard sat below `if (opts.resume)`, which
+ * returns first, so the `--list --resume` arm of it could never fire: the user
+ * asked for a listing, silently got one investigation rendered, and the exit
+ * code said it went fine. A guard that runs before every mode branch cannot
+ * lose that race.
+ *
+ * `target` is a parameter because a positional is as ignorable as a flag:
+ * `ix context Widget --list` dropped the target with nothing said.
  */
 export function detectContextModeConflict(
   opts: ContextModeOptions,
+  target?: string,
 ): string | undefined {
+  if (opts.list && target) {
+    return `--list takes no target; it enumerates every saved investigation. Drop "${target}", or drop --list to build a fresh bundle for it.`;
+  }
+  if (opts.list && opts.resume) {
+    return "--list and --resume cannot be combined; --list enumerates saved investigations, --resume renders one. Run --list first, then --resume the id you want.";
+  }
+  if (opts.list && opts.diff) {
+    return "--list and --diff cannot be combined; --list enumerates saved investigations, --diff compares one against a fresh build.";
+  }
+  if (opts.list && opts.save) {
+    return "--list cannot be combined with --save; --list reads saved investigations, --save writes one, and --list builds no bundle to write.";
+  }
+  if (opts.list && opts.out) {
+    return "--list cannot be combined with --out; --list enumerates to stdout."
+      + " Redirect it (`ix context --list --format json > <path>`) if you need the listing on disk.";
+  }
   if (opts.resume && opts.diff) {
     return "--resume and --diff cannot be combined; --resume renders a saved investigation, --diff renders a comparison against one.";
   }
@@ -379,6 +401,29 @@ export function sanitizeId(id: string): string {
   }
   if (out.startsWith(".")) out = `~2E${out.slice(1)}`;
   return out || "unnamed";
+}
+
+/**
+ * Recover the id the user typed from the id stored on disk.
+ *
+ * `sanitizeId` is injective and deliberately *not* idempotent — it encodes `~`
+ * as `~7E` precisely so a raw `~` cannot be confused with an escape — so the
+ * stored form is the wrong thing to hand back to the user. `ix context --list`
+ * printed it anyway, next to "Resume with: ix context --resume <id>", and
+ * `--resume` sanitizes what it is given: an id saved as `widget/auth` was
+ * listed as `widget~2Fauth`, and resuming that looked for `widget~7E2Fauth`,
+ * which does not exist. `saveInvestigation`'s own note echoes the id the user
+ * typed, so the two affordances contradicted each other.
+ *
+ * `sanitizeId(unsanitizeId(stored)) === stored` for every id this CLI wrote,
+ * which is what makes the listed id usable. A hand-written file whose id is
+ * outside `sanitizeId`'s range has no input that reaches it and is not a case
+ * this recovers.
+ */
+export function unsanitizeId(stored: string): string {
+  return stored.replace(/~([0-9A-Fa-f]{2})/g, (_m, hex: string) =>
+    String.fromCharCode(parseInt(hex, 16)),
+  );
 }
 
 export function saveInvestigation(id: string, bundle: ContextBundle): void {
@@ -482,23 +527,58 @@ export function listInvestigations(): { saved: SavedInvestigation[]; skipped: nu
   return { saved: out, skipped };
 }
 
+/** One saved investigation as `--list` describes it: what it is, not what is in it. */
+interface InvestigationSummary {
+  /** The id to type back, not the id on disk — see `unsanitizeId`. */
+  id: string;
+  savedAt: string;
+  target: { name: string; kind: string };
+  freshness: ContextBundle["freshness"];
+  counts: { entities: number; relationships: number; evidence: number };
+  truncation: ContextBundle["truncation"];
+}
+
+/** Summarise one saved investigation for the listing. */
+function summariseInvestigation(s: SavedInvestigation): InvestigationSummary {
+  const b = s.bundle;
+  return {
+    id: unsanitizeId(s.id),
+    savedAt: s.savedAt,
+    target: { name: b.target.name, kind: b.target.kind },
+    freshness: b.freshness,
+    counts: {
+      entities: b.entities.length,
+      relationships: b.relationships.length,
+      evidence: b.evidence.length,
+    },
+    truncation: b.truncation,
+  };
+}
+
 /**
  * Render the saved investigations produced by `listInvestigations`.
  *
- * JSON stays the array of saved envelopes; llm emits a summary record and one
- * record per investigation; text prints the tabular summary.
+ * Every format carries the same summary: what each investigation is, how big
+ * it is, and how stale. Not the bundles themselves — `--list` is the discovery
+ * step, and twenty saved investigations is twenty complete bundles, up to 50
+ * entities, 100 relationships and 12000 characters of evidence each. A caller
+ * that wants one of them asks for it by id with `--resume <id> --format json`.
  *
  * `skipped` is reported in each format's own terms, and never on stdout except
- * as a field. It used to be a `renderWarning` inside the enumerator — which is
- * `console.log` — so a single corrupt file prepended a chalk-coloured prose
- * line to the payload and `ix context --list --format json | jq` failed on it.
- * The human warning goes to stderr; the machine formats carry a count.
+ * as a field — including in `json`, which returns an object for exactly that
+ * reason: an array has nowhere to put it, so a machine caller could not tell
+ * that files had been rejected while the human saw a warning saying so. It used
+ * to be a `renderWarning` inside the enumerator — which is `console.log` — so a
+ * single corrupt file prepended a chalk-coloured prose line to the payload and
+ * `ix context --list --format json | jq` failed on it. The human warning goes to
+ * stderr; the machine formats carry a count.
  */
 export function renderInvestigationList(
   items: SavedInvestigation[],
   skipped: number,
   format: string,
 ): void {
+  const summaries = items.map(summariseInvestigation);
   if (skipped > 0 && format !== "llm") {
     // `console.error`, not `renderWarning`: every renderer in ui.ts writes to
     // stdout, which is exactly how this line used to end up inside the JSON a
@@ -511,57 +591,56 @@ export function renderInvestigationList(
     );
   }
   if (format === "json") {
-    console.log(JSON.stringify(items, null, 2));
+    console.log(JSON.stringify({ investigations: summaries, skipped }, null, 2));
     return;
   }
   if (format === "llm") {
     printLlmLines([
       // `skipped` is a field rather than a warning: it is the one thing about
       // the listing an agent cannot see from the records themselves.
-      llmLine("investigations", { total: items.length, skipped: skipped || undefined }),
-      ...items.map((s) =>
+      llmLine("investigations", { total: summaries.length, skipped: skipped || undefined }),
+      ...summaries.map((s) =>
         llmLine("investigation", {
           id: s.id,
           saved_at: s.savedAt,
-          target: s.bundle.target.name,
-          target_kind: s.bundle.target.kind,
-          classification: s.bundle.freshness.classification,
-          stale: s.bundle.freshness.stale,
-          entities: s.bundle.entities.length,
-          relationships: s.bundle.relationships.length,
-          evidence: s.bundle.evidence.length,
-          truncated_entities: s.bundle.truncation.entitiesTruncated,
-          truncated_relationships: s.bundle.truncation.relationshipsTruncated,
-          truncated_evidence: s.bundle.truncation.evidenceTruncated,
-          truncated_chars: s.bundle.truncation.charactersTruncated,
+          target: s.target.name,
+          target_kind: s.target.kind,
+          classification: s.freshness.classification,
+          stale: s.freshness.stale,
+          entities: s.counts.entities,
+          relationships: s.counts.relationships,
+          evidence: s.counts.evidence,
+          truncated_entities: s.truncation.entitiesTruncated,
+          truncated_relationships: s.truncation.relationshipsTruncated,
+          truncated_evidence: s.truncation.evidenceTruncated,
+          truncated_chars: s.truncation.charactersTruncated,
         }),
       ),
     ]);
     return;
   }
 
-  if (items.length === 0) {
+  if (summaries.length === 0) {
     renderNote("No saved investigations. Use `ix context <target> --save <id>` to create one.");
     return;
   }
-  renderSection(`Saved investigations (${items.length})`);
-  for (const s of items) {
-    const b = s.bundle;
+  renderSection(`Saved investigations (${summaries.length})`);
+  for (const s of summaries) {
     console.log(`  ${s.id}`);
-    console.log(`    target:       ${b.target.name} (${b.target.kind})`);
+    console.log(`    target:       ${s.target.name} (${s.target.kind})`);
     console.log(`    saved_at:     ${s.savedAt}`);
-    console.log(`    freshness:    ${b.freshness.classification}`);
+    console.log(`    freshness:    ${s.freshness.classification}`);
     console.log(
-      `    counts:       entities=${b.entities.length} relationships=${b.relationships.length} evidence=${b.evidence.length}`,
+      `    counts:       entities=${s.counts.entities} relationships=${s.counts.relationships} evidence=${s.counts.evidence}`,
     );
     if (
-      b.truncation.entitiesTruncated ||
-      b.truncation.relationshipsTruncated ||
-      b.truncation.evidenceTruncated ||
-      b.truncation.charactersTruncated
+      s.truncation.entitiesTruncated ||
+      s.truncation.relationshipsTruncated ||
+      s.truncation.evidenceTruncated ||
+      s.truncation.charactersTruncated
     ) {
       console.log(
-        `    truncated:    entities=${b.truncation.entitiesTruncated} relationships=${b.truncation.relationshipsTruncated} evidence=${b.truncation.evidenceTruncated} chars=${b.truncation.charactersTruncated}`,
+        `    truncated:    entities=${s.truncation.entitiesTruncated} relationships=${s.truncation.relationshipsTruncated} evidence=${s.truncation.evidenceTruncated} chars=${s.truncation.charactersTruncated}`,
       );
     }
   }

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -16,7 +16,7 @@ import type {
 } from "../../client/types.js";
 import { getEndpoint } from "../config.js";
 import { collectFacts, type EntityFacts } from "../explain/facts.js";
-import { printLlmLines } from "../llm.js";
+import { llmError, printLlmLines } from "../llm.js";
 import { parsePickOption } from "../options.js";
 import { resolveFileOrEntity } from "../resolve.js";
 import { createStaleProbe } from "../stale.js";
@@ -140,7 +140,7 @@ export function registerContextCommand(program: Command): void {
     .action(async (target: string | undefined, opts: ContextOptions) => {
       const conflict = detectContextModeConflict(opts);
       if (conflict) {
-        reportContextModeConflict(conflict);
+        reportContextModeConflict(conflict, opts.format);
         return;
       }
       if (opts.resume) {
@@ -325,9 +325,18 @@ export function detectContextModeConflict(
   return undefined;
 }
 
-/** Render a detected mode conflict and mark the process exit code. */
-export function reportContextModeConflict(message: string): void {
-  console.error(chalk.red("Error:"), message);
+/**
+ * Render a detected mode conflict and mark the process exit code.
+ *
+ * `--format llm` gets the record form the rest of the CLI emits for errors —
+ * `error code=... message="..."`, on stdout, with the exit code still non-zero
+ * (imports.ts, trace.ts, smells.ts, locate.ts, callers.ts all do this, and
+ * docs/llm-format.md specifies the shape). An agent is told to pass the flag
+ * unconditionally, so an error it cannot read is an error it cannot act on.
+ */
+export function reportContextModeConflict(message: string, format?: string): void {
+  if (format === "llm") console.log(llmError("mode_conflict", message));
+  else console.error(chalk.red("Error:"), message);
   process.exitCode = 1;
 }
 

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
@@ -41,6 +41,7 @@ interface ContextOptions {
   save?: string;
   resume?: string;
   diff?: string;
+  list?: boolean;
   format: string;
 }
 
@@ -132,13 +133,22 @@ export function registerContextCommand(program: Command): void {
     .option("--save <id>", "Persist the bundle as a resumable investigation state")
     .option("--resume <id>", "Render a saved investigation state without a backend")
     .option("--diff <id>", "Diff a saved investigation against a fresh build of the same target")
+    .option("--list", "List saved investigations (no target, no backend)")
     .addHelpText(
       "after",
-      "\nExamples:\n  ix context IngestionService\n  ix context src/main.ts --format json\n  ix context Widget --max-entities 20 --max-evidence 10\n  ix context Widget --save widget-investigation\n  ix context --resume widget-investigation\n  ix context --diff widget-investigation",
+      "\nExamples:\n  ix context IngestionService\n  ix context src/main.ts --format json\n  ix context Widget --max-entities 20 --max-evidence 10\n  ix context Widget --save widget-investigation\n  ix context --resume widget-investigation\n  ix context --diff widget-investigation\n  ix context --list",
     )
     .action(async (target: string | undefined, opts: ContextOptions) => {
       if (opts.resume) {
         renderSavedInvestigation(opts.resume, opts.format);
+        return;
+      }
+      if (opts.list) {
+        if (opts.save || opts.diff) {
+          renderWarning("--list cannot be combined with --save or --diff.");
+          return;
+        }
+        renderInvestigationList(listInvestigations(), opts.format);
         return;
       }
       if (opts.diff) {
@@ -358,6 +368,141 @@ export function mergeDiffOptions(
     asOfRev: opts.asOfRev ?? (savedRev === undefined ? undefined : String(savedRev)),
     depth: opts.depth ?? saved.bundle.metadata.depth,
   };
+}
+
+/**
+ * Enumerate every saved investigation under IX_HOME/investigations.
+ *
+ * Mirrors the read-side validation `loadInvestigation` performs on a single
+ * file (envelope + bundle.safeParse) so a corrupt or version-skewed file is
+ * skipped silently rather than poison the listing — but a corrupt file is
+ * still surfaced through a single warning so the operator can prune it.
+ *
+ * Determinism: results are sorted newest-first by `savedAt`, falling back to
+ * the sanitized `id` so two files saved in the same millisecond still have a
+ * stable order across runs.
+ */
+export function listInvestigations(): SavedInvestigation[] {
+  const dir = investigationDir();
+  if (!existsSync(dir)) return [];
+  const entries = readdirSync(dir).filter((f) => f.endsWith(".json"));
+  const out: SavedInvestigation[] = [];
+  let skipped = 0;
+  for (const file of entries) {
+    const filePath = join(dir, file);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(filePath, "utf8"));
+    } catch {
+      skipped += 1;
+      continue;
+    }
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      (parsed as { schema?: unknown }).schema !== "ix-investigation/1" ||
+      !(parsed as { bundle?: unknown }).bundle
+    ) {
+      skipped += 1;
+      continue;
+    }
+    // Validate the body's contract matches the same versioned schema the
+    // write side enforces. We trust the original parsed JSON (cast as the
+    // SavedInvestigation type, exactly like loadInvestigation does on the
+    // happy path) instead of safeParse's data, because the on-disk envelope
+    // here was produced by saveInvestigation and the renderer only needs to
+    // forward the bundle through unchanged. That keeps the read-side
+    // validation contract symmetric with `loadInvestigation` without
+    // re-running the schema's structural narrowing (which would lose the
+    // richer record types claims/decisions/assets carry internally).
+    const bundleCheck = contextBundleSchema.safeParse((parsed as SavedInvestigation).bundle);
+    if (!bundleCheck.success) {
+      skipped += 1;
+      continue;
+    }
+    out.push(parsed as SavedInvestigation);
+  }
+  if (skipped > 0) {
+    renderWarning(
+      `${skipped} saved investigation file(s) did not match the contract; skipped. Run \`ix context --resume <id>\` for a per-file report.`,
+    );
+  }
+  return out.sort((a, b) => {
+    if (a.savedAt !== b.savedAt) return a.savedAt < b.savedAt ? 1 : -1;
+    return cmp(a.id, b.id);
+  });
+}
+
+/**
+ * Render the saved investigations produced by `listInvestigations`.
+ *
+ * The wire formats mirror the rest of the CLI: JSON is the full saved
+ * envelope so it round-trips through `--resume <id>`; LLM emits one
+ * metadata record per saved investigation; text prints a tabular
+ * summary with truncation/savedAt/target so a human can choose what
+ * to resume or diff.
+ */
+function renderInvestigationList(items: SavedInvestigation[], format: string): void {
+  if (format === "json") {
+    console.log(JSON.stringify(items, null, 2));
+    return;
+  }
+  if (format === "llm") {
+    if (items.length === 0) {
+      printLlmLines(["investigations total=0"]);
+      return;
+    }
+    printLlmLines([
+      `investigations total=${items.length}`,
+      ...items.map((s) =>
+        [
+          `investigation id=${s.id}`,
+          `saved_at=${s.savedAt}`,
+          `target=${s.bundle.target.name}`,
+          `target_kind=${s.bundle.target.kind}`,
+          `classification=${s.bundle.freshness.classification}`,
+          `stale=${s.bundle.freshness.stale}`,
+          `entities=${s.bundle.entities.length}`,
+          `relationships=${s.bundle.relationships.length}`,
+          `evidence=${s.bundle.evidence.length}`,
+          `truncated_entities=${s.bundle.truncation.entitiesTruncated}`,
+          `truncated_relationships=${s.bundle.truncation.relationshipsTruncated}`,
+          `truncated_evidence=${s.bundle.truncation.evidenceTruncated}`,
+          `truncated_chars=${s.bundle.truncation.charactersTruncated}`,
+        ].join(" "),
+      ),
+    ]);
+    return;
+  }
+
+  if (items.length === 0) {
+    renderNote("No saved investigations. Use `ix context <target> --save <id>` to create one.");
+    return;
+  }
+  renderSection(`Saved investigations (${items.length})`);
+  for (const s of items) {
+    const b = s.bundle;
+    console.log(`  ${s.id}`);
+    console.log(`    target:       ${b.target.name} (${b.target.kind})`);
+    console.log(`    saved_at:     ${s.savedAt}`);
+    console.log(`    freshness:    ${b.freshness.classification}`);
+    console.log(
+      `    counts:       entities=${b.entities.length} relationships=${b.relationships.length} evidence=${b.evidence.length}`,
+    );
+    if (
+      b.truncation.entitiesTruncated ||
+      b.truncation.relationshipsTruncated ||
+      b.truncation.evidenceTruncated ||
+      b.truncation.charactersTruncated
+    ) {
+      console.log(
+        `    truncated:    entities=${b.truncation.entitiesTruncated} relationships=${b.truncation.relationshipsTruncated} evidence=${b.truncation.evidenceTruncated} chars=${b.truncation.charactersTruncated}`,
+      );
+    }
+  }
+  console.log();
+  console.log(`Resume with: ix context --resume <id>`);
+  console.log(`Diff with:   ix context --diff <id>`);
 }
 
 export function loadInvestigation(id: string): SavedInvestigation | undefined {

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -2,7 +2,6 @@ import type { Command } from "commander";
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import chalk from "chalk";
 
 import {
   BUNDLE_SCHEMA,
@@ -20,7 +19,7 @@ import type {
 } from "../../client/types.js";
 import { getEndpoint } from "../config.js";
 import { collectFacts, type EntityFacts } from "../explain/facts.js";
-import { llmError, printLlmLines } from "../llm.js";
+import { printLlmLines, reportModeConflict } from "../llm.js";
 import { parsePickOption } from "../options.js";
 import { resolveFileOrEntity } from "../resolve.js";
 import { createStaleProbe } from "../stale.js";
@@ -138,7 +137,7 @@ export function registerContextCommand(program: Command): void {
     .action(async (target: string | undefined, opts: ContextOptions) => {
       const conflict = detectContextModeConflict(opts);
       if (conflict) {
-        reportContextModeConflict(conflict, opts.format);
+        reportModeConflict(conflict, opts.format);
         return;
       }
       if (opts.resume) {
@@ -271,18 +270,20 @@ async function buildFreshBundle(
 }
 
 
-/** Saved investigation state lives under ~/.ix/investigations. */
 /**
- * Subset of `ContextOptions` consumed by `detectContextModeConflict`. Kept as a
- * structural type so the detector can be unit-tested without driving Commander.
+ * The `ContextOptions` fields `detectContextModeConflict` consumes.
+ *
+ * `Pick`, not a hand-copied shape: the detector exists to stop a typed flag
+ * being a no-op, so its idea of the flags must come from the same declaration
+ * the action handler uses. Written out field-by-field it drifted immediately --
+ * `--list` was added to `ContextOptions` on a sibling branch and the detector
+ * could not see it, with nothing from the typechecker to say so. `Partial` so
+ * the pure function can still be called with one flag at a time in a test,
+ * without inventing a `format`.
  */
-export interface ContextModeOptions {
-  resume?: string;
-  diff?: string;
-  save?: string;
-  out?: string;
-  format?: string;
-}
+export type ContextModeOptions = Partial<
+  Pick<ContextOptions, "resume" | "diff" | "save" | "out" | "format">
+>;
 
 /**
  * Detect mutually-incompatible mode/output flags on `ix context` and return a
@@ -306,10 +307,14 @@ export function detectContextModeConflict(
     return "--resume cannot be combined with --save; --resume only renders a saved investigation, while --save writes a new one. Run --save on a fresh build instead.";
   }
   if (opts.resume && opts.out) {
+    // No "use --format json with --out" hint here. That hint was unactionable:
+    // this branch fires on `--resume` plus `--out` whatever the format, so a
+    // user who followed it landed straight back on the same error, this time
+    // with no advice at all. The two things that do work are a redirect and
+    // the saved file itself, so name those.
     return "--resume cannot be combined with --out; --resume renders to stdout."
-      + (opts.format && opts.format !== "json"
-        ? " Use --format json with --out if you need to persist the rendered output."
-        : "");
+      + " Redirect it (`ix context --resume <id> --format json > <path>`), or read"
+      + " IX_HOME/investigations/<id>.json, which is already the saved JSON.";
   }
   if (opts.diff && opts.save) {
     return "--diff cannot be combined with --save; --diff renders a comparison against a saved investigation. To persist the fresh side as a new investigation, run the fresh build without --diff and use --save there.";
@@ -323,21 +328,7 @@ export function detectContextModeConflict(
   return undefined;
 }
 
-/**
- * Render a detected mode conflict and mark the process exit code.
- *
- * `--format llm` gets the record form the rest of the CLI emits for errors —
- * `error code=... message="..."`, on stdout, with the exit code still non-zero
- * (imports.ts, trace.ts, smells.ts, locate.ts, callers.ts all do this, and
- * docs/llm-format.md specifies the shape). An agent is told to pass the flag
- * unconditionally, so an error it cannot read is an error it cannot act on.
- */
-export function reportContextModeConflict(message: string, format?: string): void {
-  if (format === "llm") console.log(llmError("mode_conflict", message));
-  else console.error(chalk.red("Error:"), message);
-  process.exitCode = 1;
-}
-
+/** Saved investigation state lives under ~/.ix/investigations. */
 function investigationDir(): string {
   // IX_HOME is the Ix home *directory*, not the investigations directory —
   // backend-status.ts, docker.ts and upgrade.ts all read it as `IX_HOME ||

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import chalk from "chalk";
 
 import { contextBundleSchema } from "../context-bundle-schema.js";
 
@@ -137,6 +138,11 @@ export function registerContextCommand(program: Command): void {
       "\nExamples:\n  ix context IngestionService\n  ix context src/main.ts --format json\n  ix context Widget --max-entities 20 --max-evidence 10\n  ix context Widget --save widget-investigation\n  ix context --resume widget-investigation\n  ix context --diff widget-investigation",
     )
     .action(async (target: string | undefined, opts: ContextOptions) => {
+      const conflict = detectContextModeConflict(opts);
+      if (conflict) {
+        reportContextModeConflict(conflict);
+        return;
+      }
       if (opts.resume) {
         renderSavedInvestigation(opts.resume, opts.format);
         return;
@@ -268,6 +274,63 @@ async function buildFreshBundle(
 
 
 /** Saved investigation state lives under ~/.ix/investigations. */
+/**
+ * Subset of `ContextOptions` consumed by `detectContextModeConflict`. Kept as a
+ * structural type so the detector can be unit-tested without driving Commander.
+ */
+export interface ContextModeOptions {
+  resume?: string;
+  diff?: string;
+  save?: string;
+  out?: string;
+  format?: string;
+}
+
+/**
+ * Detect mutually-incompatible mode/output flags on `ix context` and return a
+ * human-readable message naming the conflict, or `undefined` if no conflict.
+ *
+ * The action handler used to silently drop `--save` and `--out` whenever
+ * `--resume` or `--diff` was passed (those branches `return` before the
+ * `--save`/`--out` branches ever run). It also accepted `--save <id>` alongside
+ * `--out <file>`, which describes two different write targets and so has no
+ * well-defined combined behaviour. Catching these combinations up front and
+ * surfacing them as a hard error mirrors the explicit-conflict style in
+ * subsystems.ts and prevents the user's typed flag from being a no-op.
+ */
+export function detectContextModeConflict(
+  opts: ContextModeOptions,
+): string | undefined {
+  if (opts.resume && opts.diff) {
+    return "--resume and --diff cannot be combined; --resume renders a saved investigation, --diff renders a comparison against one.";
+  }
+  if (opts.resume && opts.save) {
+    return "--resume cannot be combined with --save; --resume only renders a saved investigation, while --save writes a new one. Run --save on a fresh build instead.";
+  }
+  if (opts.resume && opts.out) {
+    return "--resume cannot be combined with --out; --resume renders to stdout."
+      + (opts.format && opts.format !== "json"
+        ? " Use --format json with --out if you need to persist the rendered output."
+        : "");
+  }
+  if (opts.diff && opts.save) {
+    return "--diff cannot be combined with --save; --diff renders a comparison against a saved investigation. To persist the fresh side as a new investigation, run the fresh build without --diff and use --save there.";
+  }
+  if (opts.diff && opts.out) {
+    return "--diff cannot be combined with --out; --diff renders the comparison to stdout.";
+  }
+  if (opts.save && opts.out) {
+    return "--save and --out cannot be combined; --save writes to IX_HOME/investigations/<id>.json, while --out writes to a caller-chosen path. Pick one.";
+  }
+  return undefined;
+}
+
+/** Render a detected mode conflict and mark the process exit code. */
+export function reportContextModeConflict(message: string): void {
+  console.error(chalk.red("Error:"), message);
+  process.exitCode = 1;
+}
+
 function investigationDir(): string {
   // IX_HOME is the Ix home *directory*, not the investigations directory —
   // backend-status.ts, docker.ts and upgrade.ts all read it as `IX_HOME ||

--- a/ix-cli/src/cli/commands/diff.ts
+++ b/ix-cli/src/cli/commands/diff.ts
@@ -7,6 +7,12 @@ import type { Command } from "commander";
 import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
 
+import { getEndpoint } from "../config.js";
+import { resolveFileOrEntity, resolveEntityFull, printResolved, looksFileLike, type ResolvedEntity } from "../resolve.js";
+import { formatDiff, relativePath } from "../format.js";
+import { llmLine, llmError } from "../llm.js";
+import { parsePickOption } from "../options.js";
+
 /**
  * Subset of `DiffOptions` consumed by `detectDiffModeConflict`. Kept as a
  * structural type so the detector can be unit-tested without driving Commander.
@@ -48,16 +54,20 @@ export function detectDiffModeConflict(
   return undefined;
 }
 
-/** Render a detected mode conflict and mark the process exit code. */
-export function reportDiffModeConflict(message: string): void {
-  console.error(chalk.red("Error:"), message);
+/**
+ * Render a detected mode conflict and mark the process exit code.
+ *
+ * `--format llm` gets the record form the rest of the CLI emits for errors —
+ * `error code=... message="..."`, on stdout, with the exit code still non-zero
+ * (imports.ts, trace.ts, smells.ts, locate.ts, callers.ts all do this, and
+ * docs/llm-format.md specifies the shape). An agent is told to pass the flag
+ * unconditionally, so an error it cannot read is an error it cannot act on.
+ */
+export function reportDiffModeConflict(message: string, format?: string): void {
+  if (format === "llm") console.log(llmError("mode_conflict", message));
+  else console.error(chalk.red("Error:"), message);
   process.exitCode = 1;
 }
-import { getEndpoint } from "../config.js";
-import { resolveFileOrEntity, resolveEntityFull, printResolved, looksFileLike, type ResolvedEntity } from "../resolve.js";
-import { formatDiff, relativePath } from "../format.js";
-import { llmLine, llmError } from "../llm.js";
-import { parsePickOption } from "../options.js";
 
 /** Render a `--summary` diff as a single llm record. */
 function renderDiffSummaryLlm(result: any): string {
@@ -480,7 +490,7 @@ export function registerDiffCommand(program: Command): void {
     }) => {
       const conflict = detectDiffModeConflict(opts);
       if (conflict) {
-        reportDiffModeConflict(conflict);
+        reportDiffModeConflict(conflict, opts.format);
         return;
       }
       const client = new IxClient(getEndpoint());

--- a/ix-cli/src/cli/commands/diff.ts
+++ b/ix-cli/src/cli/commands/diff.ts
@@ -10,7 +10,7 @@ import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { resolveFileOrEntity, resolveEntityFull, printResolved, looksFileLike, type ResolvedEntity } from "../resolve.js";
 import { formatDiff, relativePath } from "../format.js";
-import { llmLine, llmError } from "../llm.js";
+import { llmLine, llmError, reportModeConflict } from "../llm.js";
 import { parsePickOption } from "../options.js";
 
 /**
@@ -35,6 +35,13 @@ export interface DiffModeOptions {
  * explicit-conflict style in subsystems.ts. `--full --limit <n>` is also
  * flagged: `--full` is documented as "no limit" so the silent precedence over
  * `--limit` was the same kind of UX gap.
+ *
+ * Order is load-bearing, not incidental. `--summary` is the flag that wins at
+ * runtime, so when it is present its message is the one that names the flag
+ * actually in charge. Checking `--full --limit` first meant
+ * `ix diff 3 5 --summary --full --limit 20` reported "--full and --limit cannot
+ * be combined" -- two flags `--summary` was going to ignore anyway -- and the
+ * message that would have explained the run was unreachable for that input.
  */
 export function detectDiffModeConflict(
   opts: DiffModeOptions,
@@ -42,31 +49,16 @@ export function detectDiffModeConflict(
   if (opts.summary && opts.content) {
     return "--summary and --content cannot be combined; --summary renders counts only, --content renders the full textual diff. Pick one.";
   }
-  if (opts.full && opts.limit !== undefined) {
-    return "--full and --limit cannot be combined; --full is documented to return all changes without a limit. Drop --limit, or drop --full to keep the existing limit.";
-  }
   if (
     opts.summary &&
     (opts.full || opts.limit !== undefined)
   ) {
     return "--summary ignores --limit and --full; --summary is server-side counts only. Drop --summary to control change volume, or drop --limit/--full.";
   }
+  if (opts.full && opts.limit !== undefined) {
+    return "--full and --limit cannot be combined; --full is documented to return all changes without a limit. Drop --limit, or drop --full to keep the existing limit.";
+  }
   return undefined;
-}
-
-/**
- * Render a detected mode conflict and mark the process exit code.
- *
- * `--format llm` gets the record form the rest of the CLI emits for errors —
- * `error code=... message="..."`, on stdout, with the exit code still non-zero
- * (imports.ts, trace.ts, smells.ts, locate.ts, callers.ts all do this, and
- * docs/llm-format.md specifies the shape). An agent is told to pass the flag
- * unconditionally, so an error it cannot read is an error it cannot act on.
- */
-export function reportDiffModeConflict(message: string, format?: string): void {
-  if (format === "llm") console.log(llmError("mode_conflict", message));
-  else console.error(chalk.red("Error:"), message);
-  process.exitCode = 1;
 }
 
 /** Render a `--summary` diff as a single llm record. */
@@ -490,7 +482,7 @@ export function registerDiffCommand(program: Command): void {
     }) => {
       const conflict = detectDiffModeConflict(opts);
       if (conflict) {
-        reportDiffModeConflict(conflict, opts.format);
+        reportModeConflict(conflict, opts.format);
         return;
       }
       const client = new IxClient(getEndpoint());

--- a/ix-cli/src/cli/commands/diff.ts
+++ b/ix-cli/src/cli/commands/diff.ts
@@ -6,6 +6,53 @@ import { promisify } from "node:util";
 import type { Command } from "commander";
 import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
+
+/**
+ * Subset of `DiffOptions` consumed by `detectDiffModeConflict`. Kept as a
+ * structural type so the detector can be unit-tested without driving Commander.
+ */
+export interface DiffModeOptions {
+  summary?: boolean;
+  content?: boolean;
+  full?: boolean;
+  limit?: string;
+}
+
+/**
+ * Detect mutually-incompatible output flags on `ix diff` and return a
+ * human-readable message naming the conflict, or `undefined` if no conflict.
+ *
+ * The action handler early-returns on `--summary` before the `--content` branch
+ * is reached, so passing both flags silently dropped `--content` (and the user
+ * got a summary when they asked for the full textual diff). Catching the
+ * combination up front and surfacing it as a hard error mirrors the
+ * explicit-conflict style in subsystems.ts. `--full --limit <n>` is also
+ * flagged: `--full` is documented as "no limit" so the silent precedence over
+ * `--limit` was the same kind of UX gap.
+ */
+export function detectDiffModeConflict(
+  opts: DiffModeOptions,
+): string | undefined {
+  if (opts.summary && opts.content) {
+    return "--summary and --content cannot be combined; --summary renders counts only, --content renders the full textual diff. Pick one.";
+  }
+  if (opts.full && opts.limit !== undefined) {
+    return "--full and --limit cannot be combined; --full is documented to return all changes without a limit. Drop --limit, or drop --full to keep the existing limit.";
+  }
+  if (
+    opts.summary &&
+    (opts.full || opts.limit !== undefined)
+  ) {
+    return "--summary ignores --limit and --full; --summary is server-side counts only. Drop --summary to control change volume, or drop --limit/--full.";
+  }
+  return undefined;
+}
+
+/** Render a detected mode conflict and mark the process exit code. */
+export function reportDiffModeConflict(message: string): void {
+  console.error(chalk.red("Error:"), message);
+  process.exitCode = 1;
+}
 import { getEndpoint } from "../config.js";
 import { resolveFileOrEntity, resolveEntityFull, printResolved, looksFileLike, type ResolvedEntity } from "../resolve.js";
 import { formatDiff, relativePath } from "../format.js";
@@ -431,6 +478,11 @@ export function registerDiffCommand(program: Command): void {
       entity?: string; summary?: boolean; content?: boolean; limit?: string; full?: boolean; format: string;
       kind?: string; path?: string; pick?: number;
     }) => {
+      const conflict = detectDiffModeConflict(opts);
+      if (conflict) {
+        reportDiffModeConflict(conflict);
+        return;
+      }
       const client = new IxClient(getEndpoint());
       const from = parseInt(fromRev, 10);
       const to = parseInt(toRev, 10);

--- a/ix-cli/src/cli/llm.ts
+++ b/ix-cli/src/cli/llm.ts
@@ -18,6 +18,8 @@
  *     newlines/tabs are encoded as `\n`/`\r`/`\t` so a record never spans lines.
  */
 
+import chalk from "chalk";
+
 /** A field value before rendering. Nullish/empty values are omitted. */
 export type LlmValue = string | number | boolean | null | undefined;
 
@@ -97,4 +99,27 @@ export function printLlmLines(lines: Array<string | null | undefined>): void {
   for (const line of lines) {
     if (line != null) console.log(line);
   }
+}
+
+/**
+ * Report a mutually-exclusive flag combination in the format the caller asked
+ * for, and mark the run failed.
+ *
+ * Both halves matter. `--format llm` gets the `error code=... message="..."`
+ * record on stdout that imports.ts, trace.ts, locate.ts and callers.ts already
+ * emit and that docs/llm-format.md specifies: an agent is told to pass the flag
+ * unconditionally, so an error it cannot parse is an error it cannot act on.
+ * Every other format gets the human line on stderr, so a `--format json` caller
+ * piping to `jq` never finds prose in the payload.
+ *
+ * One function because it was otherwise written twice, byte for byte including
+ * its docblock, in `context.ts` and `diff.ts`. What it encodes -- which stream,
+ * which record kind, which exit code -- is a convention that has to change
+ * everywhere at once or not at all, and `subsystems.ts` already carries six
+ * copies of the stderr half for the same reason.
+ */
+export function reportModeConflict(message: string, format?: string): void {
+  if (format === "llm") console.log(llmError("mode_conflict", message));
+  else console.error(chalk.red("Error:"), message);
+  process.exitCode = 1;
 }

--- a/skills/ix/references/commands.md
+++ b/skills/ix/references/commands.md
@@ -97,7 +97,9 @@ ix inventory --kind function --path auth.py --format llm
 - Use `ix inventory` instead of `ix search ""` for listing entities by kind.
 - Use `ix diff --summary` for broad revision comparisons; `--full` only when
   every individual change is needed.
-- Always use `--limit` to cap result sets.
+- Always use `--limit` to cap result sets. Not on `ix diff --summary` or
+  `ix diff --full`, though: each already fixes the volume, so `--limit`
+  alongside either is refused rather than silently ignored.
 - Use `--path` or `--language` to restrict text searches.
 - Reuse exact entity IDs from previous JSON results when chaining commands.
 - Decompose large questions into multiple targeted calls.


### PR DESCRIPTION
Carries **@Alot1z's** commit from #457 (`ea26d93`) plus a fix commit, on a branch in this repo. Pushing to their fork is not something I can do from here — #457 could not be updated in place, and it was conflicting with `main` besides. **Supersedes #457**; the original is still open for @Alot1z to look at.

## The feature

`ix context --list` enumerates saved investigations. Nothing else showed you what you had stored — the only path was reading the JSON files directly.

## What the fix commit changes

**The skip report was in the payload.** `listInvestigations` called `renderWarning`, and every renderer in `ui.ts` writes to **stdout**. One corrupt file therefore prepended a chalk-coloured prose line to the JSON:

```
$ ix context --list --format json | jq .
  Warning  1 saved investigation file(s) did not match the contract; skipped...
parse error: Invalid numeric literal at line 1
```

`--format llm` got the same line in the middle of a record stream. The enumerator counts skips and returns the count now; the renderer reports it in each format's own terms — stderr for the human warning, a `skipped=` field on the `investigations` record for llm, and nothing at all when nothing was skipped. A test pins that the enumerator prints nothing whatsoever, and another pins that JSON still parses with three files skipped.

**Records go through `llmLine`.** They were built with template literals, so a target name containing a space would split the record. Same fix as #456.

**Validation is `savedInvestigationSchema` now.** #455 landed in `main` while this sat, so the hand-rolled envelope check (`schema !== "ix-investigation/1"` then a separate bundle parse) is gone — one contract, the same one the write side and `loadInvestigation` enforce, with the same `parsed.data` assertion.

**`--list` with `--save`/`--diff`/`--resume` exits non-zero.** It warned and exited 0, which tells a script that the listing it never got was fine. `refuseInvestigation`, two functions down in the same file, already sets the status this way.

## Verification

1000 tests green, lint, typecheck and knip clean, against `main` as merged.