### PR TITLE
feat(context): surface effective/requested/saved budgets on `ix context --diff`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,7 +267,9 @@ ix inventory --kind function --format json
 - Use `ix inventory` instead of `ix search ""` for listing entities by kind
 - Use `ix diff --summary` for broad revision comparisons (server-side, fast)
 - Use `--full` only when you need every individual change
-- Always use `--limit` to cap result sets
+- Always use `--limit` to cap result sets — except on `ix diff`, where
+  `--summary` and `--full` each already fix the volume and passing `--limit`
+  alongside either is refused rather than silently ignored
 - Use `--format llm` when you are reading the output; `--format json` only when chaining results between commands or extracting a specific field
 - Use `--path` or `--language` to restrict text searches
 - Use exact entity IDs from previous JSON results

--- a/docs/llm-format.md
+++ b/docs/llm-format.md
@@ -135,16 +135,37 @@ is not enough: the id is the backend's, and the statement is what changed.
 
 ```
 investigations total=2 skipped=1
-investigation id=widget saved_at=2026-01-03T09:12:44.108Z target=Widget target_kind=class classification=current entities=12 relationships=20 evidence=8
-investigation id=auth-path saved_at=2026-01-02T17:03:11.882Z target=verify_token target_kind=function classification=stale stale=true entities=31 relationships=64 evidence=25 truncated_evidence=4
+investigation id=widget saved_at=2026-01-03T09:12:44.108Z target=Widget target_kind=class classification=current stale=false entities=12 relationships=20 evidence=8 truncated_entities=0 truncated_relationships=0 truncated_evidence=0 truncated_chars=0
+investigation id=auth-path saved_at=2026-01-02T17:03:11.882Z target=verify_token target_kind=function classification=stale stale=true entities=31 relationships=64 evidence=25 truncated_entities=0 truncated_relationships=0 truncated_evidence=4 truncated_chars=0
 ```
 
 `skipped` counts saved files that did not match the contract and is present
 only when it is non-zero — it is the one thing about a listing that cannot be
-seen from the records themselves. `id` is the id `--resume` and `--diff` take,
-not the file name on disk; the two differ whenever an id contains a character
-outside `[A-Za-z0-9._-]`. The counts describe each bundle; the bundles
-themselves are not in the listing, and `ix context --resume <id>` fetches one.
+seen from the records themselves. Note that `stale=` and the four `truncated_*`
+fields are *not* dropped when zero or false: `llmField` omits only nullish and
+empty-string values, and these say "measured, and it was none", which a missing
+field does not.
+
+`id` is the id `--resume` and `--diff` take, not necessarily the file name on
+disk; the two differ whenever an id contains a character outside
+`[A-Za-z0-9._-]`. Both forms load, because the encoding is not always
+reversible — above U+00FF the escape width is ambiguous, and the listing shows
+the stored name rather than guess.
+
+The counts describe each bundle; the bundles themselves are not in the listing,
+and `ix context --resume <id>` fetches one:
+
+```
+resumed id=widget saved_at=2026-01-03T09:12:44.108Z
+context target=Widget target_kind=class stale=false classification=current entities=2 relationships=1 claims=1 decisions=0 conflicts=0 intents=0 evidence=7 truncated_entities=0 truncated_relationships=0 truncated_evidence=0 truncated_chars=0
+evidence score=0 kind=target title="Widget (class)"
+```
+
+`resumed`, not `investigation`: the record kinds are distinct because the
+shapes are, and a consumer routing on the kind should not have to guess which
+of two field sets it is holding. `saved_at` is on it because the `context`
+record that follows says whether the snapshot was fresh when it was taken, not
+when that was.
 
 Error line:
 

--- a/docs/llm-format.md
+++ b/docs/llm-format.md
@@ -83,21 +83,54 @@ contains method=12 field=4
 item name=parseFile kind=method
 ```
 
+`ix context <target>`:
+
+```
+context target=Widget target_kind=class stale=false classification=current entities=2 relationships=1 claims=1 decisions=0 conflicts=0 intents=0 evidence=7 truncated_entities=0 truncated_relationships=0 truncated_evidence=0 truncated_chars=0
+evidence score=0 kind=target title="Widget (class)"
+evidence score=20 kind=claim title="renders to DOM"
+evidence score=30 kind=relationship title="entity-1 --calls--> entity-2"
+```
+
+One header record, then the ranked evidence. The entity, relationship and claim
+lists stay counts here — `llm` is the token-minimal surface and the ranked
+evidence is what it exists to deliver; `--format json` carries the rest.
+
 `ix context --diff <id>`:
 
 ```
-diff investigation=widget target=Widget freshness_previous=current freshness_current=stale
+diff investigation=widget target=Widget saved_at=2026-01-03T09:12:44.108Z generated_at=2026-01-19T11:02:07.441Z freshness_previous=current freshness_current=stale
+budgets scope=saved entities=50 relationships=100 evidence=25 chars=12000
+budgets scope=requested entities=10 applied=false
+budgets scope=effective entities=50 relationships=100 evidence=25 chars=12000
 count added_entities=1 removed_entities=0 added_relationships=1 removed_relationships=1 added_evidence=2 removed_evidence=1 added_claims=1 removed_claims=0
-entity change=added kind=method name=mount
+entity change=added id=entity-3 kind=method name=mount path=src/widget.ts
 relationship change=removed src=entity-1 pred=calls dst=entity-2
 evidence change=added score=30 kind=relationship title="entity-1 --holds--> entity-3"
-claim change=added id="claim-mounts to DOM" status=active
+claim change=added id=c-8f31a2 entity=entity-1 status=active statement="mounts to DOM"
 ```
 
 The counts keep their zeros: "nothing was added" is the answer `--diff` was
 asked for, not a default worth dropping. Added and removed share one record
 kind and separate on `change=`, so a consumer routing on `entity` sees both
 sides of the comparison.
+
+`saved_at` is when the baseline snapshot was taken. `freshness_previous` says
+whether it was fresh *then*, not how long ago that was, so a snapshot from five
+minutes ago and one from three months ago read identically without it.
+
+The three `budgets` records say which limits governed the comparison.
+`scope=saved` is the saved investigation's, `scope=effective` is what the fresh
+bundle was actually built with, and `scope=requested` appears only when
+`--max-*` flags were passed — carrying `applied=`, because saved budgets govern
+`--diff` and a flag that changed nothing is worth saying so in a field a
+consumer can test.
+
+An `entity` record carries `id=` because `relationship` records name their
+endpoints by entity id; without it `src=`/`dst=` resolve to nothing the reader
+has seen. A `claim` record carries `statement=` for the same reason its `id=`
+is not enough: the id is the backend's, and the statement is what changed.
+
 `ix context --list`:
 
 ```

--- a/docs/llm-format.md
+++ b/docs/llm-format.md
@@ -83,6 +83,21 @@ contains method=12 field=4
 item name=parseFile kind=method
 ```
 
+`ix context --list`:
+
+```
+investigations total=2 skipped=1
+investigation id=widget saved_at=2026-01-03T09:12:44.108Z target=Widget target_kind=class classification=current entities=12 relationships=20 evidence=8
+investigation id=auth-path saved_at=2026-01-02T17:03:11.882Z target=verify_token target_kind=function classification=stale stale=true entities=31 relationships=64 evidence=25 truncated_evidence=4
+```
+
+`skipped` counts saved files that did not match the contract and is present
+only when it is non-zero — it is the one thing about a listing that cannot be
+seen from the records themselves. `id` is the id `--resume` and `--diff` take,
+not the file name on disk; the two differ whenever an id contains a character
+outside `[A-Za-z0-9._-]`. The counts describe each bundle; the bundles
+themselves are not in the listing, and `ix context --resume <id>` fetches one.
+
 Error line:
 
 ```

--- a/docs/llm-format.md
+++ b/docs/llm-format.md
@@ -83,6 +83,22 @@ contains method=12 field=4
 item name=parseFile kind=method
 ```
 
+`ix context --diff <id>`:
+
+```
+diff investigation=widget target=Widget freshness_previous=current freshness_current=stale
+count added_entities=1 removed_entities=0 added_relationships=1 removed_relationships=1 added_evidence=2 removed_evidence=1 added_claims=1 removed_claims=0
+entity change=added kind=method name=mount
+relationship change=removed src=entity-1 pred=calls dst=entity-2
+evidence change=added score=30 kind=relationship title="entity-1 --holds--> entity-3"
+claim change=added id="claim-mounts to DOM" status=active
+```
+
+The counts keep their zeros: "nothing was added" is the answer `--diff` was
+asked for, not a default worth dropping. Added and removed share one record
+kind and separate on `change=`, so a consumer routing on `entity` sees both
+sides of the comparison.
+
 Error line:
 
 ```

--- a/ix-cli/src/cli/__tests__/context-investigation.test.ts
+++ b/ix-cli/src/cli/__tests__/context-investigation.test.ts
@@ -22,6 +22,7 @@ import {
   parseRequestedBudgets,
   renderBundle,
   renderInvestigationDiff,
+  renderSavedInvestigation,
   saveInvestigation,
 } from "../commands/context.js";
 
@@ -91,6 +92,41 @@ function captureWarnings(fn: () => void): string {
   // chalk wraps the message as a whole, so the text stays contiguous; strip the
   // colour codes anyway so a CI run with colour forced on matches a local one.
   return lines.join("\n").replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+/**
+ * Run `fn` with stdout and stderr captured separately.
+ *
+ * One helper for the file. There were three, and they disagreed: two joined a
+ * multi-argument `console.log` with a space, the third pushed each argument as
+ * its own line, so identical output produced different arrays depending on
+ * which block a test happened to sit in.
+ */
+function captureStreams(fn: () => void): { out: string[]; err: string[] } {
+  const out: string[] = [];
+  const err: string[] = [];
+  const origLog = console.log;
+  const origErr = console.error;
+  console.log = (...a: unknown[]) => void out.push(a.map(String).join(" "));
+  console.error = (...a: unknown[]) => void err.push(a.map(String).join(" "));
+  try {
+    fn();
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+  }
+  return { out, err };
+}
+
+/** The same, joined the way a terminal shows it. */
+function captureText(fn: () => void): { out: string; err: string } {
+  const { out, err } = captureStreams(fn);
+  return { out: out.join("\n"), err: err.join("\n") };
+}
+
+/** Just the stdout half, for the renderers that write nothing else. */
+function captureLog(fn: () => void): string[] {
+  return captureStreams(fn).out;
 }
 
 function makeFacts(overrides: Partial<EntityFacts> = {}): EntityFacts {
@@ -401,10 +437,13 @@ describe("ix context investigation state", () => {
     saveInvestigation("widget-check", bundle);
     const stored = loadInvestigation("widget-check")!;
 
-    expect(mergeDiffOptions(stored, {})).toEqual({ asOfRev: "7", depth: "2" });
-    expect(mergeDiffOptions(stored, { asOfRev: "3" })).toEqual({ asOfRev: "3", depth: "2" });
-    expect(mergeDiffOptions(stored, { depth: "4" })).toEqual({ asOfRev: "7", depth: "4" });
-    expect(mergeDiffOptions(stored, { asOfRev: "3", depth: "4" })).toEqual({ asOfRev: "3", depth: "4" });
+    // Numbers, not strings: `--as-of-rev` is validated by its Commander
+    // argParser now, so the round trip out to a string and back through
+    // `parseInt` is gone.
+    expect(mergeDiffOptions(stored, {})).toEqual({ asOfRev: 7, depth: "2" });
+    expect(mergeDiffOptions(stored, { asOfRev: 3 })).toEqual({ asOfRev: 3, depth: "2" });
+    expect(mergeDiffOptions(stored, { depth: "4" })).toEqual({ asOfRev: 7, depth: "4" });
+    expect(mergeDiffOptions(stored, { asOfRev: 3, depth: "4" })).toEqual({ asOfRev: 3, depth: "4" });
   });
 
   it("never collides or escapes for hostile investigation ids", () => {
@@ -472,9 +511,17 @@ describe("ix context investigation state", () => {
     expect(overrideDiff.budgets.requestedApplied).toBe(false);
     expect(overrideDiff.budgets.note).toMatch(/were not applied to the fresh side/i);
 
-    // …and it reads true when they do match what the bundle was built with.
+    // Still false when the numbers happen to agree, which is the case that
+    // makes "requested equals effective" the wrong derivation: `--max-evidence
+    // 25` against a fresh side already built with 25 changes nothing, and
+    // reporting true there told an agent its override had taken.
     const matching = parseRequestedBudgets({ maxEntities: 50, maxEvidence: 25 });
-    expect(diffInvestigations(stored, fresh, matching).budgets.requestedApplied).toBe(true);
+    const agreeing = diffInvestigations(stored, fresh, matching);
+    expect(agreeing.budgets.requested).toEqual({ maxEntities: 50, maxEvidence: 25 });
+    expect(agreeing.budgets.effective).toEqual(fresh.budgets);
+    expect(agreeing.budgets.requestedApplied).toBe(false);
+    // …and the note beside it says the same thing, in every format.
+    expect(agreeing.budgets.note).toMatch(/were not applied to the fresh side/i);
   });
 
   it("records exactly the --max-* flags that were passed", () => {
@@ -535,7 +582,7 @@ describe("ix context investigation state", () => {
     // carries `applied=` so the precedence rule — saved budgets govern
     // --diff — is a field an agent can test rather than a sentence to read.
     expect(llm.lines).toContain("budgets scope=saved entities=5 relationships=1 evidence=2 chars=12000");
-    expect(llm.lines).toContain("budgets scope=requested evidence=25 applied=true");
+    expect(llm.lines).toContain("budgets scope=requested evidence=25 applied=false");
     expect(llm.lines).toContain("budgets scope=effective entities=50 relationships=100 evidence=25 chars=12000");
     // And none of the prose survives into the record stream.
     expect(llm.lines.some((l) => l.includes(":") && l.startsWith("  "))).toBe(false);
@@ -554,8 +601,11 @@ describe("ix context investigation state", () => {
     expect(parsed.budgets.requested).toEqual(requested);
     expect(parsed.budgets.effective).toEqual(fresh.budgets);
     // The same fact the llm record carries as `applied=`, so a JSON consumer
-    // does not have to string-match an English sentence for it.
-    expect(parsed.budgets.requestedApplied).toBe(true);
+    // does not have to string-match an English sentence for it — and it agrees
+    // with the note and with the text renderer's "not applied" label, which a
+    // value comparison did not.
+    expect(parsed.budgets.requestedApplied).toBe(false);
+    expect(parsed.budgets.note).toMatch(/were not applied to the fresh side/i);
   });
 
   // `--diff --format llm` used to fall through to the prose renderer, because
@@ -563,19 +613,6 @@ describe("ix context investigation state", () => {
   // by `llmLine`, so a value carrying a space is quoted rather than splitting
   // the record. These tests pin that.
   describe("--format llm rendering", () => {
-    function captureLog(fn: () => void): string[] {
-      const lines: string[] = [];
-      const orig = console.log;
-      console.log = (...args: unknown[]) => {
-        for (const arg of args) lines.push(String(arg));
-      };
-      try {
-        fn();
-      } finally {
-        console.log = orig;
-      }
-      return lines;
-    }
 
     it("emits a header and counts for an empty diff without falling back to prose", () => {
       const saved = bundleWith([makeClaim("renders to DOM", 0.9)]);
@@ -748,6 +785,24 @@ describe("ix context investigation state", () => {
       expect(lines[0]).toMatch(/^context target=Widget target_kind=class /);
     });
 
+    it("gives --resume its own record kind, not --list's", () => {
+      // Both emitted `investigation`, with two fields here and thirteen there,
+      // so a consumer routing on the record kind could not tell which shape to
+      // expect and reading `target` off this one yielded undefined.
+      const saved = bundleWith([makeClaim("renders to DOM", 0.9)]);
+      saveInvestigation("widget-resume", saved);
+      const lines = captureLog(() => renderSavedInvestigation("widget-resume", "llm"));
+
+      expect(lines[0]).toMatch(/^resumed id=widget-resume saved_at=/);
+      // …and it carries the one fact the bundle records do not: when the
+      // snapshot was taken. `classification=current` says it was fresh then,
+      // not when then was.
+      expect(lines[0]).toMatch(/saved_at=\d{4}-\d{2}-\d{2}T/);
+      // The prose note it replaces is gone from the record stream.
+      expect(lines.some((l) => l.includes("Resumed investigation"))).toBe(false);
+      expect(lines[1]).toMatch(/^context target=Widget/);
+    });
+
     it("does not regress the prose (text) renderer", () => {
       const saved = bundleWith([makeClaim("renders to DOM", 0.9)]);
       saveInvestigation("widget-llm-text", saved);
@@ -767,31 +822,6 @@ describe("ix context investigation state", () => {
   // Without it, neither humans nor agents can see what they have stored —
   // the only path was reading the JSON files directly.
   describe("listInvestigations", () => {
-    /**
-     * Run `fn` with stdout and stderr captured separately.
-     *
-     * One helper for the whole block, and multi-arg calls joined with a space
-     * the way a terminal shows them: the two ad-hoc capturers this replaces
-     * disagreed on that (one joined, one pushed each argument as its own line),
-     * so identical output produced different arrays depending on which test you
-     * happened to be reading.
-     */
-    const captureStreams = (fn: () => void) => {
-      const out: string[] = [];
-      const err: string[] = [];
-      const origLog = console.log;
-      const origErr = console.error;
-      console.log = (...a: unknown[]) => void out.push(a.join(" "));
-      console.error = (...a: unknown[]) => void err.push(a.join(" "));
-      try {
-        fn();
-      } finally {
-        console.log = origLog;
-        console.error = origErr;
-      }
-      return { out: out.join("\n"), err: err.join("\n") };
-    };
-
     /** Restamp a saved investigation's `savedAt`, leaving everything else alone. */
     const stampSavedAt = (id: string, savedAt: string) => {
       const path = join(investigationsDir(), `${id}.json`);
@@ -840,14 +870,47 @@ describe("ix context investigation state", () => {
       // `widget/auth` was saved as `widget~2Fauth` and listed as that, and
       // resuming it looked for `widget~7E2Fauth`, which does not exist.
       saveInvestigation("widget/auth", bundleWith([makeClaim("renders to DOM", 0.9)]));
-      const [only] = listInvestigations().saved;
-      expect(only.id).toBe("widget~2Fauth"); // on disk, as stored
+      // Stored encoded, one file, no separator in the name.
+      expect(readdirSync(investigationsDir())).toEqual(["widget~2Fauth.json"]);
 
-      const { out } = captureStreams(() => renderInvestigationList([only], 0, "json"));
-      const listed = JSON.parse(out).investigations[0].id;
-      expect(listed).toBe("widget/auth");
+      // Decoded once, at the read boundary, so every format agrees. Decoding at
+      // each print site is how `--format llm` came to say `widget/auth` while
+      // `--format json` and the text header said `widget~2Fauth`.
+      const [only] = listInvestigations().saved;
+      expect(only.id).toBe("widget/auth");
+      const { out } = captureText(() => renderInvestigationList([only], 0, "json"));
+      expect(JSON.parse(out).investigations[0].id).toBe("widget/auth");
       // The whole point: the id the listing offers has to load.
-      expect(loadInvestigation(listed)?.bundle.target.name).toBe("Widget");
+      expect(loadInvestigation(only.id)?.bundle.target.name).toBe("Widget");
+    });
+
+    it("lists an id that --resume can take back even when it cannot be decoded", () => {
+      // `sanitizeId` writes two hex digits below U+0100 and three or four above
+      // it, so `~7528` is either one CJK code unit or `~752` followed by a
+      // literal `8` and nothing in the string says which. Guessing produced a
+      // mangled id that loaded nothing; the round-trip check refuses to guess
+      // and shows the stored name, and `loadInvestigation` accepts that form.
+      saveInvestigation("用户", bundleWith([makeClaim("renders to DOM", 0.9)]));
+      const [only] = listInvestigations().saved;
+      expect(only.id).toBe("~7528~6237");
+      expect(loadInvestigation(only.id)?.bundle.target.name).toBe("Widget");
+      // …and the id the user actually typed still reaches the same file.
+      expect(loadInvestigation("用户")?.bundle.target.name).toBe("Widget");
+    });
+
+    it("keeps an id that is literally spelled like an encoding on its own file", () => {
+      // The on-disk fallback is second, not first, so `widget~2Fauth` typed as
+      // an id finds the file it was saved to rather than the one `widget/auth`
+      // was.
+      saveInvestigation("widget/auth", bundleWith([makeClaim("renders to DOM", 0.9)]));
+      saveInvestigation("widget~2Fauth", bundleWith([makeClaim("mounts to DOM", 0.9)]));
+      expect(readdirSync(investigationsDir()).sort()).toEqual(
+        ["widget~2Fauth.json", "widget~7E2Fauth.json"],
+      );
+      const claims = (id: string) =>
+        loadInvestigation(id)!.bundle.claims.map((c) => c.statement);
+      expect(claims("widget/auth")).toContain("renders to DOM");
+      expect(claims("widget~2Fauth")).toContain("mounts to DOM");
     });
 
     it("skips files whose envelope or bundle does not match the contract", () => {
@@ -884,7 +947,7 @@ describe("ix context investigation state", () => {
       saveInvestigation("good", bundleWith([makeClaim("renders to DOM", 0.9)]));
       const { saved } = listInvestigations();
 
-      const json = captureStreams(() => renderInvestigationList(saved, 3, "json"));
+      const json = captureText(() => renderInvestigationList(saved, 3, "json"));
       expect(() => JSON.parse(json.out)).not.toThrow();
       const parsed = JSON.parse(json.out);
       expect(parsed.investigations).toHaveLength(1);
@@ -893,18 +956,18 @@ describe("ix context investigation state", () => {
       expect(parsed.skipped).toBe(3);
       expect(json.err).toContain("3 saved investigation file(s)");
 
-      const llm = captureStreams(() => renderInvestigationList(saved, 3, "llm"));
+      const llm = captureText(() => renderInvestigationList(saved, 3, "llm"));
       expect(llm.out.split("\n")[0]).toBe("investigations total=1 skipped=3");
       // The count is the record's business; nothing is written beside it.
       expect(llm.err).toBe("");
 
       // And with nothing skipped the field is simply absent.
-      const clean = captureStreams(() => renderInvestigationList(saved, 0, "llm"));
+      const clean = captureText(() => renderInvestigationList(saved, 0, "llm"));
       expect(clean.out.split("\n")[0]).toBe("investigations total=1");
       expect(clean.err).toBe("");
       // `skipped` is still there in json, as a zero rather than as nothing:
       // "none were rejected" is an answer, and its absence is not.
-      const cleanJson = captureStreams(() => renderInvestigationList(saved, 0, "json"));
+      const cleanJson = captureText(() => renderInvestigationList(saved, 0, "json"));
       expect(JSON.parse(cleanJson.out).skipped).toBe(0);
     });
 
@@ -917,7 +980,7 @@ describe("ix context investigation state", () => {
       const { saved } = listInvestigations();
       expect(saved[0].bundle.evidence.length).toBeGreaterThan(0);
 
-      const { out } = captureStreams(() => renderInvestigationList(saved, 0, "json"));
+      const { out } = captureText(() => renderInvestigationList(saved, 0, "json"));
       const [item] = JSON.parse(out).investigations;
       expect(Object.keys(item).sort()).toEqual(
         ["counts", "freshness", "id", "savedAt", "target", "truncation"].sort(),

--- a/ix-cli/src/cli/__tests__/context-investigation.test.ts
+++ b/ix-cli/src/cli/__tests__/context-investigation.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdtempSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
   ConflictReport,
@@ -17,6 +17,8 @@ import {
   diffInvestigations,
   loadInvestigation,
   mergeDiffOptions,
+  parseRequestedBudgets,
+  renderInvestigationDiff,
   saveInvestigation,
 } from "../commands/context.js";
 
@@ -264,5 +266,113 @@ describe("ix context investigation state", () => {
     }
     expect(existsSync(join(home, "..", "escape.json"))).toBe(false);
     expect(existsSync(join(home, ".version-check.json"))).toBe(false);
+  });
+
+  it("exposes effective budgets on every --diff diff, sourced from the saved investigation", () => {
+    // The reproduction in B-4 showed that --max-* flags on the CLI do not change
+    // the fresh side's budget: buildFreshBundle always receives saved.bundle.budgets.
+    // The transparency fix surfaces that fact as data instead of hiding it, so
+    // agents reading the diff JSON can answer "what budget governed this comparison"
+    // without reading the source.
+    const saved = bundleWith([makeClaim("renders to DOM", 0.9)]);
+    saved.budgets = { maxEntities: 5, maxRelationships: 1, maxEvidence: 2, maxChars: 12000 };
+    saveInvestigation("widget-check", saved);
+    const stored = loadInvestigation("widget-check")!;
+    const fresh = bundleWith([makeClaim("renders to DOM", 0.9)]);
+
+    // Without CLI overrides, requested is absent and effective mirrors saved.
+    const baselineDiff = diffInvestigations(stored, fresh);
+    expect(baselineDiff.budgets.saved).toEqual({ maxEntities: 5, maxRelationships: 1, maxEvidence: 2, maxChars: 12000 });
+    expect(baselineDiff.budgets.requested).toBeUndefined();
+    expect(baselineDiff.budgets.effective).toEqual(baselineDiff.budgets.saved);
+    expect(baselineDiff.budgets.note).toMatch(/no --max-\* overrides/i);
+
+    // With CLI overrides parsed from raw commander strings, requested captures
+    // every flag the user passed (even ones that disagree with saved), and the
+    // note makes the precedence explicit.
+    const requested = parseRequestedBudgets({ maxEntities: "50", maxEvidence: "25", maxRelationships: "100" });
+    expect(requested).toEqual({ maxEntities: 50, maxEvidence: 25, maxRelationships: 100 });
+
+    const overrideDiff = diffInvestigations(stored, fresh, requested);
+    expect(overrideDiff.budgets.requested).toEqual(requested);
+    // Critical invariant: the fresh bundle was still built with saved budgets,
+    // so effective is the saved snapshot, not the requested one.
+    expect(overrideDiff.budgets.effective).toEqual(overrideDiff.budgets.saved);
+    expect(overrideDiff.budgets.note).toMatch(/--max-\* flags on the CLI are recorded/i);
+  });
+
+  it("treats whitespace, empty, or non-numeric --max-* strings as not provided", () => {
+    // parseRequestedBudgets must mirror commander semantics: only flag-shaped
+    // arguments count as "user override", not noise from shell quoting or
+    // accidental empty strings. This is what stops the diff output from
+    // reporting a phantom override. Numeric "0" is a real override (someone
+    // asking for "0 entities" forces an empty bundle and is what they meant),
+    // so it survives the parse — but non-strings, blanks, and NaN-producing
+    // tokens do not.
+    expect(parseRequestedBudgets({})).toBeUndefined();
+    expect(parseRequestedBudgets({ maxEntities: "", maxEvidence: "  " })).toBeUndefined();
+    expect(parseRequestedBudgets({ maxEntities: undefined })).toBeUndefined();
+    expect(parseRequestedBudgets({ maxEntities: "abc" })).toBeUndefined();
+    expect(parseRequestedBudgets({ maxEntities: "0" })).toEqual({ maxEntities: 0 });
+    expect(parseRequestedBudgets({ maxEntities: "10", maxChars: undefined })).toEqual({ maxEntities: 10 });
+    const partial = parseRequestedBudgets({ maxEntities: "10", maxEvidence: "5", maxRelationships: "0", maxChars: "12000" });
+    expect(partial).toEqual({ maxEntities: 10, maxEvidence: 5, maxRelationships: 0, maxChars: 12000 });
+  });
+
+  it("renders the budget block in --diff text and llm output", () => {
+    // Spy on console.log so we can assert exactly what humans and LLMs see.
+    // This is the regression guard for the user-visible transparency: if a
+    // future refactor flattens renderInvestigationDiff back to "entities/-
+    // +", the budget block disappears and the silent ignore comes back.
+    const saved = bundleWith([makeClaim("renders to DOM", 0.9)]);
+    saved.budgets = { maxEntities: 5, maxRelationships: 1, maxEvidence: 2, maxChars: 12000 };
+    saveInvestigation("widget-check", saved);
+    const stored = loadInvestigation("widget-check")!;
+    const fresh = bundleWith([makeClaim("renders to DOM", 0.9)]);
+    const requested = { maxEvidence: 25 };
+
+    const capture = () => {
+      const lines: string[] = [];
+      const spy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+        lines.push(args.map((a) => String(a)).join(" "));
+      });
+      return { lines, restore: () => spy.mockRestore() };
+    };
+
+    const text = capture();
+    try {
+      renderInvestigationDiff(stored, fresh, "text", requested);
+    } finally {
+      text.restore();
+    }
+    expect(text.lines.some((l) => l.includes("budgets:"))).toBe(true);
+    expect(text.lines.some((l) => l.includes("saved     :"))).toBe(true);
+    expect(text.lines.some((l) => l.includes("requested :")) && text.lines.some((l) => l.includes("evidence=25"))).toBe(true);
+    expect(text.lines.some((l) => l.includes("effective :") && l.includes("evidence=2"))).toBe(true);
+
+    const llm = capture();
+    try {
+      renderInvestigationDiff(stored, fresh, "llm", requested);
+    } finally {
+      llm.restore();
+    }
+    expect(llm.lines.some((l) => l.trim() === "budgets")).toBe(true);
+    expect(llm.lines.some((l) => l.includes("saved     :") && l.includes("evidence=2"))).toBe(true);
+    expect(llm.lines.some((l) => l.includes("requested :") && l.includes("evidence=25"))).toBe(true);
+    expect(llm.lines.some((l) => l.includes("effective :") && l.includes("evidence=2"))).toBe(true);
+
+    // json format must already cover this branch in diffInvestigations itself,
+    // but assert here that the path is wired and the renderer doesn't double-print.
+    const json = capture();
+    try {
+      renderInvestigationDiff(stored, fresh, "json", requested);
+    } finally {
+      json.restore();
+    }
+    expect(json.lines).toHaveLength(1);
+    const parsed = JSON.parse(json.lines[0].replace(/^undefined$/, ""));
+    expect(parsed.budgets.saved).toEqual(saved.budgets);
+    expect(parsed.budgets.requested).toEqual(requested);
+    expect(parsed.budgets.effective).toEqual(saved.budgets);
   });
 });

--- a/ix-cli/src/cli/__tests__/context-investigation.test.ts
+++ b/ix-cli/src/cli/__tests__/context-investigation.test.ts
@@ -426,15 +426,87 @@ describe("ix context investigation state", () => {
   // Without it, neither humans nor agents can see what they have stored —
   // the only path was reading the JSON files directly.
   describe("listInvestigations", () => {
+    /**
+     * Run `fn` with stdout and stderr captured separately.
+     *
+     * One helper for the whole block, and multi-arg calls joined with a space
+     * the way a terminal shows them: the two ad-hoc capturers this replaces
+     * disagreed on that (one joined, one pushed each argument as its own line),
+     * so identical output produced different arrays depending on which test you
+     * happened to be reading.
+     */
+    const captureStreams = (fn: () => void) => {
+      const out: string[] = [];
+      const err: string[] = [];
+      const origLog = console.log;
+      const origErr = console.error;
+      console.log = (...a: unknown[]) => void out.push(a.join(" "));
+      console.error = (...a: unknown[]) => void err.push(a.join(" "));
+      try {
+        fn();
+      } finally {
+        console.log = origLog;
+        console.error = origErr;
+      }
+      return { out: out.join("\n"), err: err.join("\n") };
+    };
+
+    /** Restamp a saved investigation's `savedAt`, leaving everything else alone. */
+    const stampSavedAt = (id: string, savedAt: string) => {
+      const path = join(investigationsDir(), `${id}.json`);
+      const state = JSON.parse(readFileSync(path, "utf8"));
+      writeFileSync(path, JSON.stringify({ ...state, savedAt }), "utf8");
+    };
+
     it("returns saved investigations newest-first", () => {
+      // The timestamps are set explicitly because `saveInvestigation` stamps
+      // them from the clock and three writes inside one millisecond is the
+      // ordinary case, not the rare one. The previous version of this test
+      // asserted `saved[0].id === "widget-a" || saved[0].id === "widget-b"` and
+      // called `.sort()` on the ids before comparing them, so it was true for
+      // either order: inverting the comparator left every assertion green and
+      // ordering — the function's whole stated purpose — had no coverage.
       saveInvestigation("widget-a", bundleWith([makeClaim("renders to DOM", 0.9)]));
       saveInvestigation("widget-b", bundleWith([makeClaim("mounts to DOM", 0.7)]));
+      saveInvestigation("widget-c", bundleWith([makeClaim("unmounts cleanly", 0.5)]));
+      stampSavedAt("widget-a", "2026-01-02T00:00:00.000Z");
+      stampSavedAt("widget-b", "2026-01-03T00:00:00.000Z");
+      stampSavedAt("widget-c", "2026-01-01T00:00:00.000Z");
+
       const list = listInvestigations();
-      expect(list.saved.map((s) => s.id).sort()).toEqual(["widget-a", "widget-b"]);
+      expect(list.saved.map((s) => s.id)).toEqual(["widget-b", "widget-a", "widget-c"]);
       expect(list.skipped).toBe(0);
-      // savedAt differs at least by a millisecond across the two writes; even
-      // on the rare same-ms tie the id tiebreaker keeps order deterministic.
-      expect(list.saved[0].id === "widget-a" || list.saved[0].id === "widget-b").toBe(true);
+    });
+
+    it("breaks a same-millisecond tie on the id, stably", () => {
+      // The reason the comparator has a second clause at all: two saves in the
+      // same millisecond must still come back in the same order every run.
+      for (const id of ["widget-c", "widget-a", "widget-b"]) {
+        saveInvestigation(id, bundleWith([makeClaim("renders to DOM", 0.9)]));
+        stampSavedAt(id, "2026-01-01T00:00:00.000Z");
+      }
+      expect(listInvestigations().saved.map((s) => s.id)).toEqual([
+        "widget-a",
+        "widget-b",
+        "widget-c",
+      ]);
+    });
+
+    it("lists an id that --resume can actually take back", () => {
+      // `sanitizeId` is injective and deliberately not idempotent — it encodes
+      // `~` as `~7E` so a raw `~` cannot be mistaken for an escape — so the id
+      // stored on disk is the wrong thing to print next to "Resume with:".
+      // `widget/auth` was saved as `widget~2Fauth` and listed as that, and
+      // resuming it looked for `widget~7E2Fauth`, which does not exist.
+      saveInvestigation("widget/auth", bundleWith([makeClaim("renders to DOM", 0.9)]));
+      const [only] = listInvestigations().saved;
+      expect(only.id).toBe("widget~2Fauth"); // on disk, as stored
+
+      const { out } = captureStreams(() => renderInvestigationList([only], 0, "json"));
+      const listed = JSON.parse(out).investigations[0].id;
+      expect(listed).toBe("widget/auth");
+      // The whole point: the id the listing offers has to load.
+      expect(loadInvestigation(listed)?.bundle.target.name).toBe("Widget");
     });
 
     it("skips files whose envelope or bundle does not match the contract", () => {
@@ -471,36 +543,46 @@ describe("ix context investigation state", () => {
       saveInvestigation("good", bundleWith([makeClaim("renders to DOM", 0.9)]));
       const { saved } = listInvestigations();
 
-      const capture = (fn: () => void) => {
-        const out: string[] = [];
-        const err: string[] = [];
-        const origLog = console.log;
-        const origErr = console.error;
-        console.log = (...a: unknown[]) => void out.push(a.join(" "));
-        console.error = (...a: unknown[]) => void err.push(a.join(" "));
-        try {
-          fn();
-        } finally {
-          console.log = origLog;
-          console.error = origErr;
-        }
-        return { out: out.join("\n"), err: err.join("\n") };
-      };
-
-      const json = capture(() => renderInvestigationList(saved, 3, "json"));
+      const json = captureStreams(() => renderInvestigationList(saved, 3, "json"));
       expect(() => JSON.parse(json.out)).not.toThrow();
-      expect(JSON.parse(json.out)).toHaveLength(1);
+      const parsed = JSON.parse(json.out);
+      expect(parsed.investigations).toHaveLength(1);
+      // An array had nowhere to put this, so a machine caller could not tell
+      // three files had been rejected while the human saw a warning saying so.
+      expect(parsed.skipped).toBe(3);
       expect(json.err).toContain("3 saved investigation file(s)");
 
-      const llm = capture(() => renderInvestigationList(saved, 3, "llm"));
+      const llm = captureStreams(() => renderInvestigationList(saved, 3, "llm"));
       expect(llm.out.split("\n")[0]).toBe("investigations total=1 skipped=3");
       // The count is the record's business; nothing is written beside it.
       expect(llm.err).toBe("");
 
       // And with nothing skipped the field is simply absent.
-      const clean = capture(() => renderInvestigationList(saved, 0, "llm"));
+      const clean = captureStreams(() => renderInvestigationList(saved, 0, "llm"));
       expect(clean.out.split("\n")[0]).toBe("investigations total=1");
       expect(clean.err).toBe("");
+      // `skipped` is still there in json, as a zero rather than as nothing:
+      // "none were rejected" is an answer, and its absence is not.
+      const cleanJson = captureStreams(() => renderInvestigationList(saved, 0, "json"));
+      expect(JSON.parse(cleanJson.out).skipped).toBe(0);
+    });
+
+    it("returns a summary per investigation, not the bundles themselves", () => {
+      // `--list` is the discovery step. Twenty saved investigations is twenty
+      // complete bundles — up to 50 entities, 100 relationships and 12000
+      // characters of evidence each — and a caller that wants one of them asks
+      // for it by id with `--resume <id> --format json`.
+      saveInvestigation("widget", bundleWith([makeClaim("renders to DOM", 0.9)]));
+      const { saved } = listInvestigations();
+      expect(saved[0].bundle.evidence.length).toBeGreaterThan(0);
+
+      const { out } = captureStreams(() => renderInvestigationList(saved, 0, "json"));
+      const [item] = JSON.parse(out).investigations;
+      expect(Object.keys(item).sort()).toEqual(
+        ["counts", "freshness", "id", "savedAt", "target", "truncation"].sort(),
+      );
+      expect(item.counts.evidence).toBe(saved[0].bundle.evidence.length);
+      expect(out).not.toContain("renders to DOM");
     });
 
     it("prints nothing itself, whatever it finds", () => {

--- a/ix-cli/src/cli/__tests__/context-investigation.test.ts
+++ b/ix-cli/src/cli/__tests__/context-investigation.test.ts
@@ -294,22 +294,20 @@ describe("ix context investigation state", () => {
 
       const lines = captureLog(() => renderInvestigationDiff(stored, fresh, "llm"));
 
-      expect(lines[0]).toBe("diff investigation=widget-llm target=Widget");
-      expect(lines).toContain("freshness_previous=current");
-      expect(lines).toContain("freshness_current=current");
-      expect(lines).toContain("count added_entities=0");
-      expect(lines).toContain("count removed_entities=0");
-      expect(lines).toContain("count added_relationships=0");
-      expect(lines).toContain("count removed_relationships=0");
-      expect(lines).toContain("count added_evidence=0");
-      expect(lines).toContain("count removed_evidence=0");
-      expect(lines).toContain("count added_claims=0");
-      expect(lines).toContain("count removed_claims=0");
+      expect(lines[0]).toBe(
+        "diff investigation=widget-llm target=Widget freshness_previous=current freshness_current=current",
+      );
+      // Zero is the answer to the question --diff was asked, so it is carried
+      // rather than dropped as a default.
+      expect(lines[1]).toBe(
+        "count added_entities=0 removed_entities=0 added_relationships=0 removed_relationships=0" +
+          " added_evidence=0 removed_evidence=0 added_claims=0 removed_claims=0",
+      );
       // No `renderSection` lines means we did not fall back to prose.
       expect(lines.some((l) => l.startsWith("==") || l.startsWith("  "))).toBe(false);
     });
 
-    it("lists added/removed entities, relationships, evidence and claims with +/- prefixes", () => {
+    it("lists added and removed entities, relationships, evidence and claims", () => {
       const saved = bundleWith([makeClaim("renders to DOM", 0.9)]);
       saveInvestigation("widget-llm-busy", saved);
       const stored = loadInvestigation("widget-llm-busy")!;
@@ -363,36 +361,30 @@ describe("ix context investigation state", () => {
       // skolem IDs are `claim:<claim_id>` and
       // `relationship:<src>:<dst>:<predicate>`, so a stale predicate in the
       // ranked evidence list yields a real added/removed pair.
-      expect(lines).toContain("count added_entities=1");
-      expect(lines).toContain("count removed_entities=0");
-      expect(lines).toContain("count added_relationships=1");
-      expect(lines).toContain("count removed_relationships=1");
-      expect(lines).toContain("count added_evidence=2");
-      expect(lines).toContain("count removed_evidence=1");
-      expect(lines).toContain("count added_claims=1");
-      expect(lines).toContain("count removed_claims=0");
+      expect(lines[1]).toBe(
+        "count added_entities=1 removed_entities=0 added_relationships=1 removed_relationships=1" +
+          " added_evidence=2 removed_evidence=1 added_claims=1 removed_claims=0",
+      );
 
-      // Items tagged with +/- so an agent can route without parsing prose.
-      expect(lines).toContain("+entity kind=method name=mount");
-      expect(lines).toContain("-relationship src=entity-1 pred=calls dst=entity-2");
-      expect(lines).toContain("+relationship src=entity-1 pred=holds dst=entity-3");
-      expect(lines).toContain("+claim id=claim-mounts to DOM");
-      expect(
-        lines.some(
-          (l) =>
-            l.startsWith("+evidence ") &&
-            l.includes("kind=relationship") &&
-            l.includes("entity-1 --holds--> entity-3"),
-        ),
-      ).toBe(true);
-      expect(
-        lines.some(
-          (l) =>
-            l.startsWith("-evidence ") &&
-            l.includes("kind=relationship") &&
-            l.includes("entity-1 --calls--> entity-2"),
-        ),
-      ).toBe(true);
+      // The change is a field, not a prefix fused to the record kind, so a
+      // consumer routing on `entity` matches both sides of the comparison.
+      expect(lines).toContain("entity change=added kind=method name=mount");
+      expect(lines).toContain("relationship change=removed src=entity-1 pred=calls dst=entity-2");
+      expect(lines).toContain("relationship change=added src=entity-1 pred=holds dst=entity-3");
+
+      // A claim id carries the statement, so it contains spaces — quoted, per
+      // docs/llm-format.md. Unquoted, `id=claim-mounts to DOM` is three tokens
+      // and a consumer reads the id as `claim-mounts`.
+      expect(lines).toContain('claim change=added id="claim-mounts to DOM" status=active');
+
+      // An evidence title is a sentence. Same rule, and the reason the value
+      // must never be built with a template literal.
+      expect(lines).toContain(
+        'evidence change=added score=30 kind=relationship title="entity-1 --holds--> entity-3"',
+      );
+      expect(lines).toContain(
+        'evidence change=removed score=30 kind=relationship title="entity-1 --calls--> entity-2"',
+      );
 
       // One record per line — the wire format invariant.
       for (const line of lines) expect(line).not.toContain("\n");

--- a/ix-cli/src/cli/__tests__/context-investigation.test.ts
+++ b/ix-cli/src/cli/__tests__/context-investigation.test.ts
@@ -17,6 +17,7 @@ import {
   diffInvestigations,
   loadInvestigation,
   mergeDiffOptions,
+  renderInvestigationDiff,
   saveInvestigation,
 } from "../commands/context.js";
 
@@ -264,5 +265,151 @@ describe("ix context investigation state", () => {
     }
     expect(existsSync(join(home, "..", "escape.json"))).toBe(false);
     expect(existsSync(join(home, ".version-check.json"))).toBe(false);
+  });
+
+  // `--diff --format llm` used to fall through to the prose renderer (the
+  // diff path only branched on `json`). The llm branch mirrors `renderBundle`'s
+  // contract: counts always emitted, items prefixed with `+`/`-` so the wire
+  // format stays one-record-per-line. These tests pin that.
+  describe("--format llm rendering", () => {
+    function captureLog(fn: () => void): string[] {
+      const lines: string[] = [];
+      const orig = console.log;
+      console.log = (...args: unknown[]) => {
+        for (const arg of args) lines.push(String(arg));
+      };
+      try {
+        fn();
+      } finally {
+        console.log = orig;
+      }
+      return lines;
+    }
+
+    it("emits a header and counts for an empty diff without falling back to prose", () => {
+      const saved = bundleWith([makeClaim("renders to DOM", 0.9)]);
+      saveInvestigation("widget-llm", saved);
+      const stored = loadInvestigation("widget-llm")!;
+      const fresh = bundleWith([makeClaim("renders to DOM", 0.9)]);
+
+      const lines = captureLog(() => renderInvestigationDiff(stored, fresh, "llm"));
+
+      expect(lines[0]).toBe("diff investigation=widget-llm target=Widget");
+      expect(lines).toContain("freshness_previous=current");
+      expect(lines).toContain("freshness_current=current");
+      expect(lines).toContain("count added_entities=0");
+      expect(lines).toContain("count removed_entities=0");
+      expect(lines).toContain("count added_relationships=0");
+      expect(lines).toContain("count removed_relationships=0");
+      expect(lines).toContain("count added_evidence=0");
+      expect(lines).toContain("count removed_evidence=0");
+      expect(lines).toContain("count added_claims=0");
+      expect(lines).toContain("count removed_claims=0");
+      // No `renderSection` lines means we did not fall back to prose.
+      expect(lines.some((l) => l.startsWith("==") || l.startsWith("  "))).toBe(false);
+    });
+
+    it("lists added/removed entities, relationships, evidence and claims with +/- prefixes", () => {
+      const saved = bundleWith([makeClaim("renders to DOM", 0.9)]);
+      saveInvestigation("widget-llm-busy", saved);
+      const stored = loadInvestigation("widget-llm-busy")!;
+
+      const fresh = buildBundle({
+        resolved: { id: "entity-1", name: "Widget", kind: "class", resolutionMode: "exact" },
+        facts: makeFacts(),
+        context: makeContext({
+          claims: [makeClaim("renders to DOM", 0.9), makeClaim("mounts to DOM", 0.7)],
+          nodes: [
+            {
+              id: "entity-2",
+              kind: "method",
+              name: "render",
+              attrs: {},
+              provenance: { sourceUri: "src/widget.ts", extractor: "tree-sitter", sourceType: "source", observedAt: "2026-01-01T00:00:00Z" },
+              createdRev: 1,
+              createdAt: "2026-01-01T00:00:00Z",
+              updatedAt: "2026-01-01T00:00:00Z",
+            },
+            {
+              id: "entity-3",
+              kind: "method",
+              name: "mount",
+              attrs: {},
+              provenance: { sourceUri: "src/widget.ts", extractor: "tree-sitter", sourceType: "source", observedAt: "2026-01-01T00:00:00Z" },
+              createdRev: 2,
+              createdAt: "2026-01-01T00:00:00Z",
+              updatedAt: "2026-01-01T00:00:00Z",
+            },
+          ],
+          // Fresh side replaces the saved `calls` edge with `holds` — so the
+          // diff sees a removed relationship (calls) and an added one (holds),
+          // matching what an agent would observe when a refactor renames a
+          // graph predicate.
+          edges: [
+            { id: "edge-add", src: "entity-1", dst: "entity-3", predicate: "holds", attrs: {}, createdRev: 2 },
+          ],
+        }),
+        provenance: { sourceType: "source", extractor: "tree-sitter", observedAt: "2026-01-01T00:00:00Z" },
+        asOfRev: undefined,
+        depth: undefined,
+        budgets: { maxEntities: 50, maxRelationships: 100, maxEvidence: 25, maxChars: 12000 },
+      });
+
+      const lines = captureLog(() => renderInvestigationDiff(stored, fresh, "llm"));
+
+      // Counts match the deterministic diff structure. The fresh bundle adds
+      // a new claim (mounts to DOM) and replaces the `calls` evidence with a
+      // `holds` one, so it has 2 added evidence records and 1 removed — the
+      // skolem IDs are `claim:<claim_id>` and
+      // `relationship:<src>:<dst>:<predicate>`, so a stale predicate in the
+      // ranked evidence list yields a real added/removed pair.
+      expect(lines).toContain("count added_entities=1");
+      expect(lines).toContain("count removed_entities=0");
+      expect(lines).toContain("count added_relationships=1");
+      expect(lines).toContain("count removed_relationships=1");
+      expect(lines).toContain("count added_evidence=2");
+      expect(lines).toContain("count removed_evidence=1");
+      expect(lines).toContain("count added_claims=1");
+      expect(lines).toContain("count removed_claims=0");
+
+      // Items tagged with +/- so an agent can route without parsing prose.
+      expect(lines).toContain("+entity kind=method name=mount");
+      expect(lines).toContain("-relationship src=entity-1 pred=calls dst=entity-2");
+      expect(lines).toContain("+relationship src=entity-1 pred=holds dst=entity-3");
+      expect(lines).toContain("+claim id=claim-mounts to DOM");
+      expect(
+        lines.some(
+          (l) =>
+            l.startsWith("+evidence ") &&
+            l.includes("kind=relationship") &&
+            l.includes("entity-1 --holds--> entity-3"),
+        ),
+      ).toBe(true);
+      expect(
+        lines.some(
+          (l) =>
+            l.startsWith("-evidence ") &&
+            l.includes("kind=relationship") &&
+            l.includes("entity-1 --calls--> entity-2"),
+        ),
+      ).toBe(true);
+
+      // One record per line — the wire format invariant.
+      for (const line of lines) expect(line).not.toContain("\n");
+    });
+
+    it("does not regress the prose (text) renderer", () => {
+      const saved = bundleWith([makeClaim("renders to DOM", 0.9)]);
+      saveInvestigation("widget-llm-text", saved);
+      const stored = loadInvestigation("widget-llm-text")!;
+      const fresh = bundleWith([makeClaim("renders to DOM", 0.9), makeClaim("mounts to DOM", 0.7)]);
+
+      const lines = captureLog(() => renderInvestigationDiff(stored, fresh, "text"));
+
+      // Prose path still emits its summary header and the `+N`/`-N` totals.
+      expect(lines.some((l) => l.includes("Investigation diff: widget-llm-text"))).toBe(true);
+      expect(lines.some((l) => /claims:\s+-\d+\s+\+\d+/.test(l))).toBe(true);
+      expect(lines.some((l) => /entities:\s+-\d+\s+\+\d+/.test(l))).toBe(true);
+    });
   });
 });

--- a/ix-cli/src/cli/__tests__/context-investigation.test.ts
+++ b/ix-cli/src/cli/__tests__/context-investigation.test.ts
@@ -15,6 +15,7 @@ import type { EntityFacts } from "../explain/facts.js";
 import {
   buildBundle,
   diffInvestigations,
+  listInvestigations,
   loadInvestigation,
   mergeDiffOptions,
   saveInvestigation,
@@ -264,5 +265,45 @@ describe("ix context investigation state", () => {
     }
     expect(existsSync(join(home, "..", "escape.json"))).toBe(false);
     expect(existsSync(join(home, ".version-check.json"))).toBe(false);
+  });
+
+  // `ix context --list` enumerates saved investigations for discovery.
+  // Without it, neither humans nor agents can see what they have stored —
+  // the only path was reading the JSON files directly.
+  describe("listInvestigations", () => {
+    it("returns saved investigations newest-first", () => {
+      saveInvestigation("widget-a", bundleWith([makeClaim("renders to DOM", 0.9)]));
+      saveInvestigation("widget-b", bundleWith([makeClaim("mounts to DOM", 0.7)]));
+      const list = listInvestigations();
+      expect(list.map((s) => s.id).sort()).toEqual(["widget-a", "widget-b"]);
+      // savedAt differs at least by a millisecond across the two writes; even
+      // on the rare same-ms tie the id tiebreaker keeps order deterministic.
+      expect(list[0].id === "widget-a" || list[0].id === "widget-b").toBe(true);
+    });
+
+    it("skips files whose envelope or bundle does not match the contract", () => {
+      saveInvestigation("good", bundleWith([makeClaim("renders to DOM", 0.9)]));
+      const dir = investigationsDir();
+      writeFileSync(join(dir, "corrupt-envelope.json"), JSON.stringify({ schema: "ix-investigation/9", bundle: {} }));
+      writeFileSync(join(dir, "truncated.json"), "{not json");
+      writeFileSync(join(dir, "tampered-body.json"), JSON.stringify({
+        schema: "ix-investigation/1",
+        id: "tampered-body",
+        savedAt: "2026-01-01T00:00:00Z",
+        bundle: { schema: "ix-context-bundle/1", generatedAt: "x", entities: "not-an-array" },
+      }));
+      writeFileSync(join(dir, "readme.md"), "not a state file");
+
+      const list = listInvestigations();
+      expect(list.map((s) => s.id)).toEqual(["good"]);
+      // The three corrupt files do not poison the listing.
+      expect(readdirSync(dir).filter((f) => f.endsWith(".json"))).toHaveLength(4);
+    });
+
+    it("returns an empty array when the investigations dir does not exist yet", () => {
+      expect(listInvestigations()).toEqual([]);
+      saveInvestigation("first", bundleWith([makeClaim("renders to DOM", 0.9)]));
+      expect(listInvestigations()).toHaveLength(1);
+    });
   });
 });

--- a/ix-cli/src/cli/__tests__/context-investigation.test.ts
+++ b/ix-cli/src/cli/__tests__/context-investigation.test.ts
@@ -20,6 +20,7 @@ import {
   loadInvestigation,
   mergeDiffOptions,
   parseRequestedBudgets,
+  renderBundle,
   renderInvestigationDiff,
   saveInvestigation,
 } from "../commands/context.js";
@@ -62,23 +63,31 @@ function envelope(id: string, bundle: unknown) {
 }
 
 /**
- * Capture what renderWarning printed while `fn` ran.
+ * Capture the refusal message `fn` printed, and prove it stayed off stdout.
  *
- * The refusal message is the only thing that says *which* guard rejected a
- * fixture; asserting on the return value alone cannot tell the envelope check
- * from the schema check. renderWarning goes to console.log (ui.ts), so that is
- * what gets spied on.
+ * The message is the only thing that says *which* guard rejected a fixture;
+ * asserting on the return value alone cannot tell the envelope check from the
+ * schema check. It goes to stderr: it used to go to console.log, which put a
+ * chalk-coloured prose line inside the payload of the very `--format json` and
+ * `--format llm` callers the refusal was answering. Anything on stdout here is
+ * that defect returning, so this fails on it rather than reading it.
  */
 function captureWarnings(fn: () => void): string {
   const lines: string[] = [];
-  const spy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+  const stdout: string[] = [];
+  const outSpy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    stdout.push(args.map(String).join(" "));
+  });
+  const spy = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
     lines.push(args.map(String).join(" "));
   });
   try {
     fn();
   } finally {
     spy.mockRestore();
+    outSpy.mockRestore();
   }
+  expect(stdout).toEqual([]);
   // chalk wraps the message as a whole, so the text stays contiguous; strip the
   // colour codes anyway so a CI run with colour forced on matches a local one.
   return lines.join("\n").replace(/\u001b\[[0-9;]*m/g, "");
@@ -424,55 +433,61 @@ describe("ix context investigation state", () => {
     expect(existsSync(join(home, ".version-check.json"))).toBe(false);
   });
 
-  it("exposes effective budgets on every --diff diff, sourced from the saved investigation", () => {
-    // The reproduction in B-4 showed that --max-* flags on the CLI do not change
-    // the fresh side's budget: buildFreshBundle always receives saved.bundle.budgets.
-    // The transparency fix surfaces that fact as data instead of hiding it, so
-    // agents reading the diff JSON can answer "what budget governed this comparison"
-    // without reading the source.
+  it("reports the budget the fresh bundle was actually built with", () => {
+    // `effective` is read off `fresh.budgets`, not restated from
+    // `saved.bundle.budgets`. That distinction is the whole point of the
+    // record: a change that let CLI overrides win would edit the
+    // `buildFreshBundle` argument in the action handler, and a restated
+    // `effective` would go on reporting the saved budget while the fresh side
+    // used another one -- the silent misreport this exists to prevent.
+    //
+    // So the two sides are given different budgets here. The earlier version of
+    // this test pinned `effective` to the *saved* snapshot even though the
+    // fresh bundle in front of it had been built with 50/100/25/12000 -- a
+    // budget neither side of the comparison had used together.
     const saved = bundleWith([makeClaim("renders to DOM", 0.9)]);
     saved.budgets = { maxEntities: 5, maxRelationships: 1, maxEvidence: 2, maxChars: 12000 };
     saveInvestigation("widget-check", saved);
     const stored = loadInvestigation("widget-check")!;
     const fresh = bundleWith([makeClaim("renders to DOM", 0.9)]);
+    expect(fresh.budgets).toEqual({ maxEntities: 50, maxRelationships: 100, maxEvidence: 25, maxChars: 12000 });
 
-    // Without CLI overrides, requested is absent and effective mirrors saved.
     const baselineDiff = diffInvestigations(stored, fresh);
     expect(baselineDiff.budgets.saved).toEqual({ maxEntities: 5, maxRelationships: 1, maxEvidence: 2, maxChars: 12000 });
     expect(baselineDiff.budgets.requested).toBeUndefined();
-    expect(baselineDiff.budgets.effective).toEqual(baselineDiff.budgets.saved);
-    expect(baselineDiff.budgets.note).toMatch(/no --max-\* overrides/i);
+    expect(baselineDiff.budgets.effective).toEqual(fresh.budgets);
+    expect(baselineDiff.budgets.requestedApplied).toBe(false);
+    // Nothing was asked for, so there is nothing to explain.
+    expect(baselineDiff.budgets.note).toBeUndefined();
 
-    // With CLI overrides parsed from raw commander strings, requested captures
-    // every flag the user passed (even ones that disagree with saved), and the
-    // note makes the precedence explicit.
-    const requested = parseRequestedBudgets({ maxEntities: "50", maxEvidence: "25", maxRelationships: "100" });
-    expect(requested).toEqual({ maxEntities: 50, maxEvidence: 25, maxRelationships: 100 });
+    // With CLI overrides, `requested` captures every flag the caller passed,
+    // and `requestedApplied` says whether they governed -- derived by comparing
+    // against `effective`, not hardcoded.
+    const requested = parseRequestedBudgets({ maxEntities: 5, maxEvidence: 2, maxRelationships: 1 });
+    expect(requested).toEqual({ maxEntities: 5, maxEvidence: 2, maxRelationships: 1 });
 
     const overrideDiff = diffInvestigations(stored, fresh, requested);
     expect(overrideDiff.budgets.requested).toEqual(requested);
-    // Critical invariant: the fresh bundle was still built with saved budgets,
-    // so effective is the saved snapshot, not the requested one.
-    expect(overrideDiff.budgets.effective).toEqual(overrideDiff.budgets.saved);
-    expect(overrideDiff.budgets.note).toMatch(/--max-\* flags on the CLI are recorded/i);
+    expect(overrideDiff.budgets.effective).toEqual(fresh.budgets);
+    expect(overrideDiff.budgets.requestedApplied).toBe(false);
+    expect(overrideDiff.budgets.note).toMatch(/were not applied to the fresh side/i);
+
+    // …and it reads true when they do match what the bundle was built with.
+    const matching = parseRequestedBudgets({ maxEntities: 50, maxEvidence: 25 });
+    expect(diffInvestigations(stored, fresh, matching).budgets.requestedApplied).toBe(true);
   });
 
-  it("treats whitespace, empty, or non-numeric --max-* strings as not provided", () => {
-    // parseRequestedBudgets must mirror commander semantics: only flag-shaped
-    // arguments count as "user override", not noise from shell quoting or
-    // accidental empty strings. This is what stops the diff output from
-    // reporting a phantom override. Numeric "0" is a real override (someone
-    // asking for "0 entities" forces an empty bundle and is what they meant),
-    // so it survives the parse — but non-strings, blanks, and NaN-producing
-    // tokens do not.
+  it("records exactly the --max-* flags that were passed", () => {
+    // Validation lives in `parseBudgetOption`, the flags' Commander argParser,
+    // so anything arriving here is already a positive integer. What is left is
+    // "which flags were given", and an absent one must not become a phantom
+    // override in the report.
     expect(parseRequestedBudgets({})).toBeUndefined();
-    expect(parseRequestedBudgets({ maxEntities: "", maxEvidence: "  " })).toBeUndefined();
     expect(parseRequestedBudgets({ maxEntities: undefined })).toBeUndefined();
-    expect(parseRequestedBudgets({ maxEntities: "abc" })).toBeUndefined();
-    expect(parseRequestedBudgets({ maxEntities: "0" })).toEqual({ maxEntities: 0 });
-    expect(parseRequestedBudgets({ maxEntities: "10", maxChars: undefined })).toEqual({ maxEntities: 10 });
-    const partial = parseRequestedBudgets({ maxEntities: "10", maxEvidence: "5", maxRelationships: "0", maxChars: "12000" });
-    expect(partial).toEqual({ maxEntities: 10, maxEvidence: 5, maxRelationships: 0, maxChars: 12000 });
+    expect(parseRequestedBudgets({ maxEntities: 10, maxChars: undefined })).toEqual({ maxEntities: 10 });
+    expect(
+      parseRequestedBudgets({ maxEntities: 10, maxEvidence: 5, maxRelationships: 1, maxChars: 12000 }),
+    ).toEqual({ maxEntities: 10, maxEvidence: 5, maxRelationships: 1, maxChars: 12000 });
   });
 
   it("renders the budget block in --diff text and llm output", () => {
@@ -502,9 +517,13 @@ describe("ix context investigation state", () => {
       text.restore();
     }
     expect(text.lines.some((l) => l.includes("budgets:"))).toBe(true);
-    expect(text.lines.some((l) => l.includes("saved     :"))).toBe(true);
-    expect(text.lines.some((l) => l.includes("requested :")) && text.lines.some((l) => l.includes("evidence=25"))).toBe(true);
-    expect(text.lines.some((l) => l.includes("effective :") && l.includes("evidence=2"))).toBe(true);
+    expect(text.lines.some((l) => l.includes("saved     :") && l.includes("evidence=2"))).toBe(true);
+    // One `some`, not two ANDed: `A.some(requested) && A.some(evidence=25)`
+    // passes when `evidence=25` lands on any line at all — the `saved` or
+    // `effective` line satisfied it — so it survived a `requested` line reading
+    // `evidence=not-given`, and on failure said only "expected false to be true".
+    expect(text.lines.some((l) => l.includes("requested :") && l.includes("evidence=25"))).toBe(true);
+    expect(text.lines.some((l) => l.includes("effective :") && l.includes("evidence=25"))).toBe(true);
 
     const llm = capture();
     try {
@@ -513,11 +532,11 @@ describe("ix context investigation state", () => {
       llm.restore();
     }
     // Records, not the prose block with the colons moved. `scope=requested`
-    // carries `applied=false` so the precedence rule — saved budgets govern
+    // carries `applied=` so the precedence rule — saved budgets govern
     // --diff — is a field an agent can test rather than a sentence to read.
     expect(llm.lines).toContain("budgets scope=saved entities=5 relationships=1 evidence=2 chars=12000");
-    expect(llm.lines).toContain("budgets scope=requested evidence=25 applied=false");
-    expect(llm.lines).toContain("budgets scope=effective entities=5 relationships=1 evidence=2 chars=12000");
+    expect(llm.lines).toContain("budgets scope=requested evidence=25 applied=true");
+    expect(llm.lines).toContain("budgets scope=effective entities=50 relationships=100 evidence=25 chars=12000");
     // And none of the prose survives into the record stream.
     expect(llm.lines.some((l) => l.includes(":") && l.startsWith("  "))).toBe(false);
 
@@ -533,7 +552,10 @@ describe("ix context investigation state", () => {
     const parsed = JSON.parse(json.lines[0]);
     expect(parsed.budgets.saved).toEqual(saved.budgets);
     expect(parsed.budgets.requested).toEqual(requested);
-    expect(parsed.budgets.effective).toEqual(saved.budgets);
+    expect(parsed.budgets.effective).toEqual(fresh.budgets);
+    // The same fact the llm record carries as `applied=`, so a JSON consumer
+    // does not have to string-match an English sentence for it.
+    expect(parsed.budgets.requestedApplied).toBe(true);
   });
 
   // `--diff --format llm` used to fall through to the prose renderer, because
@@ -563,9 +585,15 @@ describe("ix context investigation state", () => {
 
       const lines = captureLog(() => renderInvestigationDiff(stored, fresh, "llm"));
 
-      expect(lines[0]).toBe(
-        "diff investigation=widget-llm target=Widget freshness_previous=current freshness_current=current",
-      );
+      // `saved_at` and `generated_at` are on the record because
+      // `freshness_previous=current` says the snapshot was fresh when it was
+      // taken and not when that was: a baseline from five minutes ago and one
+      // from three months ago read identically without them.
+      const [header] = lines;
+      expect(header).toContain("diff investigation=widget-llm target=Widget");
+      expect(header).toContain(`saved_at=${stored.savedAt}`);
+      expect(header).toMatch(/generated_at=\d{4}-\d{2}-\d{2}T[\d:.]+Z/);
+      expect(header).toContain("freshness_previous=current freshness_current=current");
       // Zero is the answer to the question --diff was asked, so it is carried
       // rather than dropped as a default.
       expect(lines).toContain(
@@ -637,14 +665,25 @@ describe("ix context investigation state", () => {
 
       // The change is a field, not a prefix fused to the record kind, so a
       // consumer routing on `entity` matches both sides of the comparison.
-      expect(lines).toContain("entity change=added kind=method name=mount");
+      // `id=` is what makes the stream joinable: the relationship records below
+      // name their endpoints by entity id, so without it `dst=entity-3`
+      // resolves to nothing the reader has seen.
+      expect(lines).toContain(
+        "entity change=added id=entity-3 kind=method name=mount path=src/widget.ts",
+      );
       expect(lines).toContain("relationship change=removed src=entity-1 pred=calls dst=entity-2");
       expect(lines).toContain("relationship change=added src=entity-1 pred=holds dst=entity-3");
 
       // A claim id carries the statement, so it contains spaces — quoted, per
       // docs/llm-format.md. Unquoted, `id=claim-mounts to DOM` is three tokens
       // and a consumer reads the id as `claim-mounts`.
-      expect(lines).toContain('claim change=added id="claim-mounts to DOM" status=active');
+      // `statement=` is the field that says what changed. In production the id
+      // is the backend's (`c-8f31a2`), so a record carrying only the id told a
+      // reader that a claim changed and not what it says; this fixture's
+      // `claim-<statement>` ids are what hid that.
+      expect(lines).toContain(
+        'claim change=added id="claim-mounts to DOM" entity=entity-1 status=active statement="mounts to DOM"',
+      );
 
       // An evidence title is a sentence. Same rule, and the reason the value
       // must never be built with a template literal.
@@ -657,6 +696,56 @@ describe("ix context investigation state", () => {
 
       // One record per line — the wire format invariant.
       for (const line of lines) expect(line).not.toContain("\n");
+    });
+
+    it("answers a refusal with a record, not a prose warning", () => {
+      // The refusal path wrote `renderWarning`, which is console.log, so the
+      // one command being made llm-clean answered `--diff nope --format llm`
+      // with a chalk-coloured English sentence in the middle of the record
+      // stream. Every sibling command emits `error code=... message="..."`.
+      const out: string[] = [];
+      const err: string[] = [];
+      const origLog = console.log;
+      const origErr = console.error;
+      console.log = (...a: unknown[]) => void out.push(a.map(String).join(" "));
+      console.error = (...a: unknown[]) => void err.push(a.map(String).join(" "));
+      try {
+        expect(loadInvestigation("does-not-exist", "llm")).toBeUndefined();
+      } finally {
+        console.log = origLog;
+        console.error = origErr;
+      }
+      expect(out).toHaveLength(1);
+      expect(out[0]).toMatch(/^error code=no_saved_investigation message="No saved investigation/);
+      // One record on one line, with the path quoted rather than bare.
+      expect(out[0]).not.toContain("\n");
+      expect(err).toEqual([]);
+      expect(process.exitCode).toBe(1);
+      process.exitCode = undefined;
+    });
+
+    it("emits one grammar for `evidence`, whichever ix context surface produced it", () => {
+      // `renderBundle` built `evidence 30 relationship <title>` from a template
+      // literal: positional, unquoted, newlines stripped and nothing else. An
+      // evidence title is a sentence, so every one of those records split into
+      // tokens — while `--diff` emitted the keyed, quoted form for the same
+      // record kind from the same command.
+      const bundle = bundleWith([makeClaim("renders to DOM", 0.9)]);
+      const lines = captureLog(() => renderBundle(bundle, "llm"));
+
+      const evidence = lines.filter((l) => l.startsWith("evidence"));
+      expect(evidence.length).toBeGreaterThan(0);
+      for (const line of evidence) {
+        expect(line).toMatch(/^evidence score=\d+ kind=[a-z]+ title=/);
+      }
+      // The exact record `--diff` would emit for the same item, minus `change=`.
+      expect(lines).toContain(
+        'evidence score=30 kind=relationship title="entity-1 --calls--> entity-2"',
+      );
+      // And the header is a record too, not fifteen bare `key=value` lines
+      // built by interpolation — `target=${name}` breaks on any name with a
+      // space in it.
+      expect(lines[0]).toMatch(/^context target=Widget target_kind=class /);
     });
 
     it("does not regress the prose (text) renderer", () => {

--- a/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
+++ b/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
@@ -82,10 +82,13 @@ describe("detectContextModeConflict", () => {
       const msg = detectContextModeConflict({ resume: "x", out: "/tmp/x.json", format })!;
       expect(msg).toMatch(/--resume cannot be combined with --out/);
       expect(msg).not.toMatch(/--format json with --out/);
-      // And the way out it does name has to work.
-      expect(msg).toMatch(/>/);
-      expect(detectContextModeConflict({ resume: "x", format: "json" })).toBeUndefined();
+      // And the way out it names has to be a way out. `toMatch(/>/)` was
+      // satisfied by the `<id>` placeholder already in the message, so it
+      // passed for any wording at all, including one naming nothing.
+      expect(msg).toContain("ix context --resume <id> --format json > <path>");
     }
+    // The redirect it recommends is not itself refused here.
+    expect(detectContextModeConflict({ resume: "x", format: "json" })).toBeUndefined();
   });
 
   it("flags --diff + --save (C-1)", () => {
@@ -127,6 +130,17 @@ describe("detectContextModeConflict", () => {
     expect(detectContextModeConflict({ list: true, out: "/tmp/list.json" })).toMatch(
       /--list cannot be combined with --out/,
     );
+  });
+
+  it("flags a positional target alongside --resume, the sibling nobody guarded", () => {
+    // `--resume` reads the id from its own flag and never looks at the
+    // positional, so `ix context Widget --resume widget-investigation` rendered
+    // the saved investigation and dropped `Widget` with exit 0 -- the same
+    // defect as the --list one, one line below the guard added for it. --diff
+    // does use the positional, so it stays legal there.
+    expect(detectContextModeConflict({ resume: "x" }, "Widget")).toMatch(/--resume takes no target/);
+    expect(detectContextModeConflict({ diff: "x" }, "Widget")).toBeUndefined();
+    expect(detectContextModeConflict({ resume: "x" })).toBeUndefined();
   });
 
   it("flags a positional target alongside --list", () => {
@@ -202,11 +216,18 @@ describe("detectDiffModeConflict", () => {
 describe("mode-flag coverage does not drift from the command", () => {
   /** Flags that select what the command does, or where its output goes. */
   const CONTEXT_MODE_FLAGS = ["out", "save", "resume", "diff", "list"] as const;
-  /** Flags that shape the bundle a mode produces; any pair of these is legal. */
+  /**
+   * Flags that shape a bundle. Legal with each other and with the modes that
+   * build one; refused by `--list` and `--resume`, which build none — that gap
+   * was five typed flags accepted and dropped with exit 0, and this list saying
+   * "legal everywhere" is what certified it.
+   */
   const CONTEXT_BUILD_FLAGS = [
     "kind", "path", "pick", "depth", "asOfRev",
-    "maxEntities", "maxRelationships", "maxEvidence", "maxChars", "format",
+    "maxEntities", "maxRelationships", "maxEvidence", "maxChars",
   ];
+  /** Meaningful to every mode, so in neither group. */
+  const CONTEXT_UNIVERSAL_FLAGS = ["format"];
 
   function registeredAttributes(register: (p: Command) => void, name: string): string[] {
     const program = new Command();
@@ -218,8 +239,32 @@ describe("mode-flag coverage does not drift from the command", () => {
 
   it("classifies every option ix context registers", () => {
     expect(registeredAttributes(registerContextCommand, "context")).toEqual(
-      [...CONTEXT_MODE_FLAGS, ...CONTEXT_BUILD_FLAGS].sort(),
+      [...CONTEXT_MODE_FLAGS, ...CONTEXT_BUILD_FLAGS, ...CONTEXT_UNIVERSAL_FLAGS].sort(),
     );
+  });
+
+  it("refuses every build flag given to a mode that builds nothing", () => {
+    for (const mode of ["list", "resume"] as const) {
+      for (const flag of CONTEXT_BUILD_FLAGS) {
+        const opts = { [mode]: mode === "list" ? true : "x", [flag]: 1 } as Record<string, unknown>;
+        expect(
+          detectContextModeConflict(opts),
+          `--${flag} is silently ignored by --${mode}`,
+        ).toBeTruthy();
+      }
+      // …and the mode alone, or with --format, is the ordinary path.
+      expect(detectContextModeConflict({ [mode]: mode === "list" ? true : "x", format: "llm" })).toBeUndefined();
+    }
+    // --diff consumes all of them, so none of this applies to it.
+    for (const flag of CONTEXT_BUILD_FLAGS) {
+      expect(detectContextModeConflict({ diff: "x", [flag]: 1 })).toBeUndefined();
+    }
+  });
+
+  it("names every ignored flag at once, not one per re-run", () => {
+    const msg = detectContextModeConflict({ list: true, maxEntities: 10, kind: "class" })!;
+    expect(msg).toContain("--kind");
+    expect(msg).toContain("--max-entities");
   });
 
   it("refuses every pair of mode flags", () => {
@@ -309,6 +354,9 @@ describe("ix context action surfaces mode conflicts on stderr and exits 1", () =
     { args: ["context", "--list", "--save", "y"], expect: /--list cannot be combined with --save/ },
     { args: ["context", "--list", "--out", "/tmp/x.json"], expect: /--list cannot be combined with --out/ },
     { args: ["context", "Widget", "--list"], expect: /--list takes no target/ },
+    { args: ["context", "Widget", "--resume", "x"], expect: /--resume takes no target/ },
+    { args: ["context", "--list", "--max-entities", "10"], expect: /--max-entities cannot be combined with --list/ },
+    { args: ["context", "--resume", "x", "--kind", "class"], expect: /--kind cannot be combined with --resume/ },
   ])("ix $args → stderr matches $expect and exit code is 1", ({ args, expect: re }) => {
     const r = runProgram(registerContextCommand, args);
     expect(r.exitCode).toBe(1);

--- a/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
+++ b/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
@@ -109,6 +109,34 @@ describe("detectContextModeConflict", () => {
       expect(detectContextModeConflict({ resume: "x", ...other })).toMatch(/--resume/);
     }
   });
+
+  it("flags --list + --resume, which its own guard could never reach", () => {
+    // `--list`'s guard named `--resume`, but it sat below `if (opts.resume)`,
+    // which returns first. `ix context --list --resume widget` rendered one
+    // investigation, exited 0, and never said the listing had been dropped.
+    // Checked before any mode branch, that race cannot happen.
+    expect(detectContextModeConflict({ list: true, resume: "x" })).toMatch(
+      /--list and --resume cannot be combined/,
+    );
+  });
+
+  it("flags --list + --out, which nothing checked at all", () => {
+    // `ix context --list --out /tmp/list.json` listed to stdout, wrote no file,
+    // and exited 0 — the silent-ignore gap this detector exists to close, on
+    // the newest flag on the command it guards.
+    expect(detectContextModeConflict({ list: true, out: "/tmp/list.json" })).toMatch(
+      /--list cannot be combined with --out/,
+    );
+  });
+
+  it("flags a positional target alongside --list", () => {
+    // A positional is as ignorable as a flag: `ix context Widget --list`
+    // dropped the target with nothing said.
+    expect(detectContextModeConflict({ list: true }, "Widget")).toMatch(/--list takes no target/);
+    // …and a target without --list is the ordinary path.
+    expect(detectContextModeConflict({}, "Widget")).toBeUndefined();
+    expect(detectContextModeConflict({ list: true })).toBeUndefined();
+  });
 });
 
 describe("detectDiffModeConflict", () => {
@@ -173,7 +201,7 @@ describe("detectDiffModeConflict", () => {
  */
 describe("mode-flag coverage does not drift from the command", () => {
   /** Flags that select what the command does, or where its output goes. */
-  const CONTEXT_MODE_FLAGS = ["out", "save", "resume", "diff"] as const;
+  const CONTEXT_MODE_FLAGS = ["out", "save", "resume", "diff", "list"] as const;
   /** Flags that shape the bundle a mode produces; any pair of these is legal. */
   const CONTEXT_BUILD_FLAGS = [
     "kind", "path", "pick", "depth", "asOfRev",
@@ -276,6 +304,11 @@ describe("ix context action surfaces mode conflicts on stderr and exits 1", () =
     { args: ["context", "--diff", "x", "--save", "y"], expect: /--diff cannot be combined with --save/ },
     { args: ["context", "--diff", "x", "--out", "/tmp/x.json"], expect: /--diff cannot be combined with --out/ },
     { args: ["context", "--save", "y", "--out", "/tmp/x.json"], expect: /--save and --out cannot be combined/ },
+    { args: ["context", "--list", "--resume", "x"], expect: /--list and --resume cannot be combined/ },
+    { args: ["context", "--list", "--diff", "x"], expect: /--list and --diff cannot be combined/ },
+    { args: ["context", "--list", "--save", "y"], expect: /--list cannot be combined with --save/ },
+    { args: ["context", "--list", "--out", "/tmp/x.json"], expect: /--list cannot be combined with --out/ },
+    { args: ["context", "Widget", "--list"], expect: /--list takes no target/ },
   ])("ix $args → stderr matches $expect and exit code is 1", ({ args, expect: re }) => {
     const r = runProgram(registerContextCommand, args);
     expect(r.exitCode).toBe(1);

--- a/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
+++ b/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
@@ -1,0 +1,246 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Command } from "commander";
+
+import {
+  detectContextModeConflict,
+  registerContextCommand,
+} from "../commands/context.js";
+import {
+  detectDiffModeConflict,
+  registerDiffCommand,
+} from "../commands/diff.js";
+
+/**
+ * C-1..C-4 silent-ignore flag gaps in `ix context` and C-5 in `ix diff` are now
+ * surfaced as hard errors at the top of the action handler. These tests pin
+ * both the pure functions and the integration through the real Commander
+ * registration. The detectors run before any network call, so the action
+ * returns before touching the real Ix backend; no mocks are needed for the
+ * conflict paths.
+ */
+
+let home: string;
+let origExitCode: number | string | undefined;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ix-mode-conflict-test-"));
+  process.env.IX_HOME = home;
+  origExitCode = process.exitCode;
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  delete process.env.IX_HOME;
+  rmSync(home, { recursive: true, force: true });
+  process.exitCode = origExitCode;
+});
+
+describe("detectContextModeConflict", () => {
+  it("returns undefined when no flags are set", () => {
+    expect(detectContextModeConflict({})).toBeUndefined();
+  });
+
+  it("returns undefined for a single mode flag with neutral extras", () => {
+    expect(detectContextModeConflict({ resume: "x" })).toBeUndefined();
+    expect(detectContextModeConflict({ diff: "x" })).toBeUndefined();
+    expect(detectContextModeConflict({ save: "y" })).toBeUndefined();
+    expect(detectContextModeConflict({ out: "/tmp/x.json" })).toBeUndefined();
+  });
+
+  it("returns undefined for the legal save+resolve target run", () => {
+    // Fresh build with --save is fine; this is the contract path.
+    expect(detectContextModeConflict({ save: "y", format: "text" })).toBeUndefined();
+    // Fresh build with --out is fine in json mode (the existing renderWarning
+    // path still applies; the conflict detector does not flag it).
+    expect(detectContextModeConflict({ out: "/tmp/x.json", format: "json" })).toBeUndefined();
+  });
+
+  it("flags --resume + --diff", () => {
+    const msg = detectContextModeConflict({ resume: "x", diff: "y" });
+    expect(msg).toMatch(/--resume and --diff cannot be combined/);
+  });
+
+  it("flags --resume + --save", () => {
+    const msg = detectContextModeConflict({ resume: "x", save: "y" });
+    expect(msg).toMatch(/--resume cannot be combined with --save/);
+  });
+
+  it("flags --resume + --out (C-3 right-hand case)", () => {
+    const msg = detectContextModeConflict({ resume: "x", out: "/tmp/x.json" });
+    expect(msg).toMatch(/--resume cannot be combined with --out/);
+  });
+
+  it("suggests --format json to --resume --out when format is non-json", () => {
+    const msg = detectContextModeConflict({
+      resume: "x",
+      out: "/tmp/x.json",
+      format: "llm",
+    });
+    expect(msg).toMatch(/--resume cannot be combined with --out/);
+    expect(msg).toMatch(/--format json with --out/);
+  });
+
+  it("flags --diff + --save (C-1)", () => {
+    const msg = detectContextModeConflict({ diff: "x", save: "y" });
+    expect(msg).toMatch(/--diff cannot be combined with --save/);
+  });
+
+  it("flags --diff + --out (C-3 left-hand case)", () => {
+    const msg = detectContextModeConflict({ diff: "x", out: "/tmp/x.json" });
+    expect(msg).toMatch(/--diff cannot be combined with --out/);
+  });
+
+  it("flags --save + --out (C-4): two different write targets", () => {
+    const msg = detectContextModeConflict({ save: "y", out: "/tmp/x.json" });
+    expect(msg).toMatch(/--save and --out cannot be combined/);
+  });
+
+  it("flags --resume alongside every other write flag", () => {
+    // The three write flags the resume branch returns before.
+    for (const other of [{ diff: "y" }, { save: "y" }, { out: "/tmp/x.json" }]) {
+      expect(detectContextModeConflict({ resume: "x", ...other })).toMatch(/--resume/);
+    }
+  });
+});
+
+describe("detectDiffModeConflict", () => {
+  it("returns undefined when no flags are set", () => {
+    expect(detectDiffModeConflict({})).toBeUndefined();
+  });
+
+  it("returns undefined for legal single flags", () => {
+    expect(detectDiffModeConflict({ summary: true })).toBeUndefined();
+    expect(detectDiffModeConflict({ content: true })).toBeUndefined();
+    expect(detectDiffModeConflict({ full: true })).toBeUndefined();
+    expect(detectDiffModeConflict({ limit: "20" })).toBeUndefined();
+  });
+
+  it("flags --summary + --content (C-5)", () => {
+    const msg = detectDiffModeConflict({ summary: true, content: true });
+    expect(msg).toMatch(/--summary and --content cannot be combined/);
+  });
+
+  it("flags --full + --limit", () => {
+    const msg = detectDiffModeConflict({ full: true, limit: "20" });
+    expect(msg).toMatch(/--full and --limit cannot be combined/);
+  });
+
+  it("does NOT flag --full without --limit (--full alone is the documented path)", () => {
+    expect(detectDiffModeConflict({ full: true })).toBeUndefined();
+  });
+
+  it("does NOT flag --limit alone (default behaviour)", () => {
+    expect(detectDiffModeConflict({ limit: "20" })).toBeUndefined();
+  });
+
+  it("flags --summary alongside --limit or --full", () => {
+    const a = detectDiffModeConflict({ summary: true, limit: "20" });
+    expect(a).toMatch(/--summary ignores --limit and --full/);
+    const b = detectDiffModeConflict({ summary: true, full: true });
+    expect(b).toMatch(/--summary ignores --limit and --full/);
+  });
+});
+
+/**
+ * Drive the real `registerX` functions through Commander so we verify that:
+ *
+ *   1. the detector runs FIRST in the action handler (no network call);
+ *   2. the surfaced message lands on stderr with an "Error:" prefix;
+ *   3. process.exitCode is set to 1;
+ *   4. resolution/fresh-build code paths do NOT touch stdout.
+ *
+ * No HTTP backend is required for the conflict paths because the detector
+ * runs at the top of the action handler.
+ */
+function runProgram(
+  register: (program: Command) => void,
+  args: string[],
+): { stderr: string; exitCode: number | string | undefined; stdout: string } {
+  const program = new Command();
+  program.name("ix").exitOverride();
+  register(program);
+
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const origStdout = process.stdout.write.bind(process.stdout);
+  const origErr = console.error;
+  process.stdout.write = ((chunk: unknown) => {
+    stdout.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  console.error = (...a: unknown[]) => void stderr.push(a.join(" "));
+
+  let code: number | string | undefined;
+  try {
+    program.parse(["node", "ix", ...args]);
+  } catch (e) {
+    // exitOverride turns process.exit into a CommanderError; we still want
+    // the (possibly already-set) exitCode. The error message ends up in
+    // stderr elsewhere; do not forward here.
+    void e;
+  } finally {
+    code = process.exitCode;
+    process.stdout.write = origStdout;
+    console.error = origErr;
+  }
+  return { stderr: stderr.join("\n"), stdout: stdout.join(""), exitCode: code };
+}
+
+describe("ix context action surfaces mode conflicts on stderr and exits 1", () => {
+  it.each([
+    { args: ["context", "--resume", "x", "--diff", "y"], expect: /--resume and --diff/ },
+    { args: ["context", "--resume", "x", "--save", "y"], expect: /--resume cannot be combined with --save/ },
+    { args: ["context", "--resume", "x", "--out", "/tmp/x.json"], expect: /--resume cannot be combined with --out/ },
+    { args: ["context", "--diff", "x", "--save", "y"], expect: /--diff cannot be combined with --save/ },
+    { args: ["context", "--diff", "x", "--out", "/tmp/x.json"], expect: /--diff cannot be combined with --out/ },
+    { args: ["context", "--save", "y", "--out", "/tmp/x.json"], expect: /--save and --out cannot be combined/ },
+  ])("ix $args → stderr matches $expect and exit code is 1", ({ args, expect: re }) => {
+    const r = runProgram(registerContextCommand, args);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toMatch(/^Error:/m);
+    expect(r.stderr).toMatch(re);
+    expect(r.stdout).toBe("");
+  });
+});
+
+describe("ix diff action surfaces mode conflicts on stderr and exits 1", () => {
+  it.each([
+    { args: ["diff", "3", "5", "--summary", "--content"], expect: /--summary and --content cannot be combined/ },
+    { args: ["diff", "3", "5", "--full", "--limit", "20"], expect: /--full and --limit cannot be combined/ },
+    { args: ["diff", "3", "5", "--summary", "--limit", "20"], expect: /--summary ignores --limit and --full/ },
+    { args: ["diff", "3", "5", "--summary", "--full"], expect: /--summary ignores --limit and --full/ },
+  ])("ix diff $args → stderr matches $expect and exit code is 1", ({ args, expect: re }) => {
+    const r = runProgram(registerDiffCommand, args);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toMatch(/^Error:/m);
+    expect(r.stderr).toMatch(re);
+    expect(r.stdout).toBe("");
+  });
+});
+
+describe("ix help coverage stays intact (smoke)", () => {
+  it("context help still lists --resume, --diff, --save, --out", () => {
+    const program = new Command();
+    program.name("ix").exitOverride();
+    registerContextCommand(program);
+    const help = program.commands.find((c) => c.name() === "context")!.helpInformation();
+    expect(help).toMatch(/--save <id>/);
+    expect(help).toMatch(/--resume <id>/);
+    expect(help).toMatch(/--diff <id>/);
+    expect(help).toMatch(/--out <path>/);
+  });
+
+  it("diff help still lists --summary, --content, --full, --limit", () => {
+    const program = new Command();
+    program.name("ix").exitOverride();
+    registerDiffCommand(program);
+    const help = program.commands.find((c) => c.name() === "diff")!.helpInformation();
+    expect(help).toMatch(/--summary/);
+    expect(help).toMatch(/--content/);
+    expect(help).toMatch(/--full/);
+    expect(help).toMatch(/--limit/);
+  });
+});

--- a/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
+++ b/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
@@ -73,14 +73,19 @@ describe("detectContextModeConflict", () => {
     expect(msg).toMatch(/--resume cannot be combined with --out/);
   });
 
-  it("suggests --format json to --resume --out when format is non-json", () => {
-    const msg = detectContextModeConflict({
-      resume: "x",
-      out: "/tmp/x.json",
-      format: "llm",
-    });
-    expect(msg).toMatch(/--resume cannot be combined with --out/);
-    expect(msg).toMatch(/--format json with --out/);
+  it("never advises --resume --out to retry a combination it also rejects", () => {
+    // The hint used to be "use --format json with --out", which fires this same
+    // branch: the user did as they were told and got the identical error, this
+    // time with no advice at all. Whatever the message suggests must be
+    // something that is not itself refused here.
+    for (const format of ["text", "json", "llm"]) {
+      const msg = detectContextModeConflict({ resume: "x", out: "/tmp/x.json", format })!;
+      expect(msg).toMatch(/--resume cannot be combined with --out/);
+      expect(msg).not.toMatch(/--format json with --out/);
+      // And the way out it does name has to work.
+      expect(msg).toMatch(/>/);
+      expect(detectContextModeConflict({ resume: "x", format: "json" })).toBeUndefined();
+    }
   });
 
   it("flags --diff + --save (C-1)", () => {
@@ -141,6 +146,73 @@ describe("detectDiffModeConflict", () => {
     expect(a).toMatch(/--summary ignores --limit and --full/);
     const b = detectDiffModeConflict({ summary: true, full: true });
     expect(b).toMatch(/--summary ignores --limit and --full/);
+  });
+
+  it("names --summary, not --full, when all three are passed", () => {
+    // Only the two-flag pairs were covered, and the three-flag case took the
+    // `--full && --limit` branch: the user was told to drop one of two flags
+    // that `--summary` was going to ignore anyway, while the message naming the
+    // flag actually in charge was unreachable for this input.
+    const msg = detectDiffModeConflict({ summary: true, full: true, limit: "20" });
+    expect(msg).toMatch(/--summary ignores --limit and --full/);
+    expect(msg).not.toMatch(/--full and --limit cannot be combined/);
+  });
+});
+
+/**
+ * The gap the detectors are for is a flag the user typed doing nothing. A flag
+ * added later with no rule written for it reopens exactly that gap, silently:
+ * `ContextModeOptions` was a hand-copied five-field shape, `--list` was added
+ * to `ContextOptions` on a sibling branch, and neither the typechecker nor any
+ * test noticed the detector could not see it.
+ *
+ * So one side of this comes from the live Commander registration and the other
+ * is hand-listed. Two hand-lists can be wrong together; a list checked against
+ * the command cannot be. Adding an option to `ix context` fails here until it
+ * is classified — a mode flag with a rule, or a build knob.
+ */
+describe("mode-flag coverage does not drift from the command", () => {
+  /** Flags that select what the command does, or where its output goes. */
+  const CONTEXT_MODE_FLAGS = ["out", "save", "resume", "diff"] as const;
+  /** Flags that shape the bundle a mode produces; any pair of these is legal. */
+  const CONTEXT_BUILD_FLAGS = [
+    "kind", "path", "pick", "depth", "asOfRev",
+    "maxEntities", "maxRelationships", "maxEvidence", "maxChars", "format",
+  ];
+
+  function registeredAttributes(register: (p: Command) => void, name: string): string[] {
+    const program = new Command();
+    program.name("ix").exitOverride();
+    register(program);
+    const cmd = program.commands.find((c) => c.name() === name)!;
+    return cmd.options.map((o) => o.attributeName()).sort();
+  }
+
+  it("classifies every option ix context registers", () => {
+    expect(registeredAttributes(registerContextCommand, "context")).toEqual(
+      [...CONTEXT_MODE_FLAGS, ...CONTEXT_BUILD_FLAGS].sort(),
+    );
+  });
+
+  it("refuses every pair of mode flags", () => {
+    for (const a of CONTEXT_MODE_FLAGS) {
+      for (const b of CONTEXT_MODE_FLAGS) {
+        if (a >= b) continue;
+        const opts = { [a]: "x", [b]: "y" } as Record<string, string>;
+        expect(
+          detectContextModeConflict(opts),
+          `no rule for --${a} + --${b}`,
+        ).toBeTruthy();
+      }
+    }
+  });
+
+  it("leaves every single mode flag alone", () => {
+    // The mirror of the above: a rule that fires on one flag would refuse the
+    // command's ordinary use, and a pair-only assertion cannot see that.
+    for (const flag of CONTEXT_MODE_FLAGS) {
+      expect(detectContextModeConflict({ [flag]: "x" })).toBeUndefined();
+    }
   });
 });
 

--- a/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
+++ b/ix-cli/src/cli/__tests__/context-mode-conflict.test.ts
@@ -167,10 +167,16 @@ function runProgram(
   const stderr: string[] = [];
   const origStdout = process.stdout.write.bind(process.stdout);
   const origErr = console.error;
+  // Both, and console.log is the one that matters: under vitest `console` is
+  // replaced wholesale, so it never reaches `process.stdout.write` and a
+  // capture that patches only the stream sees nothing — which makes
+  // `expect(stdout).toBe("")` pass no matter what the command printed.
+  const origLog = console.log;
   process.stdout.write = ((chunk: unknown) => {
     stdout.push(String(chunk));
     return true;
   }) as typeof process.stdout.write;
+  console.log = (...a: unknown[]) => void stdout.push(a.join(" ") + "\n");
   console.error = (...a: unknown[]) => void stderr.push(a.join(" "));
 
   let code: number | string | undefined;
@@ -184,6 +190,7 @@ function runProgram(
   } finally {
     code = process.exitCode;
     process.stdout.write = origStdout;
+    console.log = origLog;
     console.error = origErr;
   }
   return { stderr: stderr.join("\n"), stdout: stdout.join(""), exitCode: code };
@@ -218,6 +225,53 @@ describe("ix diff action surfaces mode conflicts on stderr and exits 1", () => {
     expect(r.stderr).toMatch(/^Error:/m);
     expect(r.stderr).toMatch(re);
     expect(r.stdout).toBe("");
+  });
+});
+
+describe("a caller that asked for records gets the error as a record", () => {
+  // An agent is told to pass `--format llm` unconditionally, so an error it
+  // cannot read is an error it cannot act on. Same shape the rest of the CLI
+  // emits (imports/trace/smells/locate/callers) and the one docs/llm-format.md
+  // specifies: on stdout, in-stream, exit code still non-zero.
+  it("emits an error record for ix context and keeps the exit code", () => {
+    const r = runProgram(registerContextCommand, [
+      "context",
+      "--resume",
+      "x",
+      "--diff",
+      "y",
+      "--format",
+      "llm",
+    ]);
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toMatch(/^error code=mode_conflict message="/);
+    // One record, on one line, with the message quoted rather than bare.
+    expect(r.stdout.trimEnd().split("\n")).toHaveLength(1);
+    expect(r.stderr).toBe("");
+  });
+
+  it("emits an error record for ix diff and keeps the exit code", () => {
+    const r = runProgram(registerDiffCommand, [
+      "diff",
+      "3",
+      "5",
+      "--summary",
+      "--content",
+      "--format",
+      "llm",
+    ]);
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toMatch(/^error code=mode_conflict message="/);
+    expect(r.stderr).toBe("");
+  });
+
+  it("still writes prose to stderr for every other format", () => {
+    for (const format of ["text", "json"]) {
+      const r = runProgram(registerContextCommand, ["context", "--resume", "x", "--diff", "y", "--format", format]);
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/^Error:/m);
+      expect(r.stdout).toBe("");
+    }
   });
 });
 

--- a/ix-cli/src/cli/__tests__/context-pick-validation.test.ts
+++ b/ix-cli/src/cli/__tests__/context-pick-validation.test.ts
@@ -63,3 +63,65 @@ describe("ix context --pick validation", () => {
     });
   });
 });
+
+/**
+ * The `--max-*` flags now validate at parse time too, for a sharper reason than
+ * `--pick` does: `ix context --diff` reports the requested budget back to the
+ * caller. Reading the raw option string back out with `Number.parseInt` — which
+ * is what this replaces — is not a check. It reads `"10abc"` as 10, `"0x10"` as
+ * 0, `"1e3"` as 1 and `"-5"` as -5, so `--max-entities 1e3` was reported as
+ * `budgets scope=requested entities=1 applied=false`: a request the user never
+ * made, on the one record whose whole purpose is saying what they asked for.
+ */
+describe("ix context --max-* validation", () => {
+  beforeEach(() => {
+    resolveFileOrEntity.mockReset().mockResolvedValue(undefined);
+  });
+
+  it.each(["10abc", "0x10", "1e3", "-5", "0", "3.5", "", "  "])(
+    "rejects %j before building anything",
+    async (value) => {
+      const result = await runContext(["--max-entities", value]);
+
+      expect(result.error?.exitCode).toBe(1);
+      expect(result.stderr).toContain("must be a positive integer");
+      expect(resolveFileOrEntity).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["--max-relationships", "--max-evidence", "--max-chars"])(
+    "applies the same rule to %s",
+    async (flag) => {
+      expect((await runContext([flag, "10abc"])).error?.exitCode).toBe(1);
+      expect((await runContext([flag, "1000"])).error).toBeUndefined();
+    },
+  );
+
+  it("still tells the user each flag's default and range", async () => {
+    // Removing the Commander defaults is what lets an absent flag be told apart
+    // from one set to the default value — but it also removed `(default: "50")`
+    // from `--help`, leaving four flags whose default a user could not discover
+    // from the CLI at all while `--format` still showed its own.
+    const program = new Command().name("ix").exitOverride();
+    registerContextCommand(program);
+    const help = program.commands.find((c) => c.name() === "context")!.helpInformation();
+
+    // Whitespace-flattened: commander pads to a column and wraps a long
+    // description onto the next line, so a per-line search finds the flag on
+    // one line and its range on another. Flattening keeps the assertion about
+    // which text belongs to which flag, which is the whole point of it.
+    const flat = help.replace(/\s+/g, " ");
+    for (const [flag, text, fallback, min, max] of [
+      ["--max-entities", "Maximum entities in the bundle", 50, 1, 500],
+      ["--max-relationships", "Maximum relationships in the bundle", 100, 1, 1000],
+      ["--max-evidence", "Maximum evidence items in the bundle", 25, 1, 200],
+      ["--max-chars", "Maximum characters of evidence output", 12000, 1000, 1000000],
+    ] as const) {
+      // One assertion per flag, so a failure names which one lost its default
+      // rather than reporting that some string was missing from a wall of help.
+      expect(flat, `help for ${flag}`).toContain(
+        `${flag} <n> ${text} (default: ${fallback}, clamped to ${min}-${max})`,
+      );
+    }
+  });
+});

--- a/ix-cli/src/cli/__tests__/context-pick-validation.test.ts
+++ b/ix-cli/src/cli/__tests__/context-pick-validation.test.ts
@@ -125,3 +125,53 @@ describe("ix context --max-* validation", () => {
     }
   });
 });
+
+/**
+ * `--as-of-rev` sat two lines from the budget flags with a bare
+ * `parseInt(opts.asOfRev, 10)` behind it, and its value goes to the backend:
+ * `--as-of-rev abc` sent NaN, `3.9` silently became 3, `10abc` became 10.
+ */
+describe("ix context --as-of-rev validation", () => {
+  beforeEach(() => {
+    resolveFileOrEntity.mockReset().mockResolvedValue(undefined);
+  });
+
+  it.each(["abc", "3.9", "10abc", "-1", "0"])("rejects %j rather than sending it", async (value) => {
+    const result = await runContext(["--as-of-rev", value]);
+    expect(result.error?.exitCode).toBe(1);
+    expect(result.stderr).toContain("must be a positive integer");
+    expect(resolveFileOrEntity).not.toHaveBeenCalled();
+  });
+
+  it("accepts a revision", async () => {
+    expect((await runContext(["--as-of-rev", "12"])).error).toBeUndefined();
+  });
+});
+
+describe("ix context refusals reach the caller that asked for records", () => {
+  beforeEach(() => {
+    resolveFileOrEntity.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("answers a missing target with a record and a non-zero status", async () => {
+    // It was a `renderWarning` — console.log — with the exit code left at 0, so
+    // an `llm` consumer got a prose line in its record stream and a script
+    // could not tell "no target given" from a successful empty bundle.
+    const out: string[] = [];
+    const origLog = console.log;
+    const priorExit = process.exitCode;
+    console.log = (...a: unknown[]) => void out.push(a.map(String).join(" "));
+    try {
+      process.exitCode = undefined;
+      const program = new Command().name("ix").exitOverride();
+      registerContextCommand(program);
+      await program.parseAsync(["context", "--format", "llm"], { from: "user" });
+      expect(out).toHaveLength(1);
+      expect(out[0]).toMatch(/^error code=missing_target message="/);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      console.log = origLog;
+      process.exitCode = priorExit;
+    }
+  });
+});

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -123,10 +123,14 @@ export function registerContextCommand(program: Command): void {
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
     .option("--depth <depth>", "Context-graph expansion depth")
     .option("--as-of-rev <n>", "Historical context as of a graph revision")
-    .option("--max-entities <n>", "Maximum entities in the bundle", "50")
-    .option("--max-relationships <n>", "Maximum relationships in the bundle", "100")
-    .option("--max-evidence <n>", "Maximum evidence items in the bundle", "25")
-    .option("--max-chars <n>", "Maximum characters of evidence output", "12000")
+    // The --max-* flags default to undefined rather than "50"/"100"/etc. so
+    // parseRequestedBudgets can tell whether the user actually supplied an
+    // override on the command line. The numeric defaults are still applied at
+    // build time via clampInt(opts.max*, 1, 500, 50).
+    .option("--max-entities <n>", "Maximum entities in the bundle")
+    .option("--max-relationships <n>", "Maximum relationships in the bundle")
+    .option("--max-evidence <n>", "Maximum evidence items in the bundle")
+    .option("--max-chars <n>", "Maximum characters of evidence output")
     .option("--format <fmt>", "Output format (text|json|llm)", "text")
     .option("--out <path>", "Write the JSON bundle to this file instead of stdout")
     .option("--save <id>", "Persist the bundle as a resumable investigation state")
@@ -144,13 +148,19 @@ export function registerContextCommand(program: Command): void {
       if (opts.diff) {
         const saved = loadInvestigation(opts.diff);
         if (!saved) return;
+        // The fresh side of --diff is currently built with the saved investigation's
+        // own budgets (ix-cli/src/cli/commands/context.ts: `buildFreshBundle(..., saved.bundle.budgets)`),
+        // so any --max-* flags the user passes on the CLI are not applied to the
+        // fresh bundle. We capture the requested values separately so the diff output
+        // can surface them to humans and agents instead of silently dropping them.
+        const requestedBudgets = parseRequestedBudgets(opts);
         const fresh = await buildFreshBundle(
           target ?? saved.bundle.target.name,
           { ...opts, ...mergeDiffOptions(saved, opts) },
           saved.bundle.budgets,
         );
         if (!fresh) return;
-        renderInvestigationDiff(saved, fresh, opts.format);
+        renderInvestigationDiff(saved, fresh, opts.format, requestedBudgets);
         return;
       }
       if (!target) {
@@ -390,7 +400,51 @@ function renderSavedInvestigation(id: string, format: string): void {
   renderBundle(saved.bundle, format);
 }
 
-export function diffInvestigations(saved: SavedInvestigation, fresh: ContextBundle): InvestigationDiff {
+interface BudgetSnapshot {
+  maxEntities: number;
+  maxRelationships: number;
+  maxEvidence: number;
+  maxChars: number;
+}
+
+/** Compact one-line representation of a budget snapshot for human rendering. */
+function formatBudgets(b: Partial<BudgetSnapshot>, partial = false): string {
+  const fmt = (val: number | undefined, key: string): string =>
+    `${key}=${val === undefined ? "not-given" : String(val)}`;
+  const segments = [
+    fmt(b.maxEntities, "entities"),
+    fmt(b.maxRelationships, "relationships"),
+    fmt(b.maxEvidence, "evidence"),
+    fmt(b.maxChars, "chars"),
+  ].join(" ");
+  return partial ? `${segments} (CLI override; not applied to --diff fresh side)` : segments;
+}
+
+/**
+ * Apply the same clamping rules the action handler uses for direct --save runs
+ * to a budget object parsed from raw commander string values. Treats an absent
+ * or whitespace-only string as "user did not pass this flag".
+ */
+export function parseRequestedBudgets(opts: Partial<ContextOptions>): Partial<BudgetSnapshot> | undefined {
+  const fields: Array<keyof BudgetSnapshot> = ["maxEntities", "maxRelationships", "maxEvidence", "maxChars"];
+  const out: Partial<BudgetSnapshot> = {};
+  let provided = false;
+  for (const key of fields) {
+    const raw = opts[key] as string | undefined;
+    if (typeof raw !== "string" || raw.trim() === "") continue;
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed)) continue;
+    out[key] = parsed;
+    provided = true;
+  }
+  return provided ? out : undefined;
+}
+
+export function diffInvestigations(
+  saved: SavedInvestigation,
+  fresh: ContextBundle,
+  requestedBudgets?: Partial<BudgetSnapshot>,
+): InvestigationDiff {
   const prev = saved.bundle;
   const addedEntities = fresh.entities.filter((e) => !prev.entities.some((p) => p.id === e.id));
   const removedEntities = prev.entities.filter((p) => !fresh.entities.some((e) => e.id === p.id));
@@ -405,6 +459,12 @@ export function diffInvestigations(saved: SavedInvestigation, fresh: ContextBund
   const addedClaims = fresh.claims.filter((c) => !prev.claims.some((p) => p.id === c.id));
   const removedClaims = prev.claims.filter((p) => !fresh.claims.some((c) => c.id === p.id));
 
+  // Surface the silent "saved budgets govern --diff" precedence as data instead
+  // of hiding it. Today `effective` always equals `saved`; if a future change
+  // ever lets CLI overrides win on the fresh side, this block is the single
+  // place that flips and the diff output is the only observable truth.
+  const effective: BudgetSnapshot = { ...saved.bundle.budgets };
+
   return {
     schema: "ix-investigation-diff/1",
     investigation: saved.id,
@@ -412,6 +472,17 @@ export function diffInvestigations(saved: SavedInvestigation, fresh: ContextBund
     generatedAt: new Date().toISOString(),
     target: fresh.target,
     freshness: { previous: prev.freshness, current: fresh.freshness },
+    budgets: {
+      saved: saved.bundle.budgets,
+      requested: requestedBudgets,
+      effective,
+      // The note exists so an agent reading the JSON alone can tell why a
+      // --max-* flag it passed on the CLI did not change the comparison
+      // footprint, without having to read source to find the precedence rule.
+      note: requestedBudgets
+        ? "Saved investigation budgets govern --diff; --max-* flags on the CLI are recorded above for transparency but not applied to the fresh side."
+        : "Saved investigation budgets govern --diff; no --max-* overrides were supplied on the CLI.",
+    },
     added: {
       entities: addedEntities,
       relationships: addedRelationships,
@@ -434,13 +505,24 @@ interface InvestigationDiff {
   generatedAt: string;
   target: ContextBundle["target"];
   freshness: { previous: ContextBundle["freshness"]; current: ContextBundle["freshness"] };
+  budgets: {
+    saved: BudgetSnapshot;
+    requested?: Partial<BudgetSnapshot>;
+    effective: BudgetSnapshot;
+    note: string;
+  };
   added: { entities: ContextBundle["entities"]; relationships: ContextBundle["relationships"]; evidence: EvidenceItem[]; claims: ContextBundle["claims"] };
   removed: { entities: ContextBundle["entities"]; relationships: ContextBundle["relationships"]; evidence: EvidenceItem[]; claims: ContextBundle["claims"] };
 }
 
-function renderInvestigationDiff(saved: SavedInvestigation, fresh: ContextBundle, format: string): void {
+export function renderInvestigationDiff(
+  saved: SavedInvestigation,
+  fresh: ContextBundle,
+  format: string,
+  requestedBudgets?: Partial<BudgetSnapshot>,
+): void {
   const prev = saved.bundle;
-  const diff = diffInvestigations(saved, fresh);
+  const diff = diffInvestigations(saved, fresh, requestedBudgets);
 
   if (format === "json") {
     console.log(JSON.stringify(diff, null, 2));
@@ -449,6 +531,26 @@ function renderInvestigationDiff(saved: SavedInvestigation, fresh: ContextBundle
 
   renderSection(`Investigation diff: ${saved.id}`);
   console.log(`  freshness: ${prev.freshness.classification} -> ${fresh.freshness.classification}`);
+  if (format === "llm") {
+    console.log(`  budgets`);
+    console.log(`    saved     : ${formatBudgets(diff.budgets.saved)}`);
+    if (diff.budgets.requested) {
+      console.log(`    requested : ${formatBudgets(diff.budgets.requested as BudgetSnapshot, true)}`);
+    } else {
+      console.log(`    requested : (none — no --max-* flags passed)`);
+    }
+    console.log(`    effective : ${formatBudgets(diff.budgets.effective)}`);
+    console.log(`    note      : ${diff.budgets.note}`);
+  } else {
+    console.log(`  budgets:`);
+    console.log(`    saved     : ${formatBudgets(diff.budgets.saved)}`);
+    if (diff.budgets.requested) {
+      console.log(`    requested : ${formatBudgets(diff.budgets.requested as BudgetSnapshot, true)}`);
+    } else {
+      console.log(`    requested : (none)`);
+    }
+    console.log(`    effective : ${formatBudgets(diff.budgets.effective)}`);
+  }
   console.log(`  entities:  -${diff.removed.entities.length} +${diff.added.entities.length}`);
   console.log(`  relationships: -${diff.removed.relationships.length} +${diff.added.relationships.length}`);
   console.log(`  evidence:  -${diff.removed.evidence.length} +${diff.added.evidence.length}`);

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -137,7 +137,7 @@ export function registerContextCommand(program: Command): void {
       "\nExamples:\n  ix context IngestionService\n  ix context src/main.ts --format json\n  ix context Widget --max-entities 20 --max-evidence 10\n  ix context Widget --save widget-investigation\n  ix context --resume widget-investigation\n  ix context --diff widget-investigation\n  ix context --list",
     )
     .action(async (target: string | undefined, opts: ContextOptions) => {
-      const conflict = detectContextModeConflict(opts);
+      const conflict = detectContextModeConflict(opts, target);
       if (conflict) {
         reportModeConflict(conflict, opts.format);
         return;
@@ -147,14 +147,9 @@ export function registerContextCommand(program: Command): void {
         return;
       }
       if (opts.list) {
-        if (opts.save || opts.diff || opts.resume) {
-          // A refusal exits non-zero, the way `refuseInvestigation` does two
-          // functions down and the way the sibling commands do: a warning with
-          // a success status tells a script the listing it never got was fine.
-          renderWarning("--list cannot be combined with --save, --diff or --resume.");
-          process.exitCode = 1;
-          return;
-        }
+        // No guard of its own: every combination it used to check is refused
+        // above, before any mode branch can return first. The old one lived
+        // here, below `if (opts.resume)`, so its `--resume` arm was dead.
         const listed = listInvestigations();
         renderInvestigationList(listed.saved, listed.skipped, opts.format);
         return;
@@ -297,7 +292,7 @@ async function buildFreshBundle(
  * without inventing a `format`.
  */
 export type ContextModeOptions = Partial<
-  Pick<ContextOptions, "resume" | "diff" | "save" | "out" | "format">
+  Pick<ContextOptions, "resume" | "diff" | "save" | "out" | "list" | "format">
 >;
 
 /**
@@ -311,10 +306,37 @@ export type ContextModeOptions = Partial<
  * well-defined combined behaviour. Catching these combinations up front and
  * surfacing them as a hard error mirrors the explicit-conflict style in
  * subsystems.ts and prevents the user's typed flag from being a no-op.
+ *
+ * `--list` is checked here rather than inside the list branch, and that is the
+ * point rather than tidiness. Its own guard sat below `if (opts.resume)`, which
+ * returns first, so the `--list --resume` arm of it could never fire: the user
+ * asked for a listing, silently got one investigation rendered, and the exit
+ * code said it went fine. A guard that runs before every mode branch cannot
+ * lose that race.
+ *
+ * `target` is a parameter because a positional is as ignorable as a flag:
+ * `ix context Widget --list` dropped the target with nothing said.
  */
 export function detectContextModeConflict(
   opts: ContextModeOptions,
+  target?: string,
 ): string | undefined {
+  if (opts.list && target) {
+    return `--list takes no target; it enumerates every saved investigation. Drop "${target}", or drop --list to build a fresh bundle for it.`;
+  }
+  if (opts.list && opts.resume) {
+    return "--list and --resume cannot be combined; --list enumerates saved investigations, --resume renders one. Run --list first, then --resume the id you want.";
+  }
+  if (opts.list && opts.diff) {
+    return "--list and --diff cannot be combined; --list enumerates saved investigations, --diff compares one against a fresh build.";
+  }
+  if (opts.list && opts.save) {
+    return "--list cannot be combined with --save; --list reads saved investigations, --save writes one, and --list builds no bundle to write.";
+  }
+  if (opts.list && opts.out) {
+    return "--list cannot be combined with --out; --list enumerates to stdout."
+      + " Redirect it (`ix context --list --format json > <path>`) if you need the listing on disk.";
+  }
   if (opts.resume && opts.diff) {
     return "--resume and --diff cannot be combined; --resume renders a saved investigation, --diff renders a comparison against one.";
   }
@@ -379,6 +401,29 @@ export function sanitizeId(id: string): string {
   }
   if (out.startsWith(".")) out = `~2E${out.slice(1)}`;
   return out || "unnamed";
+}
+
+/**
+ * Recover the id the user typed from the id stored on disk.
+ *
+ * `sanitizeId` is injective and deliberately *not* idempotent — it encodes `~`
+ * as `~7E` precisely so a raw `~` cannot be confused with an escape — so the
+ * stored form is the wrong thing to hand back to the user. `ix context --list`
+ * printed it anyway, next to "Resume with: ix context --resume <id>", and
+ * `--resume` sanitizes what it is given: an id saved as `widget/auth` was
+ * listed as `widget~2Fauth`, and resuming that looked for `widget~7E2Fauth`,
+ * which does not exist. `saveInvestigation`'s own note echoes the id the user
+ * typed, so the two affordances contradicted each other.
+ *
+ * `sanitizeId(unsanitizeId(stored)) === stored` for every id this CLI wrote,
+ * which is what makes the listed id usable. A hand-written file whose id is
+ * outside `sanitizeId`'s range has no input that reaches it and is not a case
+ * this recovers.
+ */
+export function unsanitizeId(stored: string): string {
+  return stored.replace(/~([0-9A-Fa-f]{2})/g, (_m, hex: string) =>
+    String.fromCharCode(parseInt(hex, 16)),
+  );
 }
 
 export function saveInvestigation(id: string, bundle: ContextBundle): void {
@@ -482,23 +527,58 @@ export function listInvestigations(): { saved: SavedInvestigation[]; skipped: nu
   return { saved: out, skipped };
 }
 
+/** One saved investigation as `--list` describes it: what it is, not what is in it. */
+interface InvestigationSummary {
+  /** The id to type back, not the id on disk — see `unsanitizeId`. */
+  id: string;
+  savedAt: string;
+  target: { name: string; kind: string };
+  freshness: ContextBundle["freshness"];
+  counts: { entities: number; relationships: number; evidence: number };
+  truncation: ContextBundle["truncation"];
+}
+
+/** Summarise one saved investigation for the listing. */
+function summariseInvestigation(s: SavedInvestigation): InvestigationSummary {
+  const b = s.bundle;
+  return {
+    id: unsanitizeId(s.id),
+    savedAt: s.savedAt,
+    target: { name: b.target.name, kind: b.target.kind },
+    freshness: b.freshness,
+    counts: {
+      entities: b.entities.length,
+      relationships: b.relationships.length,
+      evidence: b.evidence.length,
+    },
+    truncation: b.truncation,
+  };
+}
+
 /**
  * Render the saved investigations produced by `listInvestigations`.
  *
- * JSON stays the array of saved envelopes; llm emits a summary record and one
- * record per investigation; text prints the tabular summary.
+ * Every format carries the same summary: what each investigation is, how big
+ * it is, and how stale. Not the bundles themselves — `--list` is the discovery
+ * step, and twenty saved investigations is twenty complete bundles, up to 50
+ * entities, 100 relationships and 12000 characters of evidence each. A caller
+ * that wants one of them asks for it by id with `--resume <id> --format json`.
  *
  * `skipped` is reported in each format's own terms, and never on stdout except
- * as a field. It used to be a `renderWarning` inside the enumerator — which is
- * `console.log` — so a single corrupt file prepended a chalk-coloured prose
- * line to the payload and `ix context --list --format json | jq` failed on it.
- * The human warning goes to stderr; the machine formats carry a count.
+ * as a field — including in `json`, which returns an object for exactly that
+ * reason: an array has nowhere to put it, so a machine caller could not tell
+ * that files had been rejected while the human saw a warning saying so. It used
+ * to be a `renderWarning` inside the enumerator — which is `console.log` — so a
+ * single corrupt file prepended a chalk-coloured prose line to the payload and
+ * `ix context --list --format json | jq` failed on it. The human warning goes to
+ * stderr; the machine formats carry a count.
  */
 export function renderInvestigationList(
   items: SavedInvestigation[],
   skipped: number,
   format: string,
 ): void {
+  const summaries = items.map(summariseInvestigation);
   if (skipped > 0 && format !== "llm") {
     // `console.error`, not `renderWarning`: every renderer in ui.ts writes to
     // stdout, which is exactly how this line used to end up inside the JSON a
@@ -511,57 +591,56 @@ export function renderInvestigationList(
     );
   }
   if (format === "json") {
-    console.log(JSON.stringify(items, null, 2));
+    console.log(JSON.stringify({ investigations: summaries, skipped }, null, 2));
     return;
   }
   if (format === "llm") {
     printLlmLines([
       // `skipped` is a field rather than a warning: it is the one thing about
       // the listing an agent cannot see from the records themselves.
-      llmLine("investigations", { total: items.length, skipped: skipped || undefined }),
-      ...items.map((s) =>
+      llmLine("investigations", { total: summaries.length, skipped: skipped || undefined }),
+      ...summaries.map((s) =>
         llmLine("investigation", {
           id: s.id,
           saved_at: s.savedAt,
-          target: s.bundle.target.name,
-          target_kind: s.bundle.target.kind,
-          classification: s.bundle.freshness.classification,
-          stale: s.bundle.freshness.stale,
-          entities: s.bundle.entities.length,
-          relationships: s.bundle.relationships.length,
-          evidence: s.bundle.evidence.length,
-          truncated_entities: s.bundle.truncation.entitiesTruncated,
-          truncated_relationships: s.bundle.truncation.relationshipsTruncated,
-          truncated_evidence: s.bundle.truncation.evidenceTruncated,
-          truncated_chars: s.bundle.truncation.charactersTruncated,
+          target: s.target.name,
+          target_kind: s.target.kind,
+          classification: s.freshness.classification,
+          stale: s.freshness.stale,
+          entities: s.counts.entities,
+          relationships: s.counts.relationships,
+          evidence: s.counts.evidence,
+          truncated_entities: s.truncation.entitiesTruncated,
+          truncated_relationships: s.truncation.relationshipsTruncated,
+          truncated_evidence: s.truncation.evidenceTruncated,
+          truncated_chars: s.truncation.charactersTruncated,
         }),
       ),
     ]);
     return;
   }
 
-  if (items.length === 0) {
+  if (summaries.length === 0) {
     renderNote("No saved investigations. Use `ix context <target> --save <id>` to create one.");
     return;
   }
-  renderSection(`Saved investigations (${items.length})`);
-  for (const s of items) {
-    const b = s.bundle;
+  renderSection(`Saved investigations (${summaries.length})`);
+  for (const s of summaries) {
     console.log(`  ${s.id}`);
-    console.log(`    target:       ${b.target.name} (${b.target.kind})`);
+    console.log(`    target:       ${s.target.name} (${s.target.kind})`);
     console.log(`    saved_at:     ${s.savedAt}`);
-    console.log(`    freshness:    ${b.freshness.classification}`);
+    console.log(`    freshness:    ${s.freshness.classification}`);
     console.log(
-      `    counts:       entities=${b.entities.length} relationships=${b.relationships.length} evidence=${b.evidence.length}`,
+      `    counts:       entities=${s.counts.entities} relationships=${s.counts.relationships} evidence=${s.counts.evidence}`,
     );
     if (
-      b.truncation.entitiesTruncated ||
-      b.truncation.relationshipsTruncated ||
-      b.truncation.evidenceTruncated ||
-      b.truncation.charactersTruncated
+      s.truncation.entitiesTruncated ||
+      s.truncation.relationshipsTruncated ||
+      s.truncation.evidenceTruncated ||
+      s.truncation.charactersTruncated
     ) {
       console.log(
-        `    truncated:    entities=${b.truncation.entitiesTruncated} relationships=${b.truncation.relationshipsTruncated} evidence=${b.truncation.evidenceTruncated} chars=${b.truncation.charactersTruncated}`,
+        `    truncated:    entities=${s.truncation.entitiesTruncated} relationships=${s.truncation.relationshipsTruncated} evidence=${s.truncation.evidenceTruncated} chars=${s.truncation.charactersTruncated}`,
       );
     }
   }

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -16,7 +16,7 @@ import type {
 } from "../../client/types.js";
 import { getEndpoint } from "../config.js";
 import { collectFacts, type EntityFacts } from "../explain/facts.js";
-import { printLlmLines } from "../llm.js";
+import { llmError, printLlmLines } from "../llm.js";
 import { parsePickOption } from "../options.js";
 import { resolveFileOrEntity } from "../resolve.js";
 import { createStaleProbe } from "../stale.js";
@@ -140,7 +140,7 @@ export function registerContextCommand(program: Command): void {
     .action(async (target: string | undefined, opts: ContextOptions) => {
       const conflict = detectContextModeConflict(opts);
       if (conflict) {
-        reportContextModeConflict(conflict);
+        reportContextModeConflict(conflict, opts.format);
         return;
       }
       if (opts.resume) {
@@ -325,9 +325,18 @@ export function detectContextModeConflict(
   return undefined;
 }
 
-/** Render a detected mode conflict and mark the process exit code. */
-export function reportContextModeConflict(message: string): void {
-  console.error(chalk.red("Error:"), message);
+/**
+ * Render a detected mode conflict and mark the process exit code.
+ *
+ * `--format llm` gets the record form the rest of the CLI emits for errors —
+ * `error code=... message="..."`, on stdout, with the exit code still non-zero
+ * (imports.ts, trace.ts, smells.ts, locate.ts, callers.ts all do this, and
+ * docs/llm-format.md specifies the shape). An agent is told to pass the flag
+ * unconditionally, so an error it cannot read is an error it cannot act on.
+ */
+export function reportContextModeConflict(message: string, format?: string): void {
+  if (format === "llm") console.log(llmError("mode_conflict", message));
+  else console.error(chalk.red("Error:"), message);
   process.exitCode = 1;
 }
 

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
@@ -41,6 +41,7 @@ interface ContextOptions {
   save?: string;
   resume?: string;
   diff?: string;
+  list?: boolean;
   format: string;
 }
 
@@ -132,13 +133,22 @@ export function registerContextCommand(program: Command): void {
     .option("--save <id>", "Persist the bundle as a resumable investigation state")
     .option("--resume <id>", "Render a saved investigation state without a backend")
     .option("--diff <id>", "Diff a saved investigation against a fresh build of the same target")
+    .option("--list", "List saved investigations (no target, no backend)")
     .addHelpText(
       "after",
-      "\nExamples:\n  ix context IngestionService\n  ix context src/main.ts --format json\n  ix context Widget --max-entities 20 --max-evidence 10\n  ix context Widget --save widget-investigation\n  ix context --resume widget-investigation\n  ix context --diff widget-investigation",
+      "\nExamples:\n  ix context IngestionService\n  ix context src/main.ts --format json\n  ix context Widget --max-entities 20 --max-evidence 10\n  ix context Widget --save widget-investigation\n  ix context --resume widget-investigation\n  ix context --diff widget-investigation\n  ix context --list",
     )
     .action(async (target: string | undefined, opts: ContextOptions) => {
       if (opts.resume) {
         renderSavedInvestigation(opts.resume, opts.format);
+        return;
+      }
+      if (opts.list) {
+        if (opts.save || opts.diff) {
+          renderWarning("--list cannot be combined with --save or --diff.");
+          return;
+        }
+        renderInvestigationList(listInvestigations(), opts.format);
         return;
       }
       if (opts.diff) {
@@ -358,6 +368,141 @@ export function mergeDiffOptions(
     asOfRev: opts.asOfRev ?? (savedRev === undefined ? undefined : String(savedRev)),
     depth: opts.depth ?? saved.bundle.metadata.depth,
   };
+}
+
+/**
+ * Enumerate every saved investigation under IX_HOME/investigations.
+ *
+ * Mirrors the read-side validation `loadInvestigation` performs on a single
+ * file (envelope + bundle.safeParse) so a corrupt or version-skewed file is
+ * skipped silently rather than poison the listing — but a corrupt file is
+ * still surfaced through a single warning so the operator can prune it.
+ *
+ * Determinism: results are sorted newest-first by `savedAt`, falling back to
+ * the sanitized `id` so two files saved in the same millisecond still have a
+ * stable order across runs.
+ */
+export function listInvestigations(): SavedInvestigation[] {
+  const dir = investigationDir();
+  if (!existsSync(dir)) return [];
+  const entries = readdirSync(dir).filter((f) => f.endsWith(".json"));
+  const out: SavedInvestigation[] = [];
+  let skipped = 0;
+  for (const file of entries) {
+    const filePath = join(dir, file);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(filePath, "utf8"));
+    } catch {
+      skipped += 1;
+      continue;
+    }
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      (parsed as { schema?: unknown }).schema !== "ix-investigation/1" ||
+      !(parsed as { bundle?: unknown }).bundle
+    ) {
+      skipped += 1;
+      continue;
+    }
+    // Validate the body's contract matches the same versioned schema the
+    // write side enforces. We trust the original parsed JSON (cast as the
+    // SavedInvestigation type, exactly like loadInvestigation does on the
+    // happy path) instead of safeParse's data, because the on-disk envelope
+    // here was produced by saveInvestigation and the renderer only needs to
+    // forward the bundle through unchanged. That keeps the read-side
+    // validation contract symmetric with `loadInvestigation` without
+    // re-running the schema's structural narrowing (which would lose the
+    // richer record types claims/decisions/assets carry internally).
+    const bundleCheck = contextBundleSchema.safeParse((parsed as SavedInvestigation).bundle);
+    if (!bundleCheck.success) {
+      skipped += 1;
+      continue;
+    }
+    out.push(parsed as SavedInvestigation);
+  }
+  if (skipped > 0) {
+    renderWarning(
+      `${skipped} saved investigation file(s) did not match the contract; skipped. Run \`ix context --resume <id>\` for a per-file report.`,
+    );
+  }
+  return out.sort((a, b) => {
+    if (a.savedAt !== b.savedAt) return a.savedAt < b.savedAt ? 1 : -1;
+    return cmp(a.id, b.id);
+  });
+}
+
+/**
+ * Render the saved investigations produced by `listInvestigations`.
+ *
+ * The wire formats mirror the rest of the CLI: JSON is the full saved
+ * envelope so it round-trips through `--resume <id>`; LLM emits one
+ * metadata record per saved investigation; text prints a tabular
+ * summary with truncation/savedAt/target so a human can choose what
+ * to resume or diff.
+ */
+function renderInvestigationList(items: SavedInvestigation[], format: string): void {
+  if (format === "json") {
+    console.log(JSON.stringify(items, null, 2));
+    return;
+  }
+  if (format === "llm") {
+    if (items.length === 0) {
+      printLlmLines(["investigations total=0"]);
+      return;
+    }
+    printLlmLines([
+      `investigations total=${items.length}`,
+      ...items.map((s) =>
+        [
+          `investigation id=${s.id}`,
+          `saved_at=${s.savedAt}`,
+          `target=${s.bundle.target.name}`,
+          `target_kind=${s.bundle.target.kind}`,
+          `classification=${s.bundle.freshness.classification}`,
+          `stale=${s.bundle.freshness.stale}`,
+          `entities=${s.bundle.entities.length}`,
+          `relationships=${s.bundle.relationships.length}`,
+          `evidence=${s.bundle.evidence.length}`,
+          `truncated_entities=${s.bundle.truncation.entitiesTruncated}`,
+          `truncated_relationships=${s.bundle.truncation.relationshipsTruncated}`,
+          `truncated_evidence=${s.bundle.truncation.evidenceTruncated}`,
+          `truncated_chars=${s.bundle.truncation.charactersTruncated}`,
+        ].join(" "),
+      ),
+    ]);
+    return;
+  }
+
+  if (items.length === 0) {
+    renderNote("No saved investigations. Use `ix context <target> --save <id>` to create one.");
+    return;
+  }
+  renderSection(`Saved investigations (${items.length})`);
+  for (const s of items) {
+    const b = s.bundle;
+    console.log(`  ${s.id}`);
+    console.log(`    target:       ${b.target.name} (${b.target.kind})`);
+    console.log(`    saved_at:     ${s.savedAt}`);
+    console.log(`    freshness:    ${b.freshness.classification}`);
+    console.log(
+      `    counts:       entities=${b.entities.length} relationships=${b.relationships.length} evidence=${b.evidence.length}`,
+    );
+    if (
+      b.truncation.entitiesTruncated ||
+      b.truncation.relationshipsTruncated ||
+      b.truncation.evidenceTruncated ||
+      b.truncation.charactersTruncated
+    ) {
+      console.log(
+        `    truncated:    entities=${b.truncation.entitiesTruncated} relationships=${b.truncation.relationshipsTruncated} evidence=${b.truncation.evidenceTruncated} chars=${b.truncation.charactersTruncated}`,
+      );
+    }
+  }
+  console.log();
+  console.log(`Resume with: ix context --resume <id>`);
+  console.log(`Diff with:   ix context --diff <id>`);
 }
 
 export function loadInvestigation(id: string): SavedInvestigation | undefined {

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -15,7 +15,7 @@ import type {
 } from "../../client/types.js";
 import { getEndpoint } from "../config.js";
 import { collectFacts, type EntityFacts } from "../explain/facts.js";
-import { printLlmLines } from "../llm.js";
+import { llmLine, printLlmLines } from "../llm.js";
 import { parsePickOption } from "../options.js";
 import { resolveFileOrEntity } from "../resolve.js";
 import { createStaleProbe } from "../stale.js";
@@ -447,32 +447,48 @@ export function renderInvestigationDiff(saved: SavedInvestigation, fresh: Contex
     return;
   }
   if (format === "llm") {
-    // `ix context --diff --format llm` previously fell through to the prose
-    // renderer below because the diff path only branched on `json`. That made
-    // the most common agent path (`--diff --format llm`) the worst one: the
-    // prose scaling was the whole reason `llm` exists. Mirror `renderBundle`'s
-    // llm branch and emit one record per line in the same `key=value` wire
-    // format the rest of the CLI uses.
+    // `ix context --diff --format llm` used to fall through to the prose
+    // renderer below, because this path only branched on `json`. That made the
+    // most common agent path the worst one: escaping the prose is what `llm`
+    // exists for.
+    //
+    // Every line goes through `llmLine`, never a template literal. The values
+    // here are the ones most likely to contain a space in the whole CLI — an
+    // evidence title is a sentence, and a claim id carries the statement — and
+    // `key=value` with an unquoted space is not a record a consumer can split.
+    // `llmQuote` also encodes newlines, so a title cannot break the one
+    // record per line invariant.
     printLlmLines([
-      `diff investigation=${saved.id} target=${fresh.target.name}`,
-      `freshness_previous=${prev.freshness.classification}`,
-      `freshness_current=${fresh.freshness.classification}`,
-      `count added_entities=${diff.added.entities.length}`,
-      `count removed_entities=${diff.removed.entities.length}`,
-      `count added_relationships=${diff.added.relationships.length}`,
-      `count removed_relationships=${diff.removed.relationships.length}`,
-      `count added_evidence=${diff.added.evidence.length}`,
-      `count removed_evidence=${diff.removed.evidence.length}`,
-      `count added_claims=${diff.added.claims.length}`,
-      `count removed_claims=${diff.removed.claims.length}`,
-      ...diff.added.entities.map((e) => `+entity kind=${e.kind} name=${e.name}`),
-      ...diff.removed.entities.map((e) => `-entity kind=${e.kind} name=${e.name}`),
-      ...diff.added.relationships.map((r) => `+relationship src=${r.src} pred=${r.predicate} dst=${r.dst}`),
-      ...diff.removed.relationships.map((r) => `-relationship src=${r.src} pred=${r.predicate} dst=${r.dst}`),
-      ...diff.added.evidence.map((e) => `+evidence score=${e.score} kind=${e.kind} title=${e.title.replaceAll("\n", " ")}`),
-      ...diff.removed.evidence.map((e) => `-evidence score=${e.score} kind=${e.kind} title=${e.title.replaceAll("\n", " ")}`),
-      ...diff.added.claims.map((c) => `+claim id=${(c as { id?: string }).id ?? ""}`),
-      ...diff.removed.claims.map((c) => `-claim id=${(c as { id?: string }).id ?? ""}`),
+      llmLine("diff", {
+        investigation: saved.id,
+        target: fresh.target.name,
+        freshness_previous: prev.freshness.classification,
+        freshness_current: fresh.freshness.classification,
+      }),
+      // One record rather than eight, and the zeros are kept: "nothing was
+      // added" is the answer to the question `--diff` was asked, so dropping
+      // it as a default would remove the signal.
+      llmLine("count", {
+        added_entities: diff.added.entities.length,
+        removed_entities: diff.removed.entities.length,
+        added_relationships: diff.added.relationships.length,
+        removed_relationships: diff.removed.relationships.length,
+        added_evidence: diff.added.evidence.length,
+        removed_evidence: diff.removed.evidence.length,
+        added_claims: diff.added.claims.length,
+        removed_claims: diff.removed.claims.length,
+      }),
+      // `change=` rather than a `+`/`-` prefix on the record kind: a consumer
+      // routing on the kind should still match `entity` on both sides of the
+      // comparison, and a fused marker means it matches neither.
+      ...diff.added.entities.map((e) => llmLine("entity", { change: "added", kind: e.kind, name: e.name })),
+      ...diff.removed.entities.map((e) => llmLine("entity", { change: "removed", kind: e.kind, name: e.name })),
+      ...diff.added.relationships.map((r) => llmLine("relationship", { change: "added", src: r.src, pred: r.predicate, dst: r.dst })),
+      ...diff.removed.relationships.map((r) => llmLine("relationship", { change: "removed", src: r.src, pred: r.predicate, dst: r.dst })),
+      ...diff.added.evidence.map((e) => llmLine("evidence", { change: "added", score: e.score, kind: e.kind, title: e.title })),
+      ...diff.removed.evidence.map((e) => llmLine("evidence", { change: "removed", score: e.score, kind: e.kind, title: e.title })),
+      ...diff.added.claims.map((c) => llmLine("claim", { change: "added", id: c.id, status: c.status })),
+      ...diff.removed.claims.map((c) => llmLine("claim", { change: "removed", id: c.id, status: c.status })),
     ]);
     return;
   }

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -2,7 +2,6 @@ import type { Command } from "commander";
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import chalk from "chalk";
 
 import {
   BUNDLE_SCHEMA,
@@ -20,7 +19,7 @@ import type {
 } from "../../client/types.js";
 import { getEndpoint } from "../config.js";
 import { collectFacts, type EntityFacts } from "../explain/facts.js";
-import { llmError, printLlmLines } from "../llm.js";
+import { printLlmLines, reportModeConflict } from "../llm.js";
 import { parsePickOption } from "../options.js";
 import { resolveFileOrEntity } from "../resolve.js";
 import { createStaleProbe } from "../stale.js";
@@ -138,7 +137,7 @@ export function registerContextCommand(program: Command): void {
     .action(async (target: string | undefined, opts: ContextOptions) => {
       const conflict = detectContextModeConflict(opts);
       if (conflict) {
-        reportContextModeConflict(conflict, opts.format);
+        reportModeConflict(conflict, opts.format);
         return;
       }
       if (opts.resume) {
@@ -271,18 +270,20 @@ async function buildFreshBundle(
 }
 
 
-/** Saved investigation state lives under ~/.ix/investigations. */
 /**
- * Subset of `ContextOptions` consumed by `detectContextModeConflict`. Kept as a
- * structural type so the detector can be unit-tested without driving Commander.
+ * The `ContextOptions` fields `detectContextModeConflict` consumes.
+ *
+ * `Pick`, not a hand-copied shape: the detector exists to stop a typed flag
+ * being a no-op, so its idea of the flags must come from the same declaration
+ * the action handler uses. Written out field-by-field it drifted immediately --
+ * `--list` was added to `ContextOptions` on a sibling branch and the detector
+ * could not see it, with nothing from the typechecker to say so. `Partial` so
+ * the pure function can still be called with one flag at a time in a test,
+ * without inventing a `format`.
  */
-export interface ContextModeOptions {
-  resume?: string;
-  diff?: string;
-  save?: string;
-  out?: string;
-  format?: string;
-}
+export type ContextModeOptions = Partial<
+  Pick<ContextOptions, "resume" | "diff" | "save" | "out" | "format">
+>;
 
 /**
  * Detect mutually-incompatible mode/output flags on `ix context` and return a
@@ -306,10 +307,14 @@ export function detectContextModeConflict(
     return "--resume cannot be combined with --save; --resume only renders a saved investigation, while --save writes a new one. Run --save on a fresh build instead.";
   }
   if (opts.resume && opts.out) {
+    // No "use --format json with --out" hint here. That hint was unactionable:
+    // this branch fires on `--resume` plus `--out` whatever the format, so a
+    // user who followed it landed straight back on the same error, this time
+    // with no advice at all. The two things that do work are a redirect and
+    // the saved file itself, so name those.
     return "--resume cannot be combined with --out; --resume renders to stdout."
-      + (opts.format && opts.format !== "json"
-        ? " Use --format json with --out if you need to persist the rendered output."
-        : "");
+      + " Redirect it (`ix context --resume <id> --format json > <path>`), or read"
+      + " IX_HOME/investigations/<id>.json, which is already the saved JSON.";
   }
   if (opts.diff && opts.save) {
     return "--diff cannot be combined with --save; --diff renders a comparison against a saved investigation. To persist the fresh side as a new investigation, run the fresh build without --diff and use --save there.";
@@ -323,21 +328,7 @@ export function detectContextModeConflict(
   return undefined;
 }
 
-/**
- * Render a detected mode conflict and mark the process exit code.
- *
- * `--format llm` gets the record form the rest of the CLI emits for errors —
- * `error code=... message="..."`, on stdout, with the exit code still non-zero
- * (imports.ts, trace.ts, smells.ts, locate.ts, callers.ts all do this, and
- * docs/llm-format.md specifies the shape). An agent is told to pass the flag
- * unconditionally, so an error it cannot read is an error it cannot act on.
- */
-export function reportContextModeConflict(message: string, format?: string): void {
-  if (format === "llm") console.log(llmError("mode_conflict", message));
-  else console.error(chalk.red("Error:"), message);
-  process.exitCode = 1;
-}
-
+/** Saved investigation state lives under ~/.ix/investigations. */
 function investigationDir(): string {
   // IX_HOME is the Ix home *directory*, not the investigations directory —
   // backend-status.ts, docker.ts and upgrade.ts all read it as `IX_HOME ||

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import chalk from "chalk";
 
 import { contextBundleSchema } from "../context-bundle-schema.js";
 
@@ -137,6 +138,11 @@ export function registerContextCommand(program: Command): void {
       "\nExamples:\n  ix context IngestionService\n  ix context src/main.ts --format json\n  ix context Widget --max-entities 20 --max-evidence 10\n  ix context Widget --save widget-investigation\n  ix context --resume widget-investigation\n  ix context --diff widget-investigation",
     )
     .action(async (target: string | undefined, opts: ContextOptions) => {
+      const conflict = detectContextModeConflict(opts);
+      if (conflict) {
+        reportContextModeConflict(conflict);
+        return;
+      }
       if (opts.resume) {
         renderSavedInvestigation(opts.resume, opts.format);
         return;
@@ -268,6 +274,63 @@ async function buildFreshBundle(
 
 
 /** Saved investigation state lives under ~/.ix/investigations. */
+/**
+ * Subset of `ContextOptions` consumed by `detectContextModeConflict`. Kept as a
+ * structural type so the detector can be unit-tested without driving Commander.
+ */
+export interface ContextModeOptions {
+  resume?: string;
+  diff?: string;
+  save?: string;
+  out?: string;
+  format?: string;
+}
+
+/**
+ * Detect mutually-incompatible mode/output flags on `ix context` and return a
+ * human-readable message naming the conflict, or `undefined` if no conflict.
+ *
+ * The action handler used to silently drop `--save` and `--out` whenever
+ * `--resume` or `--diff` was passed (those branches `return` before the
+ * `--save`/`--out` branches ever run). It also accepted `--save <id>` alongside
+ * `--out <file>`, which describes two different write targets and so has no
+ * well-defined combined behaviour. Catching these combinations up front and
+ * surfacing them as a hard error mirrors the explicit-conflict style in
+ * subsystems.ts and prevents the user's typed flag from being a no-op.
+ */
+export function detectContextModeConflict(
+  opts: ContextModeOptions,
+): string | undefined {
+  if (opts.resume && opts.diff) {
+    return "--resume and --diff cannot be combined; --resume renders a saved investigation, --diff renders a comparison against one.";
+  }
+  if (opts.resume && opts.save) {
+    return "--resume cannot be combined with --save; --resume only renders a saved investigation, while --save writes a new one. Run --save on a fresh build instead.";
+  }
+  if (opts.resume && opts.out) {
+    return "--resume cannot be combined with --out; --resume renders to stdout."
+      + (opts.format && opts.format !== "json"
+        ? " Use --format json with --out if you need to persist the rendered output."
+        : "");
+  }
+  if (opts.diff && opts.save) {
+    return "--diff cannot be combined with --save; --diff renders a comparison against a saved investigation. To persist the fresh side as a new investigation, run the fresh build without --diff and use --save there.";
+  }
+  if (opts.diff && opts.out) {
+    return "--diff cannot be combined with --out; --diff renders the comparison to stdout.";
+  }
+  if (opts.save && opts.out) {
+    return "--save and --out cannot be combined; --save writes to IX_HOME/investigations/<id>.json, while --out writes to a caller-chosen path. Pick one.";
+  }
+  return undefined;
+}
+
+/** Render a detected mode conflict and mark the process exit code. */
+export function reportContextModeConflict(message: string): void {
+  console.error(chalk.red("Error:"), message);
+  process.exitCode = 1;
+}
+
 function investigationDir(): string {
   // IX_HOME is the Ix home *directory*, not the investigations directory —
   // backend-status.ts, docker.ts and upgrade.ts all read it as `IX_HOME ||

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -438,12 +438,42 @@ interface InvestigationDiff {
   removed: { entities: ContextBundle["entities"]; relationships: ContextBundle["relationships"]; evidence: EvidenceItem[]; claims: ContextBundle["claims"] };
 }
 
-function renderInvestigationDiff(saved: SavedInvestigation, fresh: ContextBundle, format: string): void {
+export function renderInvestigationDiff(saved: SavedInvestigation, fresh: ContextBundle, format: string): void {
   const prev = saved.bundle;
   const diff = diffInvestigations(saved, fresh);
 
   if (format === "json") {
     console.log(JSON.stringify(diff, null, 2));
+    return;
+  }
+  if (format === "llm") {
+    // `ix context --diff --format llm` previously fell through to the prose
+    // renderer below because the diff path only branched on `json`. That made
+    // the most common agent path (`--diff --format llm`) the worst one: the
+    // prose scaling was the whole reason `llm` exists. Mirror `renderBundle`'s
+    // llm branch and emit one record per line in the same `key=value` wire
+    // format the rest of the CLI uses.
+    printLlmLines([
+      `diff investigation=${saved.id} target=${fresh.target.name}`,
+      `freshness_previous=${prev.freshness.classification}`,
+      `freshness_current=${fresh.freshness.classification}`,
+      `count added_entities=${diff.added.entities.length}`,
+      `count removed_entities=${diff.removed.entities.length}`,
+      `count added_relationships=${diff.added.relationships.length}`,
+      `count removed_relationships=${diff.removed.relationships.length}`,
+      `count added_evidence=${diff.added.evidence.length}`,
+      `count removed_evidence=${diff.removed.evidence.length}`,
+      `count added_claims=${diff.added.claims.length}`,
+      `count removed_claims=${diff.removed.claims.length}`,
+      ...diff.added.entities.map((e) => `+entity kind=${e.kind} name=${e.name}`),
+      ...diff.removed.entities.map((e) => `-entity kind=${e.kind} name=${e.name}`),
+      ...diff.added.relationships.map((r) => `+relationship src=${r.src} pred=${r.predicate} dst=${r.dst}`),
+      ...diff.removed.relationships.map((r) => `-relationship src=${r.src} pred=${r.predicate} dst=${r.dst}`),
+      ...diff.added.evidence.map((e) => `+evidence score=${e.score} kind=${e.kind} title=${e.title.replaceAll("\n", " ")}`),
+      ...diff.removed.evidence.map((e) => `-evidence score=${e.score} kind=${e.kind} title=${e.title.replaceAll("\n", " ")}`),
+      ...diff.added.claims.map((c) => `+claim id=${(c as { id?: string }).id ?? ""}`),
+      ...diff.removed.claims.map((c) => `-claim id=${(c as { id?: string }).id ?? ""}`),
+    ]);
     return;
   }
 

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -19,22 +19,79 @@ import type {
 } from "../../client/types.js";
 import { getEndpoint } from "../config.js";
 import { collectFacts, type EntityFacts } from "../explain/facts.js";
-import { llmLine, printLlmLines, reportModeConflict } from "../llm.js";
-import { parsePickOption } from "../options.js";
+import { llmError, llmLine, printLlmLines, reportModeConflict } from "../llm.js";
+import { parseBudgetOption, parsePickOption } from "../options.js";
 import { resolveFileOrEntity } from "../resolve.js";
 import { createStaleProbe } from "../stale.js";
 import { renderNote, renderSection, renderWarning } from "../ui.js";
 
-interface ContextOptions {
+/** The four `--max-*` knobs that bound a bundle. */
+interface BudgetSnapshot {
+  maxEntities: number;
+  maxRelationships: number;
+  maxEvidence: number;
+  maxChars: number;
+}
+
+/**
+ * The four budgets, described once: flag key, output label, clamp range, and
+ * the default applied when the flag is absent.
+ *
+ * These four facts used to live in five hand-maintained places -- the option
+ * registration, the `clampInt` calls, the record fields, the prose formatter
+ * and the requested-budget reader -- so a fifth budget meant five edits and
+ * missing one was silent. They had already drifted: a comment on the
+ * registration described `clampInt(opts.max*, 1, 500, 50)` as if it were the
+ * rule for all four, which is right for entities and wrong for the rest
+ * (`--max-chars` is 1000-1000000 defaulting to 12000). Everything below reads
+ * this table, and `--help` interpolates it, so the number a user is told is
+ * the number that is applied.
+ */
+const BUDGETS = [
+  { key: "maxEntities", label: "entities", help: "Maximum entities in the bundle", min: 1, max: 500, fallback: 50 },
+  { key: "maxRelationships", label: "relationships", help: "Maximum relationships in the bundle", min: 1, max: 1000, fallback: 100 },
+  { key: "maxEvidence", label: "evidence", help: "Maximum evidence items in the bundle", min: 1, max: 200, fallback: 25 },
+  { key: "maxChars", label: "chars", help: "Maximum characters of evidence output", min: 1000, max: 1_000_000, fallback: 12_000 },
+] as const satisfies ReadonlyArray<{
+  key: keyof BudgetSnapshot;
+  label: string;
+  help: string;
+  min: number;
+  max: number;
+  fallback: number;
+}>;
+
+/**
+ * `--help` text for one budget flag.
+ *
+ * The Commander defaults were removed so an absent flag is distinguishable
+ * from one set to the default value -- `--diff` reports which budgets the
+ * caller actually asked for. Removing them also removed `(default: "50")` from
+ * `ix context --help`, leaving four flags whose default and range a user could
+ * not discover from the CLI at all, so the text says both, read off the table
+ * that enforces them.
+ */
+function budgetHelp(key: keyof BudgetSnapshot): string {
+  const b = BUDGETS.find((entry) => entry.key === key)!;
+  return `${b.help} (default: ${b.fallback}, clamped to ${b.min}-${b.max})`;
+}
+
+/** Apply the table's range and default to whatever the caller supplied. */
+function clampBudgets(opts: Partial<BudgetSnapshot>): BudgetSnapshot {
+  const out = {} as BudgetSnapshot;
+  for (const b of BUDGETS) {
+    const raw = opts[b.key];
+    out[b.key] = raw === undefined ? b.fallback : Math.min(b.max, Math.max(b.min, raw));
+  }
+  return out;
+}
+
+interface ContextOptions extends Partial<BudgetSnapshot> {
   kind?: string;
   path?: string;
   pick?: number;
   depth?: string;
   asOfRev?: string;
-  maxEntities?: string;
-  maxRelationships?: string;
-  maxEvidence?: string;
-  maxChars?: string;
   out?: string;
   save?: string;
   resume?: string;
@@ -88,7 +145,7 @@ interface ContextBundle {
   };
   freshness: { stale: boolean; classification: "current" | "stale" | "unverified" };
   evidence: EvidenceItem[];
-  budgets: { maxEntities: number; maxRelationships: number; maxEvidence: number; maxChars: number };
+  budgets: BudgetSnapshot;
   truncation: {
     entitiesTruncated: number;
     relationshipsTruncated: number;
@@ -122,14 +179,15 @@ export function registerContextCommand(program: Command): void {
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
     .option("--depth <depth>", "Context-graph expansion depth")
     .option("--as-of-rev <n>", "Historical context as of a graph revision")
-    // The --max-* flags default to undefined rather than "50"/"100"/etc. so
-    // parseRequestedBudgets can tell whether the user actually supplied an
-    // override on the command line. The numeric defaults are still applied at
-    // build time via clampInt(opts.max*, 1, 500, 50).
-    .option("--max-entities <n>", "Maximum entities in the bundle")
-    .option("--max-relationships <n>", "Maximum relationships in the bundle")
-    .option("--max-evidence <n>", "Maximum evidence items in the bundle")
-    .option("--max-chars <n>", "Maximum characters of evidence output")
+    // No Commander default on the --max-* flags, so `parseRequestedBudgets`
+    // can tell an absent flag from one set to the default value. The defaults
+    // and ranges are the BUDGETS table's, applied by `clampBudgets` and shown
+    // in the help text by `budgetHelp` -- they differ per flag, so there is no
+    // single pair to name here.
+    .option("--max-entities <n>", budgetHelp("maxEntities"), parseBudgetOption)
+    .option("--max-relationships <n>", budgetHelp("maxRelationships"), parseBudgetOption)
+    .option("--max-evidence <n>", budgetHelp("maxEvidence"), parseBudgetOption)
+    .option("--max-chars <n>", budgetHelp("maxChars"), parseBudgetOption)
     .option("--format <fmt>", "Output format (text|json|llm)", "text")
     .option("--out <path>", "Write the JSON bundle to this file instead of stdout")
     .option("--save <id>", "Persist the bundle as a resumable investigation state")
@@ -159,13 +217,13 @@ export function registerContextCommand(program: Command): void {
         return;
       }
       if (opts.diff) {
-        const saved = loadInvestigation(opts.diff);
+        const saved = loadInvestigation(opts.diff, opts.format);
         if (!saved) return;
-        // The fresh side of --diff is currently built with the saved investigation's
-        // own budgets (ix-cli/src/cli/commands/context.ts: `buildFreshBundle(..., saved.bundle.budgets)`),
-        // so any --max-* flags the user passes on the CLI are not applied to the
-        // fresh bundle. We capture the requested values separately so the diff output
-        // can surface them to humans and agents instead of silently dropping them.
+        // The fresh side of --diff is built with the saved investigation's own
+        // budgets, the argument to `buildFreshBundle` below, so any --max-*
+        // flags the caller passed are not applied to it. Captured here so the
+        // diff output can report what was asked for instead of dropping it
+        // silently; what actually governed is read back off the built bundle.
         const requestedBudgets = parseRequestedBudgets(opts);
         const fresh = await buildFreshBundle(
           target ?? saved.bundle.target.name,
@@ -191,10 +249,7 @@ export function registerContextCommand(program: Command): void {
       if (!resolved) return;
 
       const asOfRev = opts.asOfRev ? parseInt(opts.asOfRev, 10) : undefined;
-      const maxEntities = clampInt(opts.maxEntities, 1, 500, 50);
-      const maxRelationships = clampInt(opts.maxRelationships, 1, 1000, 100);
-      const maxEvidence = clampInt(opts.maxEvidence, 1, 200, 25);
-      const maxChars = clampInt(opts.maxChars, 1000, 1_000_000, 12_000);
+      const budgets = clampBudgets(opts);
 
       const [facts, context, provenance] = await Promise.all([
         collectFacts(client, resolved.id, resolved.name, resolved.kind),
@@ -212,7 +267,7 @@ export function registerContextCommand(program: Command): void {
         provenance,
         asOfRev,
         depth: opts.depth,
-        budgets: { maxEntities, maxRelationships, maxEvidence, maxChars },
+        budgets,
       });
 
       if (opts.save) {
@@ -268,7 +323,7 @@ export function registerContextCommand(program: Command): void {
 async function buildFreshBundle(
   target: string,
   opts: { kind?: string; path?: string; pick?: number; depth?: string; asOfRev?: string },
-  budgets: { maxEntities: number; maxRelationships: number; maxEvidence: number; maxChars: number },
+  budgets: BudgetSnapshot,
 ): Promise<ContextBundle | undefined> {
   const client = new IxClient(getEndpoint());
   const resolved = await resolveFileOrEntity(client, target, {
@@ -664,16 +719,25 @@ export function renderInvestigationList(
  * `--resume`/`--diff` can tell a refusal from a successful render. The sibling
  * commands (config, init, map) already signal refusals this way.
  */
-function refuseInvestigation(message: string): undefined {
-  renderWarning(message);
+function refuseInvestigation(code: string, message: string, format?: string): undefined {
+  // `--format llm` gets the record every sibling command emits for a failure
+  // (`callers.ts`, `contains.ts`, `depends.ts`, `diff.ts`, `history.ts` all do
+  // this, and docs/llm-format.md specifies the shape). This path used to write
+  // `renderWarning`, which is `console.log`, so the one command being made
+  // llm-clean answered a refusal with a chalk-coloured prose line in the middle
+  // of the record stream — and with a prose line inside the JSON payload for a
+  // `--format json` caller piping to `jq`. The human keeps the same wording, on
+  // stderr, where prose belongs whatever the format.
+  if (format === "llm") console.log(llmError(code, message));
+  else console.error(`  Warning  ${message}`);
   process.exitCode = 1;
   return undefined;
 }
 
-export function loadInvestigation(id: string): SavedInvestigation | undefined {
+export function loadInvestigation(id: string, format?: string): SavedInvestigation | undefined {
   const path = investigationPath(id);
   if (!existsSync(path)) {
-    return refuseInvestigation(`No saved investigation "${id}" at ${path}`);
+    return refuseInvestigation("no_saved_investigation", `No saved investigation "${id}" at ${path}`, format);
   }
   let raw: unknown;
   // Scoped to the read and the parse: those are the only calls here that throw,
@@ -682,7 +746,7 @@ export function loadInvestigation(id: string): SavedInvestigation | undefined {
   try {
     raw = JSON.parse(readFileSync(path, "utf8"));
   } catch {
-    return refuseInvestigation(`Saved investigation "${id}" is not valid JSON; refusing to resume.`);
+    return refuseInvestigation("invalid_saved_investigation", `Saved investigation "${id}" is not valid JSON; refusing to resume.`, format);
   }
 
   // Validate the whole envelope coming back off disk against the same versioned
@@ -699,15 +763,19 @@ export function loadInvestigation(id: string): SavedInvestigation | undefined {
     // Distinguish the two version-skew cases from a generic shape mismatch, so
     // the warning names which contract was not met.
     if (issues.some((issue) => issue.path[0] === "schema")) {
-      return refuseInvestigation(`Saved investigation "${id}" has an unknown schema; refusing to resume.`);
+      return refuseInvestigation("invalid_saved_investigation", `Saved investigation "${id}" has an unknown schema; refusing to resume.`, format);
     }
     if (issues.some((issue) => issue.path[0] === "bundle" && issue.path[1] === "schema")) {
       return refuseInvestigation(
+        "invalid_saved_investigation",
         `Saved investigation "${id}" holds a bundle from a different contract than ${BUNDLE_SCHEMA}; refusing to resume.`,
+        format,
       );
     }
     return refuseInvestigation(
+      "invalid_saved_investigation",
       `Saved investigation "${id}" does not match the ${BUNDLE_SCHEMA} schema (${issues.length} issue(s)); refusing to resume.`,
+      format,
     );
   }
   // Return the validated value, not the raw parse: saveInvestigation persists
@@ -724,21 +792,24 @@ export function loadInvestigation(id: string): SavedInvestigation | undefined {
 }
 
 function renderSavedInvestigation(id: string, format: string): void {
-  const saved = loadInvestigation(id);
+  const saved = loadInvestigation(id, format);
   if (!saved) return;
   if (format === "json") {
     console.log(JSON.stringify(saved, null, 2));
     return;
   }
-  renderNote(`Resumed investigation "${saved.id}" saved ${saved.savedAt}`);
+  if (format === "llm") {
+    // A record, not the prose note below. `renderNote` would put a
+    // chalk-coloured English sentence at the head of a record stream, and
+    // it carries the one fact the bundle records do not: when this snapshot
+    // was taken. `classification=current` says it was fresh when it was
+    // saved, not when that was.
+    printLlmLines([llmLine("investigation", { id: unsanitizeId(saved.id), saved_at: saved.savedAt })]);
+    renderBundle(saved.bundle, format);
+    return;
+  }
+  renderNote(`Resumed investigation "${unsanitizeId(saved.id)}" saved ${saved.savedAt}`);
   renderBundle(saved.bundle, format);
-}
-
-interface BudgetSnapshot {
-  maxEntities: number;
-  maxRelationships: number;
-  maxEvidence: number;
-  maxChars: number;
 }
 
 /**
@@ -748,48 +819,40 @@ interface BudgetSnapshot {
  * override needs no `not-given` sentinel the way the prose form does.
  */
 function budgetFields(b: Partial<BudgetSnapshot>): Record<string, number | undefined> {
-  return {
-    entities: b.maxEntities,
-    relationships: b.maxRelationships,
-    evidence: b.maxEvidence,
-    chars: b.maxChars,
-  };
+  return Object.fromEntries(BUDGETS.map((f) => [f.label, b[f.key]]));
 }
 
 /** Compact one-line representation of a budget snapshot for human rendering. */
 function formatBudgets(b: Partial<BudgetSnapshot>, partial = false): string {
-  const fmt = (val: number | undefined, key: string): string =>
-    `${key}=${val === undefined ? "not-given" : String(val)}`;
-  const segments = [
-    fmt(b.maxEntities, "entities"),
-    fmt(b.maxRelationships, "relationships"),
-    fmt(b.maxEvidence, "evidence"),
-    fmt(b.maxChars, "chars"),
-  ].join(" ");
+  const segments = BUDGETS.map((f) => {
+    const val = b[f.key];
+    return `${f.label}=${val === undefined ? "not-given" : String(val)}`;
+  }).join(" ");
   return partial ? `${segments} (CLI override; not applied to --diff fresh side)` : segments;
 }
 
 /**
- * Read the raw `--max-*` strings commander collected into numbers.
+ * Which `--max-*` flags the caller actually passed, or `undefined` for none.
  *
- * Deliberately *not* clamped, unlike the action handler's `clampInt` calls for
- * a direct run: these values are reported, never applied — saved budgets
- * govern `--diff` — so clamping them would misreport what the caller actually
- * asked for. If they are ever made to win on the fresh side, they must be
- * clamped at that point, and the ranges live in the handler.
+ * Validation happens once, at parse time: `parseBudgetOption` is the flags'
+ * Commander `argParser`, so a value that reaches here is already a positive
+ * integer. Reading the raw strings back out with `Number.parseInt` was not a
+ * check — it took `"10abc"` as 10, `"1e3"` as 1 and `"-5"` as -5, and this
+ * record's whole purpose is reporting what the caller asked for, so a silently
+ * repaired number is the one error it cannot afford.
  *
- * An absent or whitespace-only string means the flag was not passed.
+ * Deliberately *not* clamped, unlike `clampBudgets` on a direct run: these
+ * values are reported, never applied — saved budgets govern `--diff` — so
+ * clamping them would report a budget the caller did not ask for either. If
+ * they are ever made to win on the fresh side, they must be clamped there.
  */
-export function parseRequestedBudgets(opts: Partial<ContextOptions>): Partial<BudgetSnapshot> | undefined {
-  const fields: Array<keyof BudgetSnapshot> = ["maxEntities", "maxRelationships", "maxEvidence", "maxChars"];
+export function parseRequestedBudgets(opts: Partial<BudgetSnapshot>): Partial<BudgetSnapshot> | undefined {
   const out: Partial<BudgetSnapshot> = {};
   let provided = false;
-  for (const key of fields) {
-    const raw = opts[key] as string | undefined;
-    if (typeof raw !== "string" || raw.trim() === "") continue;
-    const parsed = Number.parseInt(raw, 10);
-    if (!Number.isFinite(parsed)) continue;
-    out[key] = parsed;
+  for (const f of BUDGETS) {
+    const value = opts[f.key];
+    if (value === undefined) continue;
+    out[f.key] = value;
     provided = true;
   }
   return provided ? out : undefined;
@@ -814,11 +877,18 @@ export function diffInvestigations(
   const addedClaims = fresh.claims.filter((c) => !prev.claims.some((p) => p.id === c.id));
   const removedClaims = prev.claims.filter((p) => !fresh.claims.some((c) => c.id === p.id));
 
-  // Surface the silent "saved budgets govern --diff" precedence as data instead
-  // of hiding it. Today `effective` always equals `saved`; if a future change
-  // ever lets CLI overrides win on the fresh side, this block is the single
-  // place that flips and the diff output is the only observable truth.
-  const effective: BudgetSnapshot = { ...saved.bundle.budgets };
+  // Read off the bundle that was actually built, not restated from the
+  // argument that built it. `{ ...saved.bundle.budgets }` would assert how the
+  // fresh side was constructed rather than report it: today the two agree, but
+  // letting CLI overrides win would mean editing the `buildFreshBundle` call in
+  // the action handler, and `effective` would go on reporting the saved budget
+  // while the fresh side used another one -- the silent misreport this record
+  // exists to prevent. `ContextBundle.budgets` records the truth on both sides.
+  const effective: BudgetSnapshot = { ...fresh.budgets };
+  // Whether the caller's --max-* flags governed the fresh side. Derived by
+  // comparison rather than hardcoded false, for the same reason.
+  const requestedApplied = requestedBudgets !== undefined
+    && BUDGETS.every((f) => requestedBudgets[f.key] === undefined || requestedBudgets[f.key] === effective[f.key]);
 
   return {
     schema: "ix-investigation-diff/1",
@@ -831,12 +901,18 @@ export function diffInvestigations(
       saved: saved.bundle.budgets,
       requested: requestedBudgets,
       effective,
-      // The note exists so an agent reading the JSON alone can tell why a
-      // --max-* flag it passed on the CLI did not change the comparison
-      // footprint, without having to read source to find the precedence rule.
-      note: requestedBudgets
-        ? "Saved investigation budgets govern --diff; --max-* flags on the CLI are recorded above for transparency but not applied to the fresh side."
-        : "Saved investigation budgets govern --diff; no --max-* overrides were supplied on the CLI.",
+      // The same fact the llm record carries as `applied=`. It was prose only
+      // here, so a JSON consumer had to string-match a sentence whose wording
+      // changed with the case, while the llm consumer got a boolean it could
+      // test. One contract, both formats.
+      requestedApplied,
+      // Prose for the human reading the JSON, and only when there is something
+      // to explain: without --max-* flags the sentence said nothing.
+      ...(requestedBudgets
+        ? {
+            note: "Saved investigation budgets govern --diff; the --max-* flags recorded here were not applied to the fresh side.",
+          }
+        : {}),
     },
     added: {
       entities: addedEntities,
@@ -864,10 +940,61 @@ interface InvestigationDiff {
     saved: BudgetSnapshot;
     requested?: Partial<BudgetSnapshot>;
     effective: BudgetSnapshot;
-    note: string;
+    /** Did `requested` govern the fresh side? The testable form of `note`. */
+    requestedApplied: boolean;
+    /** Present only when `requested` is: without it there is nothing to explain. */
+    note?: string;
   };
   added: { entities: ContextBundle["entities"]; relationships: ContextBundle["relationships"]; evidence: EvidenceItem[]; claims: ContextBundle["claims"] };
   removed: { entities: ContextBundle["entities"]; relationships: ContextBundle["relationships"]; evidence: EvidenceItem[]; claims: ContextBundle["claims"] };
+}
+
+/** Which side of a comparison a record is on, or neither for a plain bundle. */
+type RecordChange = "added" | "removed" | undefined;
+
+/**
+ * The `entity`, `evidence` and `claim` records, built in one place.
+ *
+ * `ix context <target> --format llm` and `ix context --diff <id> --format llm`
+ * are the same command and emitted two different grammars for the same record
+ * kind: the bundle renderer built `evidence 30 relationship <title>` from a
+ * template literal, positional and unquoted, so a title with a space in it —
+ * which is every title — split into tokens no consumer could reassemble. These
+ * builders are the keyed form, and `llmQuote` handles the spaces and newlines.
+ *
+ * `change` is dropped when absent (`llmField` drops nullish), so the plain
+ * bundle emits the same record without it.
+ */
+function entityRecord(change: RecordChange) {
+  return (e: ContextBundle["entities"][number]): string =>
+    llmLine("entity", {
+      change,
+      // Relationship records name their endpoints by entity id, so this is
+      // what lets a reader resolve `src=`/`dst=` to something it has seen.
+      id: e.id,
+      kind: e.kind,
+      name: e.name,
+      path: e.path,
+      // Only when true: `stale=false` on every entity is noise, and `llmField`
+      // renders a boolean rather than dropping it.
+      stale: e.stale || undefined,
+    });
+}
+
+function evidenceRecord(change: RecordChange) {
+  return (e: EvidenceItem): string =>
+    llmLine("evidence", { change, score: e.score, kind: e.kind, title: e.title });
+}
+
+function claimRecord(change: RecordChange) {
+  return (c: ContextBundle["claims"][number]): string =>
+    llmLine("claim", {
+      change,
+      id: c.id,
+      entity: c.entityId,
+      status: c.status,
+      statement: c.statement,
+    });
 }
 
 export function renderInvestigationDiff(
@@ -897,19 +1024,32 @@ export function renderInvestigationDiff(
     // record per line invariant.
     printLlmLines([
       llmLine("diff", {
-        investigation: saved.id,
+        investigation: unsanitizeId(saved.id),
         target: fresh.target.name,
+        // How old the saved side is. `freshness_previous=current` says the
+        // snapshot was fresh when it was taken, not when that was — and a
+        // snapshot from five minutes ago and one from three months ago are the
+        // same word. Both timestamps are on the JSON diff; only the prose
+        // renderer showed them, so the llm stream was the one surface that
+        // could not tell how stale the comparison's own baseline is.
+        saved_at: diff.savedAt,
+        generated_at: diff.generatedAt,
         freshness_previous: prev.freshness.classification,
         freshness_current: fresh.freshness.classification,
       }),
       // Which budgets governed the comparison. `scope=requested` appears
-      // only when --max-* flags were passed, and carries `applied=false`
-      // rather than a sentence explaining itself: the precedence rule is
-      // that saved budgets govern --diff, and a field an agent can test
-      // beats a note it has to read.
+      // only when --max-* flags were passed, and carries `applied=` rather
+      // than a sentence explaining itself: the precedence rule is that saved
+      // budgets govern --diff, and a field an agent can test beats a note it
+      // has to read. `effective` is read off the bundle that was built, so it
+      // is a report and not a restatement of `saved`.
       llmLine("budgets", { scope: "saved", ...budgetFields(diff.budgets.saved) }),
       ...(diff.budgets.requested
-        ? [llmLine("budgets", { scope: "requested", ...budgetFields(diff.budgets.requested), applied: false })]
+        ? [llmLine("budgets", {
+            scope: "requested",
+            ...budgetFields(diff.budgets.requested),
+            applied: diff.budgets.requestedApplied,
+          })]
         : []),
       llmLine("budgets", { scope: "effective", ...budgetFields(diff.budgets.effective) }),
       // One record rather than eight, and the zeros are kept: "nothing was
@@ -928,14 +1068,25 @@ export function renderInvestigationDiff(
       // `change=` rather than a `+`/`-` prefix on the record kind: a consumer
       // routing on the kind should still match `entity` on both sides of the
       // comparison, and a fused marker means it matches neither.
-      ...diff.added.entities.map((e) => llmLine("entity", { change: "added", kind: e.kind, name: e.name })),
-      ...diff.removed.entities.map((e) => llmLine("entity", { change: "removed", kind: e.kind, name: e.name })),
+      //
+      // `id=` on entities is what makes the stream joinable. Relationship
+      // records name their endpoints by entity id, so without it
+      // `relationship src=entity-1 dst=entity-2` resolves to nothing a reader
+      // has seen and an added entity cannot be matched to the edge that
+      // involves it. `--format json` loses none of this, and llm carrying less
+      // than the format it is meant to replace is the wrong trade.
+      ...diff.added.entities.map(entityRecord("added")),
+      ...diff.removed.entities.map(entityRecord("removed")),
       ...diff.added.relationships.map((r) => llmLine("relationship", { change: "added", src: r.src, pred: r.predicate, dst: r.dst })),
       ...diff.removed.relationships.map((r) => llmLine("relationship", { change: "removed", src: r.src, pred: r.predicate, dst: r.dst })),
-      ...diff.added.evidence.map((e) => llmLine("evidence", { change: "added", score: e.score, kind: e.kind, title: e.title })),
-      ...diff.removed.evidence.map((e) => llmLine("evidence", { change: "removed", score: e.score, kind: e.kind, title: e.title })),
-      ...diff.added.claims.map((c) => llmLine("claim", { change: "added", id: c.id, status: c.status })),
-      ...diff.removed.claims.map((c) => llmLine("claim", { change: "removed", id: c.id, status: c.status })),
+      ...diff.added.evidence.map(evidenceRecord("added")),
+      ...diff.removed.evidence.map(evidenceRecord("removed")),
+      // `statement=` is the field that says what changed. The id is the
+      // backend's (`c-8f31a2`), so `claim change=added id=c-8f31a2
+      // status=active` told a reader that a claim changed and not what it
+      // says. The test fixture hid it by fabricating `claim-<statement>` ids.
+      ...diff.added.claims.map(claimRecord("added")),
+      ...diff.removed.claims.map(claimRecord("removed")),
     ]);
     return;
   }
@@ -983,7 +1134,7 @@ interface BuildInput {
   provenance: unknown;
   asOfRev?: number;
   depth?: string;
-  budgets: { maxEntities: number; maxRelationships: number; maxEvidence: number; maxChars: number };
+  budgets: BudgetSnapshot;
   /**
    * Per-entity staleness probe. Injected so buildBundle stays a pure function
    * under test; production passes nothing and gets the real baseline-backed one.
@@ -1248,31 +1399,42 @@ function rankEvidence(input: {
   return items.sort((a, b) => a.score - b.score || cmp(a.id, b.id));
 }
 
-function renderBundle(bundle: ContextBundle, format: string): void {
+export function renderBundle(bundle: ContextBundle, format: string): void {
   if (format === "json") {
     console.log(JSON.stringify(bundle, null, 2));
     return;
   }
   if (format === "llm") {
+    // Every line through `llmLine`, none through a template literal. This block
+    // built `target=${name}` and `evidence 30 relationship <title>` by
+    // interpolation: the first breaks on any name containing a space or an `=`,
+    // and the second is positional, unquoted, and breaks on every title, which
+    // is a sentence. `ix context --diff --format llm` emits the keyed form for
+    // the same record kinds, so a consumer routing on `evidence` from the same
+    // command was handed two grammars.
     printLlmLines([
-      `target=${bundle.target.name}`,
-      `target_kind=${bundle.target.kind}`,
-      `stale=${bundle.freshness.stale}`,
-      `classification=${bundle.freshness.classification}`,
-      `entities=${bundle.entities.length}`,
-      `relationships=${bundle.relationships.length}`,
-      `claims=${bundle.claims.length}`,
-      `decisions=${bundle.decisions.length}`,
-      `conflicts=${bundle.conflicts.length}`,
-      `intents=${bundle.intents.length}`,
-      `evidence=${bundle.evidence.length}`,
-      `truncated_entities=${bundle.truncation.entitiesTruncated}`,
-      `truncated_relationships=${bundle.truncation.relationshipsTruncated}`,
-      `truncated_evidence=${bundle.truncation.evidenceTruncated}`,
-      `truncated_chars=${bundle.truncation.charactersTruncated}`,
-      ...bundle.evidence.map(
-        (item) => `evidence ${item.score} ${item.kind} ${item.title.replaceAll("\n", " ")}`,
-      ),
+      llmLine("context", {
+        target: bundle.target.name,
+        target_kind: bundle.target.kind,
+        stale: bundle.freshness.stale,
+        classification: bundle.freshness.classification,
+        entities: bundle.entities.length,
+        relationships: bundle.relationships.length,
+        claims: bundle.claims.length,
+        decisions: bundle.decisions.length,
+        conflicts: bundle.conflicts.length,
+        intents: bundle.intents.length,
+        evidence: bundle.evidence.length,
+        truncated_entities: bundle.truncation.entitiesTruncated,
+        truncated_relationships: bundle.truncation.relationshipsTruncated,
+        truncated_evidence: bundle.truncation.evidenceTruncated,
+        truncated_chars: bundle.truncation.charactersTruncated,
+      }),
+      // Evidence only, as before. The entity, relationship and claim lists are
+      // deliberately still counts here: `--format llm` is the token-minimal
+      // surface, the ranked evidence is what it exists to deliver, and
+      // `--format json` carries the rest for a caller that wants it.
+      ...bundle.evidence.map(evidenceRecord(undefined)),
     ]);
     return;
   }
@@ -1319,12 +1481,6 @@ function asRecord(value: unknown): Record<string, unknown> {
 
 function asString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
-}
-
-function clampInt(raw: string | undefined, min: number, max: number, fallback: number): number {
-  const parsed = raw ? parseInt(raw, 10) : NaN;
-  if (Number.isNaN(parsed)) return fallback;
-  return Math.min(max, Math.max(min, parsed));
 }
 
 function cmp(a: string, b: string): number {

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -19,11 +19,11 @@ import type {
 } from "../../client/types.js";
 import { getEndpoint } from "../config.js";
 import { collectFacts, type EntityFacts } from "../explain/facts.js";
-import { llmError, llmLine, printLlmLines, reportModeConflict } from "../llm.js";
-import { parseBudgetOption, parsePickOption } from "../options.js";
+import { llmLine, printLlmLines } from "../llm.js";
+import { parseBudgetOption, parsePickOption, parseRevisionOption } from "../options.js";
 import { resolveFileOrEntity } from "../resolve.js";
 import { createStaleProbe } from "../stale.js";
-import { renderNote, renderSection, renderWarning } from "../ui.js";
+import { renderNote, renderSection, renderWarning, renderWarningErr, reportFailure } from "../ui.js";
 
 /** The four `--max-*` knobs that bound a bundle. */
 interface BudgetSnapshot {
@@ -48,12 +48,13 @@ interface BudgetSnapshot {
  * the number that is applied.
  */
 const BUDGETS = [
-  { key: "maxEntities", label: "entities", help: "Maximum entities in the bundle", min: 1, max: 500, fallback: 50 },
-  { key: "maxRelationships", label: "relationships", help: "Maximum relationships in the bundle", min: 1, max: 1000, fallback: 100 },
-  { key: "maxEvidence", label: "evidence", help: "Maximum evidence items in the bundle", min: 1, max: 200, fallback: 25 },
-  { key: "maxChars", label: "chars", help: "Maximum characters of evidence output", min: 1000, max: 1_000_000, fallback: 12_000 },
+  { key: "maxEntities", flag: "--max-entities", label: "entities", help: "Maximum entities in the bundle", min: 1, max: 500, fallback: 50 },
+  { key: "maxRelationships", flag: "--max-relationships", label: "relationships", help: "Maximum relationships in the bundle", min: 1, max: 1000, fallback: 100 },
+  { key: "maxEvidence", flag: "--max-evidence", label: "evidence", help: "Maximum evidence items in the bundle", min: 1, max: 200, fallback: 25 },
+  { key: "maxChars", flag: "--max-chars", label: "chars", help: "Maximum characters of evidence output", min: 1000, max: 1_000_000, fallback: 12_000 },
 ] as const satisfies ReadonlyArray<{
   key: keyof BudgetSnapshot;
+  flag: string;
   label: string;
   help: string;
   min: number;
@@ -72,8 +73,27 @@ const BUDGETS = [
  * that enforces them.
  */
 function budgetHelp(key: keyof BudgetSnapshot): string {
-  const b = BUDGETS.find((entry) => entry.key === key)!;
+  const b = budgetField(key);
   return `${b.help} (default: ${b.fallback}, clamped to ${b.min}-${b.max})`;
+}
+
+/** The table row for one budget. */
+function budgetField(key: keyof BudgetSnapshot): (typeof BUDGETS)[number] {
+  return BUDGETS.find((entry) => entry.key === key)!;
+}
+
+/**
+ * The Commander `argParser` for one budget flag.
+ *
+ * The example in the rejection message comes from the flag's own default, not
+ * from a constant: a single hardcoded "50" told someone who mistyped
+ * `--max-chars` to try 50, which parses and is then silently clamped up to 1000
+ * by `clampBudgets` -- while the help text one line away says the range is
+ * 1000-1000000.
+ */
+function budgetParser(key: keyof BudgetSnapshot): (value: string) => number {
+  const example = String(budgetField(key).fallback);
+  return (value: string) => parseBudgetOption(value, example);
 }
 
 /** Apply the table's range and default to whatever the caller supplied. */
@@ -91,7 +111,7 @@ interface ContextOptions extends Partial<BudgetSnapshot> {
   path?: string;
   pick?: number;
   depth?: string;
-  asOfRev?: string;
+  asOfRev?: number;
   out?: string;
   save?: string;
   resume?: string;
@@ -178,16 +198,16 @@ export function registerContextCommand(program: Command): void {
     .option("--path <path>", "Prefer symbols from files matching this path substring")
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
     .option("--depth <depth>", "Context-graph expansion depth")
-    .option("--as-of-rev <n>", "Historical context as of a graph revision")
+    .option("--as-of-rev <n>", "Historical context as of a graph revision", parseRevisionOption)
     // No Commander default on the --max-* flags, so `parseRequestedBudgets`
     // can tell an absent flag from one set to the default value. The defaults
     // and ranges are the BUDGETS table's, applied by `clampBudgets` and shown
     // in the help text by `budgetHelp` -- they differ per flag, so there is no
     // single pair to name here.
-    .option("--max-entities <n>", budgetHelp("maxEntities"), parseBudgetOption)
-    .option("--max-relationships <n>", budgetHelp("maxRelationships"), parseBudgetOption)
-    .option("--max-evidence <n>", budgetHelp("maxEvidence"), parseBudgetOption)
-    .option("--max-chars <n>", budgetHelp("maxChars"), parseBudgetOption)
+    .option("--max-entities <n>", budgetHelp("maxEntities"), budgetParser("maxEntities"))
+    .option("--max-relationships <n>", budgetHelp("maxRelationships"), budgetParser("maxRelationships"))
+    .option("--max-evidence <n>", budgetHelp("maxEvidence"), budgetParser("maxEvidence"))
+    .option("--max-chars <n>", budgetHelp("maxChars"), budgetParser("maxChars"))
     .option("--format <fmt>", "Output format (text|json|llm)", "text")
     .option("--out <path>", "Write the JSON bundle to this file instead of stdout")
     .option("--save <id>", "Persist the bundle as a resumable investigation state")
@@ -201,7 +221,7 @@ export function registerContextCommand(program: Command): void {
     .action(async (target: string | undefined, opts: ContextOptions) => {
       const conflict = detectContextModeConflict(opts, target);
       if (conflict) {
-        reportModeConflict(conflict, opts.format);
+        reportFailure("mode_conflict", conflict, opts.format);
         return;
       }
       if (opts.resume) {
@@ -235,7 +255,14 @@ export function registerContextCommand(program: Command): void {
         return;
       }
       if (!target) {
-        renderWarning("ix context requires a target unless --resume <id> or --diff <id> is given.");
+        // An error with a non-zero status, not a stdout warning with a zero one:
+        // a script asked for a bundle and got none, and a `--format llm` caller
+        // got a prose line in the middle of a record stream saying so.
+        reportFailure(
+          "missing_target",
+          "ix context requires a target unless --resume <id>, --diff <id> or --list is given.",
+          opts.format,
+        );
         return;
       }
 
@@ -248,8 +275,8 @@ export function registerContextCommand(program: Command): void {
       });
       if (!resolved) return;
 
-      const asOfRev = opts.asOfRev ? parseInt(opts.asOfRev, 10) : undefined;
       const budgets = clampBudgets(opts);
+      const asOfRev = opts.asOfRev;
 
       const [facts, context, provenance] = await Promise.all([
         collectFacts(client, resolved.id, resolved.name, resolved.kind),
@@ -277,7 +304,9 @@ export function registerContextCommand(program: Command): void {
       }
 
       if (opts.out && opts.format !== "json") {
-        renderWarning("--out writes JSON; ignoring --format and forcing json.");
+        // stderr: --out still writes the file and still prints a note, so this
+        // advisory would otherwise sit in the stdout an `llm` caller is reading.
+        renderWarningErr("--out writes JSON; ignoring --format and forcing json.");
       }
       const out = opts.out;
       if (out) {
@@ -288,7 +317,11 @@ export function registerContextCommand(program: Command): void {
         // in a caller-owned file (CodeQL js/network-data-written-to-file).
         const parsed = contextBundleSchema.safeParse(bundle);
         if (!parsed.success) {
-          renderWarning(`--out "${out}" refused: the bundle does not match the ${BUNDLE_SCHEMA} schema (${parsed.error.issues.length} issue(s)).`);
+          reportFailure(
+            "out_refused",
+            `--out "${out}" refused: the bundle does not match the ${BUNDLE_SCHEMA} schema (${parsed.error.issues.length} issue(s)).`,
+            opts.format,
+          );
           return;
         }
         // Atomic write: serialize to a private temp file in the SAME directory,
@@ -307,7 +340,11 @@ export function registerContextCommand(program: Command): void {
           if (err.code === "EISDIR" || err.code === "EPERM") {
             try {
               if (fs.statSync(targetPath).isDirectory()) {
-                renderWarning(`--out "${out}" is a directory; refusing to write the bundle there.`);
+                reportFailure(
+                  "out_refused",
+                  `--out "${out}" is a directory; refusing to write the bundle there.`,
+                  opts.format,
+                );
                 return;
               }
             } catch { /* target may not exist; fall through to rethrow */ }
@@ -322,7 +359,7 @@ export function registerContextCommand(program: Command): void {
 
 async function buildFreshBundle(
   target: string,
-  opts: { kind?: string; path?: string; pick?: number; depth?: string; asOfRev?: string },
+  opts: { kind?: string; path?: string; pick?: number; depth?: string; asOfRev?: number },
   budgets: BudgetSnapshot,
 ): Promise<ContextBundle | undefined> {
   const client = new IxClient(getEndpoint());
@@ -333,7 +370,7 @@ async function buildFreshBundle(
   });
   if (!resolved) return undefined;
 
-  const asOfRev = opts.asOfRev ? parseInt(opts.asOfRev, 10) : undefined;
+  const asOfRev = opts.asOfRev;
   const [facts, context, provenance] = await Promise.all([
     collectFacts(client, resolved.id, resolved.name, resolved.kind),
     client.query(resolved.name, { asOfRev, depth: opts.depth }),
@@ -346,19 +383,41 @@ async function buildFreshBundle(
 
 
 /**
- * The `ContextOptions` fields `detectContextModeConflict` consumes.
+ * What `detectContextModeConflict` reads: all of `ContextOptions`.
  *
- * `Pick`, not a hand-copied shape: the detector exists to stop a typed flag
- * being a no-op, so its idea of the flags must come from the same declaration
- * the action handler uses. Written out field-by-field it drifted immediately --
- * `--list` was added to `ContextOptions` on a sibling branch and the detector
- * could not see it, with nothing from the typechecker to say so. `Partial` so
- * the pure function can still be called with one flag at a time in a test,
- * without inventing a `format`.
+ * Derived from the action handler's own declaration, never hand-copied. The
+ * detector exists to stop a typed flag being a no-op, so a shape it maintains
+ * separately is the one thing it cannot afford: written out field-by-field it
+ * drifted immediately, when `--list` was added to `ContextOptions` on a sibling
+ * branch and the detector could not see it with nothing from the typechecker to
+ * say so. `Partial` so the pure function can be called with one flag at a time
+ * in a test, without inventing a `format`.
  */
-export type ContextModeOptions = Partial<
-  Pick<ContextOptions, "resume" | "diff" | "save" | "out" | "list" | "format">
->;
+export type ContextModeOptions = Partial<ContextOptions>;
+
+/**
+ * Flags that shape a bundle this run builds, and are therefore meaningless to a
+ * mode that builds none.
+ *
+ * `--list` enumerates saved state and `--resume` renders it verbatim; neither
+ * resolves a target or applies a budget, so every one of these was accepted and
+ * dropped in silence — `ix context --list --max-entities 10 --kind class` took
+ * five typed flags and exited 0. `--diff` is not here: it re-resolves the target
+ * with `--kind`/`--path`/`--pick`, forwards `--depth`/`--as-of-rev` through
+ * `mergeDiffOptions`, and reports the `--max-*` values rather than dropping
+ * them.
+ *
+ * Listed as `[field, flag]` because the message has to name what the user
+ * typed, and Commander's camelCase attribute is not that.
+ */
+const BUILD_FLAGS: ReadonlyArray<[keyof ContextOptions, string]> = [
+  ["kind", "--kind"],
+  ["path", "--path"],
+  ["pick", "--pick"],
+  ["depth", "--depth"],
+  ["asOfRev", "--as-of-rev"],
+  ...BUDGETS.map((b) => [b.key, b.flag] as [keyof ContextOptions, string]),
+];
 
 /**
  * Detect mutually-incompatible mode/output flags on `ix context` and return a
@@ -380,7 +439,8 @@ export type ContextModeOptions = Partial<
  * lose that race.
  *
  * `target` is a parameter because a positional is as ignorable as a flag:
- * `ix context Widget --list` dropped the target with nothing said.
+ * `ix context Widget --list` and `ix context Widget --resume x` both dropped it
+ * with nothing said.
  */
 export function detectContextModeConflict(
   opts: ContextModeOptions,
@@ -388,6 +448,23 @@ export function detectContextModeConflict(
 ): string | undefined {
   if (opts.list && target) {
     return `--list takes no target; it enumerates every saved investigation. Drop "${target}", or drop --list to build a fresh bundle for it.`;
+  }
+  if (opts.resume && target) {
+    return `--resume takes no target; it renders the investigation you name, whatever that was built for. Drop "${target}", or use --diff <id> to compare a saved investigation against a fresh build of it.`;
+  }
+  // Flags that shape a bundle, given to a mode that builds none. Reported as
+  // one message naming every offender, because dropping one at a time and
+  // re-running to find the next is the experience this detector exists to
+  // avoid, and the flags are all wrong for the same reason.
+  for (const [mode, why] of [
+    ["list", "--list enumerates saved investigations and builds no bundle"],
+    ["resume", "--resume renders a saved investigation exactly as it was built"],
+  ] as const) {
+    if (!opts[mode]) continue;
+    const ignored = BUILD_FLAGS.filter(([field]) => opts[field] !== undefined).map(([, flag]) => flag);
+    if (ignored.length > 0) {
+      return `${ignored.join(", ")} cannot be combined with --${mode}; ${why}, so ${ignored.length > 1 ? "those flags change" : "that flag changes"} nothing. Drop ${ignored.length > 1 ? "them" : "it"}, or run ix context <target> to build a bundle with ${ignored.length > 1 ? "them" : "it"}.`;
+    }
   }
   if (opts.list && opts.resume) {
     return "--list and --resume cannot be combined; --list enumerates saved investigations, --resume renders one. Run --list first, then --resume the id you want.";
@@ -469,27 +546,40 @@ export function sanitizeId(id: string): string {
 }
 
 /**
- * Recover the id the user typed from the id stored on disk.
+ * The id to show the user, given the id stored on disk.
  *
- * `sanitizeId` is injective and deliberately *not* idempotent — it encodes `~`
- * as `~7E` precisely so a raw `~` cannot be confused with an escape — so the
- * stored form is the wrong thing to hand back to the user. `ix context --list`
- * printed it anyway, next to "Resume with: ix context --resume <id>", and
- * `--resume` sanitizes what it is given: an id saved as `widget/auth` was
- * listed as `widget~2Fauth`, and resuming that looked for `widget~7E2Fauth`,
- * which does not exist. `saveInvestigation`'s own note echoes the id the user
- * typed, so the two affordances contradicted each other.
+ * `sanitizeId` is deliberately *not* idempotent — it encodes `~` as `~7E` so a
+ * raw `~` cannot be mistaken for an escape — so the stored form is the wrong
+ * thing to hand back. `ix context --list` printed it next to "Resume with:
+ * ix context --resume <id>", and `--resume` sanitizes what it is given: an id
+ * saved as `widget/auth` was listed as `widget~2Fauth`, and resuming that
+ * looked for `widget~7E2Fauth`, which does not exist.
  *
- * `sanitizeId(unsanitizeId(stored)) === stored` for every id this CLI wrote,
- * which is what makes the listed id usable. A hand-written file whose id is
- * outside `sanitizeId`'s range has no input that reaches it and is not a case
- * this recovers.
+ * The escape is not fixed-width, and that is why this decodes and then
+ * re-encodes rather than trusting the decode. `toString(16)` gives two hex
+ * digits below U+0100 and three or four above it, so `~7528` is either one CJK
+ * code unit or `~752` followed by a literal `8`, and nothing in the string says
+ * which. Two hex digits is the case every Latin-1 id takes; anything else fails
+ * the re-encode and the stored id is returned untouched, which is honest rather
+ * than a guess. `loadInvestigation` accepts that form too, so a listed id loads
+ * either way — the display is the nicety, the load is the contract.
  */
-export function unsanitizeId(stored: string): string {
-  return stored.replace(/~([0-9A-Fa-f]{2})/g, (_m, hex: string) =>
+export function displayId(stored: string): string {
+  const decoded = stored.replace(/~([0-9A-Fa-f]{2})/g, (_m, hex: string) =>
     String.fromCharCode(parseInt(hex, 16)),
   );
+  return sanitizeId(decoded) === stored ? decoded : stored;
 }
+
+/**
+ * The shape `sanitizeId` produces: what a file in the investigations directory
+ * can be named, and therefore what `loadInvestigation` may accept verbatim.
+ *
+ * The leading character excludes `.` so no input names a dotfile, and the set
+ * excludes every path separator, so nothing here can address a second directory
+ * segment or a parent.
+ */
+const STORED_ID = /^[A-Za-z0-9_~-][A-Za-z0-9._~-]*$/;
 
 export function saveInvestigation(id: string, bundle: ContextBundle): void {
   const dir = investigationDir();
@@ -537,11 +627,13 @@ interface SavedInvestigation {
  */
 export function mergeDiffOptions(
   saved: SavedInvestigation,
-  opts: { asOfRev?: string; depth?: string },
-): { asOfRev?: string; depth?: string } {
-  const savedRev = saved.bundle.metadata.asOfRev;
+  opts: { asOfRev?: number; depth?: string },
+): { asOfRev?: number; depth?: string } {
+  // Numbers on both sides now: `--as-of-rev` is validated by its Commander
+  // argParser, so the round trip through a string that this used to do -- and
+  // the `parseInt` on the far side of it -- is gone.
   return {
-    asOfRev: opts.asOfRev ?? (savedRev === undefined ? undefined : String(savedRev)),
+    asOfRev: opts.asOfRev ?? saved.bundle.metadata.asOfRev,
     depth: opts.depth ?? saved.bundle.metadata.depth,
   };
 }
@@ -582,8 +674,11 @@ export function listInvestigations(): { saved: SavedInvestigation[]; skipped: nu
     // The validated value, not the raw parse — the same assertion
     // `loadInvestigation` makes, and for the same reason: it re-narrows the
     // open report arrays the schema leaves as records, and every field the
-    // renderer dereferences has been checked by this point.
-    out.push(parsed.data as unknown as SavedInvestigation);
+    // renderer dereferences has been checked by this point. The id is decoded
+    // here too, so every reader of an enumerated investigation sees the id it
+    // can type back — see `displayId`.
+    const state = parsed.data as unknown as SavedInvestigation;
+    out.push({ ...state, id: displayId(state.id) });
   }
   out.sort((a, b) => {
     if (a.savedAt !== b.savedAt) return a.savedAt < b.savedAt ? 1 : -1;
@@ -594,7 +689,7 @@ export function listInvestigations(): { saved: SavedInvestigation[]; skipped: nu
 
 /** One saved investigation as `--list` describes it: what it is, not what is in it. */
 interface InvestigationSummary {
-  /** The id to type back, not the id on disk — see `unsanitizeId`. */
+  /** The id to type back, not the id on disk — decoded by `displayId` on read. */
   id: string;
   savedAt: string;
   target: { name: string; kind: string };
@@ -607,7 +702,7 @@ interface InvestigationSummary {
 function summariseInvestigation(s: SavedInvestigation): InvestigationSummary {
   const b = s.bundle;
   return {
-    id: unsanitizeId(s.id),
+    id: s.id,
     savedAt: s.savedAt,
     target: { name: b.target.name, kind: b.target.kind },
     freshness: b.freshness,
@@ -650,9 +745,8 @@ export function renderInvestigationList(
     // caller was piping. Plain text rather than chalk — nothing else in this
     // file writes to stderr, and a colour code is not worth an import that
     // only this line needs.
-    console.error(
-      `  Warning  ${skipped} saved investigation file(s) did not match the contract; skipped.` +
-        " Run `ix context --resume <id>` for a per-file report.",
+    renderWarningErr(
+      `${skipped} saved investigation file(s) in ${investigationDir()} did not match the contract; skipped.`,
     );
   }
   if (format === "json") {
@@ -728,14 +822,24 @@ function refuseInvestigation(code: string, message: string, format?: string): un
   // of the record stream — and with a prose line inside the JSON payload for a
   // `--format json` caller piping to `jq`. The human keeps the same wording, on
   // stderr, where prose belongs whatever the format.
-  if (format === "llm") console.log(llmError(code, message));
-  else console.error(`  Warning  ${message}`);
-  process.exitCode = 1;
+  reportFailure(code, message, format);
   return undefined;
 }
 
 export function loadInvestigation(id: string, format?: string): SavedInvestigation | undefined {
-  const path = investigationPath(id);
+  let path = investigationPath(id);
+  if (!existsSync(path) && STORED_ID.test(id)) {
+    // Also accept the on-disk form. `sanitizeId` is not idempotent, so an id
+    // that is already encoded gets encoded again and misses its own file:
+    // `widget/auth` is stored as `widget~2Fauth`, and asking for
+    // `widget~2Fauth` looked for `widget~7E2Fauth`. `displayId` recovers the
+    // typed form for every Latin-1 id, but the escape width is ambiguous above
+    // that, so for the rest the encoded name is the only thing a listing can
+    // print — and it has to work. Second, not first, so an id that is genuinely
+    // spelled `widget~2Fauth` still finds its own file before this.
+    const encoded = join(investigationDir(), `${id}.json`);
+    if (existsSync(encoded)) path = encoded;
+  }
   if (!existsSync(path)) {
     return refuseInvestigation("no_saved_investigation", `No saved investigation "${id}" at ${path}`, format);
   }
@@ -788,10 +892,17 @@ export function loadInvestigation(id: string, format?: string): SavedInvestigati
   // the backend) plus the literals zod widens to `string`. Every field this file
   // dereferences has been checked by this point — unlike the `as` cast on raw
   // JSON.parse output that this replaces, which checked nothing.
-  return parsed.data as unknown as SavedInvestigation;
+  //
+  // The id is decoded here, at the one boundary every reader comes through,
+  // rather than at each place one is printed. Decoding per call site is how
+  // `--format llm` came to report `widget/auth` while `--format json` and the
+  // text header reported `widget~2Fauth` for the same investigation, and a
+  // JSON-chaining caller fed the second back to `--resume` and was refused.
+  const state = parsed.data as unknown as SavedInvestigation;
+  return { ...state, id: displayId(state.id) };
 }
 
-function renderSavedInvestigation(id: string, format: string): void {
+export function renderSavedInvestigation(id: string, format: string): void {
   const saved = loadInvestigation(id, format);
   if (!saved) return;
   if (format === "json") {
@@ -804,11 +915,11 @@ function renderSavedInvestigation(id: string, format: string): void {
     // it carries the one fact the bundle records do not: when this snapshot
     // was taken. `classification=current` says it was fresh when it was
     // saved, not when that was.
-    printLlmLines([llmLine("investigation", { id: unsanitizeId(saved.id), saved_at: saved.savedAt })]);
+    printLlmLines([llmLine("resumed", { id: saved.id, saved_at: saved.savedAt })]);
     renderBundle(saved.bundle, format);
     return;
   }
-  renderNote(`Resumed investigation "${unsanitizeId(saved.id)}" saved ${saved.savedAt}`);
+  renderNote(`Resumed investigation "${saved.id}" saved ${saved.savedAt}`);
   renderBundle(saved.bundle, format);
 }
 
@@ -885,10 +996,20 @@ export function diffInvestigations(
   // while the fresh side used another one -- the silent misreport this record
   // exists to prevent. `ContextBundle.budgets` records the truth on both sides.
   const effective: BudgetSnapshot = { ...fresh.budgets };
-  // Whether the caller's --max-* flags governed the fresh side. Derived by
-  // comparison rather than hardcoded false, for the same reason.
-  const requestedApplied = requestedBudgets !== undefined
-    && BUDGETS.every((f) => requestedBudgets[f.key] === undefined || requestedBudgets[f.key] === effective[f.key]);
+  // Whether the caller's --max-* flags governed the fresh side.
+  //
+  // Not `requested equals effective`. Equal numbers are not evidence of
+  // causation: `--max-evidence 25` against a saved budget of 25 produces
+  // identical values while the flag changed nothing, and reporting `true` there
+  // told an agent its override had taken -- so it raised the number, got the
+  // saved budget again and now `false`. Three formats of one command disagreed,
+  // because the note printed beside it said the opposite.
+  //
+  // What decides this is which budget the action handler hands
+  // `buildFreshBundle`, and that is `saved.bundle.budgets` unconditionally, one
+  // call site named in the comment there. So this is false, and the day that
+  // call changes it is the day this needs to change with it.
+  const requestedApplied = false;
 
   return {
     schema: "ix-investigation-diff/1",
@@ -1024,7 +1145,7 @@ export function renderInvestigationDiff(
     // record per line invariant.
     printLlmLines([
       llmLine("diff", {
-        investigation: unsanitizeId(saved.id),
+        investigation: saved.id,
         target: fresh.target.name,
         // How old the saved side is. `freshness_previous=current` says the
         // snapshot was fresh when it was taken, not when that was — and a

--- a/ix-cli/src/cli/commands/diff.ts
+++ b/ix-cli/src/cli/commands/diff.ts
@@ -7,6 +7,12 @@ import type { Command } from "commander";
 import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
 
+import { getEndpoint } from "../config.js";
+import { resolveFileOrEntity, resolveEntityFull, printResolved, looksFileLike, type ResolvedEntity } from "../resolve.js";
+import { formatDiff, relativePath } from "../format.js";
+import { llmLine, llmError } from "../llm.js";
+import { parsePickOption } from "../options.js";
+
 /**
  * Subset of `DiffOptions` consumed by `detectDiffModeConflict`. Kept as a
  * structural type so the detector can be unit-tested without driving Commander.
@@ -48,16 +54,20 @@ export function detectDiffModeConflict(
   return undefined;
 }
 
-/** Render a detected mode conflict and mark the process exit code. */
-export function reportDiffModeConflict(message: string): void {
-  console.error(chalk.red("Error:"), message);
+/**
+ * Render a detected mode conflict and mark the process exit code.
+ *
+ * `--format llm` gets the record form the rest of the CLI emits for errors —
+ * `error code=... message="..."`, on stdout, with the exit code still non-zero
+ * (imports.ts, trace.ts, smells.ts, locate.ts, callers.ts all do this, and
+ * docs/llm-format.md specifies the shape). An agent is told to pass the flag
+ * unconditionally, so an error it cannot read is an error it cannot act on.
+ */
+export function reportDiffModeConflict(message: string, format?: string): void {
+  if (format === "llm") console.log(llmError("mode_conflict", message));
+  else console.error(chalk.red("Error:"), message);
   process.exitCode = 1;
 }
-import { getEndpoint } from "../config.js";
-import { resolveFileOrEntity, resolveEntityFull, printResolved, looksFileLike, type ResolvedEntity } from "../resolve.js";
-import { formatDiff, relativePath } from "../format.js";
-import { llmLine, llmError } from "../llm.js";
-import { parsePickOption } from "../options.js";
 
 /** Render a `--summary` diff as a single llm record. */
 function renderDiffSummaryLlm(result: any): string {
@@ -480,7 +490,7 @@ export function registerDiffCommand(program: Command): void {
     }) => {
       const conflict = detectDiffModeConflict(opts);
       if (conflict) {
-        reportDiffModeConflict(conflict);
+        reportDiffModeConflict(conflict, opts.format);
         return;
       }
       const client = new IxClient(getEndpoint());

--- a/ix-cli/src/cli/commands/diff.ts
+++ b/ix-cli/src/cli/commands/diff.ts
@@ -10,7 +10,7 @@ import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { resolveFileOrEntity, resolveEntityFull, printResolved, looksFileLike, type ResolvedEntity } from "../resolve.js";
 import { formatDiff, relativePath } from "../format.js";
-import { llmLine, llmError } from "../llm.js";
+import { llmLine, llmError, reportModeConflict } from "../llm.js";
 import { parsePickOption } from "../options.js";
 
 /**
@@ -35,6 +35,13 @@ export interface DiffModeOptions {
  * explicit-conflict style in subsystems.ts. `--full --limit <n>` is also
  * flagged: `--full` is documented as "no limit" so the silent precedence over
  * `--limit` was the same kind of UX gap.
+ *
+ * Order is load-bearing, not incidental. `--summary` is the flag that wins at
+ * runtime, so when it is present its message is the one that names the flag
+ * actually in charge. Checking `--full --limit` first meant
+ * `ix diff 3 5 --summary --full --limit 20` reported "--full and --limit cannot
+ * be combined" -- two flags `--summary` was going to ignore anyway -- and the
+ * message that would have explained the run was unreachable for that input.
  */
 export function detectDiffModeConflict(
   opts: DiffModeOptions,
@@ -42,31 +49,16 @@ export function detectDiffModeConflict(
   if (opts.summary && opts.content) {
     return "--summary and --content cannot be combined; --summary renders counts only, --content renders the full textual diff. Pick one.";
   }
-  if (opts.full && opts.limit !== undefined) {
-    return "--full and --limit cannot be combined; --full is documented to return all changes without a limit. Drop --limit, or drop --full to keep the existing limit.";
-  }
   if (
     opts.summary &&
     (opts.full || opts.limit !== undefined)
   ) {
     return "--summary ignores --limit and --full; --summary is server-side counts only. Drop --summary to control change volume, or drop --limit/--full.";
   }
+  if (opts.full && opts.limit !== undefined) {
+    return "--full and --limit cannot be combined; --full is documented to return all changes without a limit. Drop --limit, or drop --full to keep the existing limit.";
+  }
   return undefined;
-}
-
-/**
- * Render a detected mode conflict and mark the process exit code.
- *
- * `--format llm` gets the record form the rest of the CLI emits for errors —
- * `error code=... message="..."`, on stdout, with the exit code still non-zero
- * (imports.ts, trace.ts, smells.ts, locate.ts, callers.ts all do this, and
- * docs/llm-format.md specifies the shape). An agent is told to pass the flag
- * unconditionally, so an error it cannot read is an error it cannot act on.
- */
-export function reportDiffModeConflict(message: string, format?: string): void {
-  if (format === "llm") console.log(llmError("mode_conflict", message));
-  else console.error(chalk.red("Error:"), message);
-  process.exitCode = 1;
 }
 
 /** Render a `--summary` diff as a single llm record. */
@@ -490,7 +482,7 @@ export function registerDiffCommand(program: Command): void {
     }) => {
       const conflict = detectDiffModeConflict(opts);
       if (conflict) {
-        reportDiffModeConflict(conflict, opts.format);
+        reportModeConflict(conflict, opts.format);
         return;
       }
       const client = new IxClient(getEndpoint());

--- a/ix-cli/src/cli/commands/diff.ts
+++ b/ix-cli/src/cli/commands/diff.ts
@@ -10,7 +10,8 @@ import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { resolveFileOrEntity, resolveEntityFull, printResolved, looksFileLike, type ResolvedEntity } from "../resolve.js";
 import { formatDiff, relativePath } from "../format.js";
-import { llmLine, llmError, reportModeConflict } from "../llm.js";
+import { llmLine, llmError } from "../llm.js";
+import { reportFailure } from "../ui.js";
 import { parsePickOption } from "../options.js";
 
 /**
@@ -482,7 +483,7 @@ export function registerDiffCommand(program: Command): void {
     }) => {
       const conflict = detectDiffModeConflict(opts);
       if (conflict) {
-        reportModeConflict(conflict, opts.format);
+        reportFailure("mode_conflict", conflict, opts.format);
         return;
       }
       const client = new IxClient(getEndpoint());

--- a/ix-cli/src/cli/commands/diff.ts
+++ b/ix-cli/src/cli/commands/diff.ts
@@ -6,6 +6,53 @@ import { promisify } from "node:util";
 import type { Command } from "commander";
 import chalk from "chalk";
 import { IxClient } from "../../client/api.js";
+
+/**
+ * Subset of `DiffOptions` consumed by `detectDiffModeConflict`. Kept as a
+ * structural type so the detector can be unit-tested without driving Commander.
+ */
+export interface DiffModeOptions {
+  summary?: boolean;
+  content?: boolean;
+  full?: boolean;
+  limit?: string;
+}
+
+/**
+ * Detect mutually-incompatible output flags on `ix diff` and return a
+ * human-readable message naming the conflict, or `undefined` if no conflict.
+ *
+ * The action handler early-returns on `--summary` before the `--content` branch
+ * is reached, so passing both flags silently dropped `--content` (and the user
+ * got a summary when they asked for the full textual diff). Catching the
+ * combination up front and surfacing it as a hard error mirrors the
+ * explicit-conflict style in subsystems.ts. `--full --limit <n>` is also
+ * flagged: `--full` is documented as "no limit" so the silent precedence over
+ * `--limit` was the same kind of UX gap.
+ */
+export function detectDiffModeConflict(
+  opts: DiffModeOptions,
+): string | undefined {
+  if (opts.summary && opts.content) {
+    return "--summary and --content cannot be combined; --summary renders counts only, --content renders the full textual diff. Pick one.";
+  }
+  if (opts.full && opts.limit !== undefined) {
+    return "--full and --limit cannot be combined; --full is documented to return all changes without a limit. Drop --limit, or drop --full to keep the existing limit.";
+  }
+  if (
+    opts.summary &&
+    (opts.full || opts.limit !== undefined)
+  ) {
+    return "--summary ignores --limit and --full; --summary is server-side counts only. Drop --summary to control change volume, or drop --limit/--full.";
+  }
+  return undefined;
+}
+
+/** Render a detected mode conflict and mark the process exit code. */
+export function reportDiffModeConflict(message: string): void {
+  console.error(chalk.red("Error:"), message);
+  process.exitCode = 1;
+}
 import { getEndpoint } from "../config.js";
 import { resolveFileOrEntity, resolveEntityFull, printResolved, looksFileLike, type ResolvedEntity } from "../resolve.js";
 import { formatDiff, relativePath } from "../format.js";
@@ -431,6 +478,11 @@ export function registerDiffCommand(program: Command): void {
       entity?: string; summary?: boolean; content?: boolean; limit?: string; full?: boolean; format: string;
       kind?: string; path?: string; pick?: number;
     }) => {
+      const conflict = detectDiffModeConflict(opts);
+      if (conflict) {
+        reportDiffModeConflict(conflict);
+        return;
+      }
       const client = new IxClient(getEndpoint());
       const from = parseInt(fromRev, 10);
       const to = parseInt(toRev, 10);

--- a/ix-cli/src/cli/llm.ts
+++ b/ix-cli/src/cli/llm.ts
@@ -18,6 +18,8 @@
  *     newlines/tabs are encoded as `\n`/`\r`/`\t` so a record never spans lines.
  */
 
+import chalk from "chalk";
+
 /** A field value before rendering. Nullish/empty values are omitted. */
 export type LlmValue = string | number | boolean | null | undefined;
 
@@ -97,4 +99,27 @@ export function printLlmLines(lines: Array<string | null | undefined>): void {
   for (const line of lines) {
     if (line != null) console.log(line);
   }
+}
+
+/**
+ * Report a mutually-exclusive flag combination in the format the caller asked
+ * for, and mark the run failed.
+ *
+ * Both halves matter. `--format llm` gets the `error code=... message="..."`
+ * record on stdout that imports.ts, trace.ts, locate.ts and callers.ts already
+ * emit and that docs/llm-format.md specifies: an agent is told to pass the flag
+ * unconditionally, so an error it cannot parse is an error it cannot act on.
+ * Every other format gets the human line on stderr, so a `--format json` caller
+ * piping to `jq` never finds prose in the payload.
+ *
+ * One function because it was otherwise written twice, byte for byte including
+ * its docblock, in `context.ts` and `diff.ts`. What it encodes -- which stream,
+ * which record kind, which exit code -- is a convention that has to change
+ * everywhere at once or not at all, and `subsystems.ts` already carries six
+ * copies of the stderr half for the same reason.
+ */
+export function reportModeConflict(message: string, format?: string): void {
+  if (format === "llm") console.log(llmError("mode_conflict", message));
+  else console.error(chalk.red("Error:"), message);
+  process.exitCode = 1;
 }

--- a/ix-cli/src/cli/llm.ts
+++ b/ix-cli/src/cli/llm.ts
@@ -18,8 +18,6 @@
  *     newlines/tabs are encoded as `\n`/`\r`/`\t` so a record never spans lines.
  */
 
-import chalk from "chalk";
-
 /** A field value before rendering. Nullish/empty values are omitted. */
 export type LlmValue = string | number | boolean | null | undefined;
 
@@ -99,27 +97,4 @@ export function printLlmLines(lines: Array<string | null | undefined>): void {
   for (const line of lines) {
     if (line != null) console.log(line);
   }
-}
-
-/**
- * Report a mutually-exclusive flag combination in the format the caller asked
- * for, and mark the run failed.
- *
- * Both halves matter. `--format llm` gets the `error code=... message="..."`
- * record on stdout that imports.ts, trace.ts, locate.ts and callers.ts already
- * emit and that docs/llm-format.md specifies: an agent is told to pass the flag
- * unconditionally, so an error it cannot parse is an error it cannot act on.
- * Every other format gets the human line on stderr, so a `--format json` caller
- * piping to `jq` never finds prose in the payload.
- *
- * One function because it was otherwise written twice, byte for byte including
- * its docblock, in `context.ts` and `diff.ts`. What it encodes -- which stream,
- * which record kind, which exit code -- is a convention that has to change
- * everywhere at once or not at all, and `subsystems.ts` already carries six
- * copies of the stderr half for the same reason.
- */
-export function reportModeConflict(message: string, format?: string): void {
-  if (format === "llm") console.log(llmError("mode_conflict", message));
-  else console.error(chalk.red("Error:"), message);
-  process.exitCode = 1;
 }

--- a/ix-cli/src/cli/options.ts
+++ b/ix-cli/src/cli/options.ts
@@ -36,7 +36,25 @@ export function parsePickOption(value: string): number {
  * requested budget back to the caller, and a silently repaired number
  * (`--max-entities 1e3` becoming 1) is a misreport of the one thing that record
  * exists to carry.
+ *
+ * `example` is the flag's own default, supplied by the caller. A shared literal
+ * would be wrong for at least one flag: `--max-chars` starts at 12000 and
+ * clamps up from anything below 1000, so suggesting 50 there names a value the
+ * command silently replaces.
  */
-export function parseBudgetOption(value: string): number {
-  return parsePositiveInt(value, "50");
+export function parseBudgetOption(value: string, example: string): number {
+  return parsePositiveInt(value, example);
+}
+
+/**
+ * Parse a revision flag: a positive integer graph revision.
+ *
+ * `parseInt(opts.asOfRev, 10)` reached `client.query({ asOfRev })` and
+ * `buildBundle` unchecked, so `--as-of-rev abc` sent NaN to the backend,
+ * `--as-of-rev 3.9` silently became 3, and `--as-of-rev 10abc` became 10 — the
+ * same not-a-validator failure the budget flags had, on the flag two lines
+ * above them.
+ */
+export function parseRevisionOption(value: string): number {
+  return parsePositiveInt(value, "12");
 }

--- a/ix-cli/src/cli/options.ts
+++ b/ix-cli/src/cli/options.ts
@@ -1,14 +1,42 @@
 import { InvalidArgumentError } from "commander";
 
-export function parsePickOption(value: string): number {
+/**
+ * Parse a flag that must be a positive integer, rejecting anything else.
+ *
+ * The regex is the check; `Number` is only the conversion. `Number.parseInt`
+ * on its own is not a validator and never was: it reads `"10abc"` as 10,
+ * `"0x10"` as 0, `"1e3"` as 1 and `"-5"` as -5, so every one of those reaches
+ * the command as a value the caller never typed. `Number.isSafeInteger` then
+ * rejects the digit strings too large to survive the round trip.
+ *
+ * `example` is interpolated into the message so each flag can show a plausible
+ * value for itself; the wording is otherwise identical, because the rule is.
+ */
+function parsePositiveInt(value: string, example: string): number {
   const normalized = value.trim();
-  if (!/^\+?[1-9]\d*$/.test(normalized)) {
-    throw new InvalidArgumentError("must be a positive integer (for example, 1 or 2)");
-  }
+  const reject = () =>
+    new InvalidArgumentError(`must be a positive integer (for example, ${example})`);
+  if (!/^\+?[1-9]\d*$/.test(normalized)) throw reject();
 
   const parsed = Number(normalized);
-  if (!Number.isSafeInteger(parsed)) {
-    throw new InvalidArgumentError("must be a positive integer (for example, 1 or 2)");
-  }
+  if (!Number.isSafeInteger(parsed)) throw reject();
   return parsed;
+}
+
+export function parsePickOption(value: string): number {
+  return parsePositiveInt(value, "1 or 2");
+}
+
+/**
+ * Parse a `--max-*` budget flag.
+ *
+ * Validated at parse time rather than read back out of the raw option string
+ * later, so the value is parsed once and a malformed one is refused where the
+ * user can see which flag they mistyped. `ix context --diff` reports the
+ * requested budget back to the caller, and a silently repaired number
+ * (`--max-entities 1e3` becoming 1) is a misreport of the one thing that record
+ * exists to carry.
+ */
+export function parseBudgetOption(value: string): number {
+  return parsePositiveInt(value, "50");
 }

--- a/ix-cli/src/cli/ui.ts
+++ b/ix-cli/src/cli/ui.ts
@@ -7,6 +7,8 @@
 
 import chalk from "chalk";
 
+import { llmError } from "./llm.js";
+
 // ── Brand palette ─────────────────────────────────────────────────────────────
 //
 //   Primary / kind accent   chalk.cyan
@@ -70,6 +72,22 @@ export function renderWarning(text: string): void {
   console.log(`  ${chalk.yellow("Warning")}  ${chalk.yellow(text)}`);
 }
 
+/**
+ * The same warning, on stderr.
+ *
+ * Every renderer here writes to stdout, which is where a command's payload
+ * goes: a warning printed alongside a `--format json` bundle lands inside what
+ * the caller pipes to `jq`, and inside the record stream for `--format llm`.
+ * When a command has a machine format, its prose belongs on the other stream.
+ *
+ * Same padding and same colour as `renderWarning`, deliberately — this had been
+ * hand-rolled twice as `console.error("  Warning  " + text)`, which put the
+ * convention in three places and dropped the colour humans were getting.
+ */
+export function renderWarningErr(text: string): void {
+  console.error(`  ${chalk.yellow("Warning")}  ${chalk.yellow(text)}`);
+}
+
 /** Success confirmation. */
 export function renderSuccess(text: string): void {
   console.log(`  ${chalk.green(text)}`);
@@ -85,4 +103,31 @@ export function renderError(text: string): void {
 /** Print the "Resolved: kind name" header shown at the top of most command text output. */
 export function renderResolvedHeader(kind: string, name: string): void {
   console.log(`${chalk.bold("Resolved:")} ${chalk.cyan(kind)} ${chalk.bold(name)}`);
+}
+
+/**
+ * Report a command failure in the format the caller asked for, and mark the run
+ * failed.
+ *
+ * Both halves matter. `--format llm` gets the `error code=... message="..."`
+ * record on stdout that `callers.ts`, `contains.ts`, `depends.ts`, `diff.ts` and
+ * `history.ts` already emit and that docs/llm-format.md specifies: an agent is
+ * told to pass the flag unconditionally, so an error it cannot parse is an
+ * error it cannot act on. Every other format gets the human line on stderr, so
+ * a `--format json` caller piping to `jq` never finds prose in the payload.
+ *
+ * One function because it was otherwise written twice, byte for byte including
+ * its docblock, in `context.ts` and `diff.ts`, while five more refusals in the
+ * same handler wrote `renderWarning` — which is `console.log` — and left the
+ * exit code at 0, so a script could not tell a refusal from an empty success.
+ * `subsystems.ts` carries six more copies of the stderr half.
+ *
+ * Here rather than in `llm.ts`: this is an output-routing decision, and putting
+ * it there forced `chalk` into the module documented as the token-minimal wire
+ * format renderer, for the sake of one human-facing line.
+ */
+export function reportFailure(code: string, message: string, format?: string): void {
+  if (format === "llm") console.log(llmError(code, message));
+  else console.error(chalk.red("Error:"), message);
+  process.exitCode = 1;
 }

--- a/skills/ix/references/commands.md
+++ b/skills/ix/references/commands.md
@@ -97,7 +97,9 @@ ix inventory --kind function --path auth.py --format llm
 - Use `ix inventory` instead of `ix search ""` for listing entities by kind.
 - Use `ix diff --summary` for broad revision comparisons; `--full` only when
   every individual change is needed.
-- Always use `--limit` to cap result sets.
+- Always use `--limit` to cap result sets. Not on `ix diff --summary` or
+  `ix diff --full`, though: each already fixes the volume, so `--limit`
+  alongside either is refused rather than silently ignored.
 - Use `--path` or `--language` to restrict text searches.
 - Reuse exact entity IDs from previous JSON results when chaining commands.
 - Decompose large questions into multiple targeted calls.


### PR DESCRIPTION
Carries **@Alot1z's** commit from #458 (`58aea40`) plus a fix, on a branch in this repo — pushing to their fork is not something I can do from here. **Supersedes #458**, which stays open for @Alot1z.

**Stacked on #456**: merge that first. The reason is the defect itself.

## What was wrong

The `format === "llm"` branch printed

```js
console.log(`  budgets`);
console.log(`    saved     : ${formatBudgets(diff.budgets.saved)}`);
```

— two-space indents, aligned colons, a bare header line, in the format `docs/llm-format.md` defines as *"no decorative whitespace, separators, or headers"*. It was the text renderer with the colon moved, and it could not have been anything else: on this branch the whole diff renderer is prose, and `--format llm` never had a record stream to put a budget record into. That is why this is stacked on #456 rather than standalone.

## What it emits now

```
budgets scope=saved entities=5 relationships=1 evidence=2 chars=12000
budgets scope=requested evidence=25 applied=false
budgets scope=effective entities=5 relationships=1 evidence=2 chars=12000
```

`applied=false` rather than the explanatory sentence: the precedence rule is that saved budgets govern `--diff`, and a field an agent can test beats a note it has to read. Absent overrides are simply absent — `llmField` drops nullish, so the record form needs no `not-given` sentinel the prose form uses.

## One comment that was load-bearing and wrong

`parseRequestedBudgets` said it applied *"the same clamping rules the action handler uses"*. It applies none — the handler uses `clampInt(opts.maxEntities, 1, 500, 50)`. Not dangerous while the values are reported and never applied, which is exactly the point: clamping them **would misreport what the caller asked for**. So the code is right and the comment was wrong; the comment now says so, and says where the ranges live if these are ever made to win on the fresh side.

Also drops `JSON.parse(json.lines[0].replace(/^undefined$/, ""))` from the test — the capture works, the guard was hiding nothing.

## Verification

1001 tests green, lint, typecheck and knip clean, with `main` merged in.