### PR TITLE
fix(ingest): bound the manifest reads a scanned repo controls

### DIFF
--- a/ix-cli/src/cli/__tests__/bounded-read.test.ts
+++ b/ix-cli/src/cli/__tests__/bounded-read.test.ts
@@ -1,0 +1,116 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as nodePath from "node:path";
+
+import { readRepoFile } from "../bounded-read.js";
+
+/**
+ * `readRepoFile` is the one guard standing between ingestion and a file whose
+ * path AND contents the scanned repository chose. Every case below is a way a
+ * repo can name something that is not the small text file the caller expects.
+ */
+describe("readRepoFile", () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = fs.mkdtempSync(nodePath.join(os.tmpdir(), "ix-bounded-"));
+  });
+
+  afterAll(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("reads an ordinary file", () => {
+    const p = nodePath.join(root, "plain.json");
+    fs.writeFileSync(p, '{ "name": "reads-fine" }');
+    expect(readRepoFile(root, p)).toBe('{ "name": "reads-fine" }');
+  });
+
+  it("refuses a file whose reported size is over the cap", () => {
+    const p = nodePath.join(root, "big.json");
+    fs.writeFileSync(p, "x".repeat(4096));
+    expect(readRepoFile(root, p, 1024)).toBeNull();
+    // ...and the same file is fine under a cap that admits it, so it is the cap
+    // doing the work rather than anything else about the file.
+    expect(readRepoFile(root, p, 8192)).not.toBeNull();
+  });
+
+  it("refuses a directory", () => {
+    const p = nodePath.join(root, "adir");
+    fs.mkdirSync(p, { recursive: true });
+    expect(readRepoFile(root, p)).toBeNull();
+  });
+
+  it("refuses a file that does not exist", () => {
+    expect(readRepoFile(root, nodePath.join(root, "absent.json"))).toBeNull();
+  });
+
+  /**
+   * The case the outer size check cannot catch, and the reason the read is
+   * capped separately.
+   *
+   * A `/proc` entry is a REGULAR file — `isFile()` is true — that reports size
+   * 0 while holding kilobytes. `fs.readFileSync(handle)` re-stats, sees 0, and
+   * falls back to reading 8 KB chunks until EOF with no limit, so a guard built
+   * only from `fstat().size` admits the whole file. Remove the cap inside
+   * `readCapped` and this goes green while nothing else in the suite moves.
+   */
+  it.skipIf(process.platform !== "linux")(
+    "refuses a size-0 regular file whose contents exceed the cap",
+    () => {
+      // Present on every Linux, stable, and comfortably over 100 bytes.
+      expect(fs.statSync("/proc/meminfo").isFile()).toBe(true);
+      expect(fs.statSync("/proc/meminfo").size).toBe(0);
+      expect(readRepoFile("/proc", "/proc/meminfo", 100)).toBeNull();
+      // A cap it does fit under still reads, so the refusal above is the cap.
+      expect(readRepoFile("/proc", "/proc/meminfo", 1024 * 1024)).toContain("MemTotal");
+    },
+  );
+
+  // POSIX only: creating a symlink on Windows needs privileges the runner does
+  // not have, and /dev/zero has no Windows equivalent.
+  describe.skipIf(process.platform === "win32")("symlinks", () => {
+    it("refuses a file symlinked outside the root", () => {
+      const outside = nodePath.join(os.tmpdir(), `ix-outside-${process.pid}.txt`);
+      fs.writeFileSync(outside, "SECRET");
+      const inside = nodePath.join(root, "escapes.json");
+      fs.symlinkSync(outside, inside);
+      try {
+        expect(readRepoFile(root, inside)).toBeNull();
+      } finally {
+        fs.rmSync(outside, { force: true });
+      }
+    });
+
+    it("still reads when the ROOT itself is reached through a symlink", () => {
+      // Resolving the file but not the root would reject every read on macOS
+      // (/var -> /private/var), on a network home, or in a pnpm workspace whose
+      // package directory is a link. No CI runner here has a symlinked root, so
+      // nothing else would notice.
+      const realRoot = fs.mkdtempSync(nodePath.join(os.tmpdir(), "ix-realroot-"));
+      const linkedRoot = nodePath.join(os.tmpdir(), `ix-linkedroot-${process.pid}`);
+      fs.writeFileSync(nodePath.join(realRoot, "package.json"), '{ "name": "via-link" }');
+      fs.symlinkSync(realRoot, linkedRoot, "dir");
+      try {
+        expect(readRepoFile(linkedRoot, nodePath.join(linkedRoot, "package.json"))).toContain(
+          "via-link",
+        );
+      } finally {
+        fs.rmSync(linkedRoot, { force: true });
+        fs.rmSync(realRoot, { recursive: true, force: true });
+      }
+    });
+
+    it("refuses a character device, rather than reading it forever", () => {
+      const dev = nodePath.join(root, "zero.json");
+      fs.symlinkSync("/dev/zero", dev);
+      // The assertion that matters is that this returns at all: an unguarded
+      // read of /dev/zero does not throw and does not finish, it consumes
+      // memory until the process dies.
+      const started = Date.now();
+      expect(readRepoFile(root, dev)).toBeNull();
+      expect(Date.now() - started).toBeLessThan(2000);
+    });
+  });
+});

--- a/ix-cli/src/cli/__tests__/bounded-read.test.ts
+++ b/ix-cli/src/cli/__tests__/bounded-read.test.ts
@@ -3,14 +3,14 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as nodePath from "node:path";
 
-import { readRepoFile } from "../bounded-read.js";
+import { readBoundedFile, readCapped } from "../bounded-read.js";
 
 /**
- * `readRepoFile` is the one guard standing between ingestion and a file whose
- * path AND contents the scanned repository chose. Every case below is a way a
- * repo can name something that is not the small text file the caller expects.
+ * `readBoundedFile` stands between ingestion and a file whose path AND contents
+ * the scanned repository chose. Every case below is a way a repo can name
+ * something that is not the small text file the caller expects.
  */
-describe("readRepoFile", () => {
+describe("readBoundedFile", () => {
   let root: string;
 
   beforeAll(() => {
@@ -24,93 +24,153 @@ describe("readRepoFile", () => {
   it("reads an ordinary file", () => {
     const p = nodePath.join(root, "plain.json");
     fs.writeFileSync(p, '{ "name": "reads-fine" }');
-    expect(readRepoFile(root, p)).toBe('{ "name": "reads-fine" }');
+    expect(readBoundedFile(p)).toBe('{ "name": "reads-fine" }');
   });
 
   it("refuses a file whose reported size is over the cap", () => {
     const p = nodePath.join(root, "big.json");
     fs.writeFileSync(p, "x".repeat(4096));
-    expect(readRepoFile(root, p, 1024)).toBeNull();
+    expect(readBoundedFile(p, { maxBytes: 1024 })).toBeNull();
     // ...and the same file is fine under a cap that admits it, so it is the cap
     // doing the work rather than anything else about the file.
-    expect(readRepoFile(root, p, 8192)).not.toBeNull();
+    expect(readBoundedFile(p, { maxBytes: 8192 })).not.toBeNull();
   });
 
   it("refuses a directory", () => {
     const p = nodePath.join(root, "adir");
     fs.mkdirSync(p, { recursive: true });
-    expect(readRepoFile(root, p)).toBeNull();
+    expect(readBoundedFile(p)).toBeNull();
   });
 
   it("refuses a file that does not exist", () => {
-    expect(readRepoFile(root, nodePath.join(root, "absent.json"))).toBeNull();
+    expect(readBoundedFile(nodePath.join(root, "absent.json"))).toBeNull();
   });
 
-  /**
-   * The case the outer size check cannot catch, and the reason the read is
-   * capped separately.
-   *
-   * A `/proc` entry is a REGULAR file — `isFile()` is true — that reports size
-   * 0 while holding kilobytes. `fs.readFileSync(handle)` re-stats, sees 0, and
-   * falls back to reading 8 KB chunks until EOF with no limit, so a guard built
-   * only from `fstat().size` admits the whole file. Remove the cap inside
-   * `readCapped` and this goes green while nothing else in the suite moves.
-   */
-  it.skipIf(process.platform !== "linux")(
-    "refuses a size-0 regular file whose contents exceed the cap",
-    () => {
-      // Present on every Linux, stable, and comfortably over 100 bytes.
-      expect(fs.statSync("/proc/meminfo").isFile()).toBe(true);
-      expect(fs.statSync("/proc/meminfo").size).toBe(0);
-      expect(readRepoFile("/proc", "/proc/meminfo", 100)).toBeNull();
-      // A cap it does fit under still reads, so the refusal above is the cap.
-      expect(readRepoFile("/proc", "/proc/meminfo", 1024 * 1024)).toContain("MemTotal");
-    },
-  );
+  it("refuses when the caller's accept check says no, and reads when it says yes", () => {
+    const p = nodePath.join(root, "gated.json");
+    fs.writeFileSync(p, "gated");
+    expect(readBoundedFile(p, { accept: () => false })).toBeNull();
+    expect(readBoundedFile(p, { accept: () => true })).toBe("gated");
+  });
 
-  // POSIX only: creating a symlink on Windows needs privileges the runner does
-  // not have, and /dev/zero has no Windows equivalent.
-  describe.skipIf(process.platform === "win32")("symlinks", () => {
-    it("refuses a file symlinked outside the root", () => {
-      const outside = nodePath.join(os.tmpdir(), `ix-outside-${process.pid}.txt`);
-      fs.writeFileSync(outside, "SECRET");
-      const inside = nodePath.join(root, "escapes.json");
-      fs.symlinkSync(outside, inside);
-      try {
-        expect(readRepoFile(root, inside)).toBeNull();
-      } finally {
-        fs.rmSync(outside, { force: true });
-      }
+  it("hands accept the stats of the file it actually opened", () => {
+    const p = nodePath.join(root, "stats.json");
+    fs.writeFileSync(p, "12345");
+    const real = fs.statSync(p);
+    let seen: fs.Stats | null = null;
+    readBoundedFile(p, {
+      accept: (stats) => {
+        seen = stats;
+        return true;
+      },
     });
+    // Same inode as the path names, so a caller can tie a resolved path back to
+    // the handle rather than to a name that may have been swapped underneath.
+    expect(seen!.ino).toBe(real.ino);
+    expect(seen!.dev).toBe(real.dev);
+    expect(seen!.size).toBe(5);
+  });
+});
 
-    it("still reads when the ROOT itself is reached through a symlink", () => {
-      // Resolving the file but not the root would reject every read on macOS
-      // (/var -> /private/var), on a network home, or in a pnpm workspace whose
-      // package directory is a link. No CI runner here has a symlinked root, so
-      // nothing else would notice.
-      const realRoot = fs.mkdtempSync(nodePath.join(os.tmpdir(), "ix-realroot-"));
-      const linkedRoot = nodePath.join(os.tmpdir(), `ix-linkedroot-${process.pid}`);
-      fs.writeFileSync(nodePath.join(realRoot, "package.json"), '{ "name": "via-link" }');
-      fs.symlinkSync(realRoot, linkedRoot, "dir");
-      try {
-        expect(readRepoFile(linkedRoot, nodePath.join(linkedRoot, "package.json"))).toContain(
-          "via-link",
-        );
-      } finally {
-        fs.rmSync(linkedRoot, { force: true });
-        fs.rmSync(realRoot, { recursive: true, force: true });
-      }
-    });
+/**
+ * The cap lives in the READ, not in the fstat, because `fs.readFileSync(handle)`
+ * re-stats and reads that size instead. Pinning `readCapped` directly is the
+ * only way to assert that on every platform: the wiring can only be caught
+ * where a size-0 regular file exists, which is Linux alone.
+ */
+describe("readCapped", () => {
+  let root: string;
 
-    it("refuses a character device, rather than reading it forever", () => {
-      const dev = nodePath.join(root, "zero.json");
-      fs.symlinkSync("/dev/zero", dev);
+  beforeAll(() => {
+    root = fs.mkdtempSync(nodePath.join(os.tmpdir(), "ix-capped-"));
+  });
+
+  afterAll(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  const withHandle = <T>(p: string, fn: (fd: number) => T): T => {
+    const fd = fs.openSync(p, "r");
+    try {
+      return fn(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+  };
+
+  it("refuses a handle holding more than the cap", () => {
+    const p = nodePath.join(root, "over.txt");
+    fs.writeFileSync(p, "x".repeat(4096));
+    expect(withHandle(p, (fd) => readCapped(fd, 1024))).toBeNull();
+    expect(withHandle(p, (fd) => readCapped(fd, 8192))).toHaveLength(4096);
+  });
+
+  it("admits a file exactly at the cap and refuses one byte more", () => {
+    const at = nodePath.join(root, "at.txt");
+    fs.writeFileSync(at, "y".repeat(100));
+    expect(withHandle(at, (fd) => readCapped(fd, 100))).toHaveLength(100);
+    expect(withHandle(at, (fd) => readCapped(fd, 99))).toBeNull();
+  });
+
+  it("reads a file that spans several chunks, without corrupting a split character", () => {
+    // A 2-byte character straddling the 64 KiB chunk boundary: decoding per
+    // chunk instead of after the concat would turn it into replacement chars.
+    const p = nodePath.join(root, "multibyte.txt");
+    const head = "a".repeat(64 * 1024 - 1);
+    fs.writeFileSync(p, head + "é" + "b".repeat(10), "utf8");
+    const out = withHandle(p, (fd) => readCapped(fd, 1024 * 1024));
+    expect(out).toBe(head + "é" + "b".repeat(10));
+  });
+
+  it("returns empty string for an empty file", () => {
+    const p = nodePath.join(root, "empty.txt");
+    fs.writeFileSync(p, "");
+    expect(withHandle(p, (fd) => readCapped(fd, 1024))).toBe("");
+  });
+});
+
+/**
+ * The case the fstat size check cannot catch, and the reason the read is capped
+ * separately. A `/proc` entry is a REGULAR file — `isFile()` true — that reports
+ * size 0 while holding kilobytes, so a guard built only from `fstat().size`
+ * admits the whole file.
+ */
+describe.skipIf(process.platform !== "linux")("size-0 regular files", () => {
+  it("refuses one whose contents exceed the cap", (ctx) => {
+    // Not every /proc is the kernel's: lxcfs and gVisor overlays report a real
+    // size, and there the premise of this test simply does not hold. Skip
+    // explicitly rather than assert, and never pass silently.
+    let stats: fs.Stats;
+    try {
+      stats = fs.statSync("/proc/meminfo");
+    } catch {
+      return ctx.skip("no /proc/meminfo on this runner");
+    }
+    if (!stats.isFile() || stats.size !== 0) {
+      return ctx.skip("/proc/meminfo is not a size-0 regular file here");
+    }
+    expect(readBoundedFile("/proc/meminfo", { maxBytes: 100 })).toBeNull();
+    // A cap it does fit under still reads, so the refusal above is the cap.
+    expect(readBoundedFile("/proc/meminfo")).toContain("MemTotal");
+  });
+});
+
+// POSIX only: creating a symlink on Windows needs privileges the runner does
+// not have, and /dev/zero has no Windows equivalent.
+describe.skipIf(process.platform === "win32")("character devices", () => {
+  it("refuses one reached through a symlink, rather than reading it forever", () => {
+    const dir = fs.mkdtempSync(nodePath.join(os.tmpdir(), "ix-dev-"));
+    const dev = nodePath.join(dir, "zero.json");
+    fs.symlinkSync("/dev/zero", dev);
+    try {
       // The assertion that matters is that this returns at all: an unguarded
       // read of /dev/zero does not throw and does not finish, it consumes
       // memory until the process dies.
       const started = Date.now();
-      expect(readRepoFile(root, dev)).toBeNull();
+      expect(readBoundedFile(dev)).toBeNull();
       expect(Date.now() - started).toBeLessThan(2000);
-    });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/ix-cli/src/cli/__tests__/bounded-read.test.ts
+++ b/ix-cli/src/cli/__tests__/bounded-read.test.ts
@@ -89,8 +89,10 @@ describe("readCapped", () => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 
+  // The same flags readBoundedFile opens with, so these exercise the handle
+  // production actually hands to readCapped.
   const withHandle = <T>(p: string, fn: (fd: number) => T): T => {
-    const fd = fs.openSync(p, "r");
+    const fd = fs.openSync(p, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
     try {
       return fn(fd);
     } finally {
@@ -105,7 +107,7 @@ describe("readCapped", () => {
     expect(withHandle(p, (fd) => readCapped(fd, 8192))).toHaveLength(4096);
   });
 
-  it("admits a file exactly at the cap and refuses one byte more", () => {
+  it("admits a file exactly at the cap and refuses a cap one byte tighter", () => {
     const at = nodePath.join(root, "at.txt");
     fs.writeFileSync(at, "y".repeat(100));
     expect(withHandle(at, (fd) => readCapped(fd, 100))).toHaveLength(100);
@@ -113,13 +115,18 @@ describe("readCapped", () => {
   });
 
   it("reads a file that spans several chunks, without corrupting a split character", () => {
-    // A 2-byte character straddling the 64 KiB chunk boundary: decoding per
-    // chunk instead of after the concat would turn it into replacement chars.
+    // Every character is 3 bytes and the chunk is 65536, which is not a
+    // multiple of 3 — so whichever byte a read happens to stop on, some
+    // character straddles a boundary. Placing one 2-byte character at offset
+    // 65535 instead would only split it if the first read returned exactly
+    // 65536 bytes, which POSIX does not promise and FUSE/network mounts do not
+    // deliver; that test would pass vacuously there. Decoding per chunk rather
+    // than after the concat turns the split character into replacement chars.
     const p = nodePath.join(root, "multibyte.txt");
-    const head = "a".repeat(64 * 1024 - 1);
-    fs.writeFileSync(p, head + "é" + "b".repeat(10), "utf8");
-    const out = withHandle(p, (fd) => readCapped(fd, 1024 * 1024));
-    expect(out).toBe(head + "é" + "b".repeat(10));
+    const text = "€".repeat(30000); // 90000 bytes, > 64 KiB
+    fs.writeFileSync(p, text, "utf8");
+    expect(fs.statSync(p).size).toBe(90000);
+    expect(withHandle(p, (fd) => readCapped(fd, 1024 * 1024))).toBe(text);
   });
 
   it("returns empty string for an empty file", () => {
@@ -159,10 +166,11 @@ describe.skipIf(process.platform !== "linux")("size-0 regular files", () => {
 // not have, and /dev/zero has no Windows equivalent.
 describe.skipIf(process.platform === "win32")("character devices", () => {
   it("refuses one reached through a symlink, rather than reading it forever", () => {
-    const dir = fs.mkdtempSync(nodePath.join(os.tmpdir(), "ix-dev-"));
-    const dev = nodePath.join(dir, "zero.json");
-    fs.symlinkSync("/dev/zero", dev);
+    let dir: string | undefined;
     try {
+      dir = fs.mkdtempSync(nodePath.join(os.tmpdir(), "ix-dev-"));
+      const dev = nodePath.join(dir, "zero.json");
+      fs.symlinkSync("/dev/zero", dev);
       // The assertion that matters is that this returns at all: an unguarded
       // read of /dev/zero does not throw and does not finish, it consumes
       // memory until the process dies.
@@ -170,7 +178,71 @@ describe.skipIf(process.platform === "win32")("character devices", () => {
       expect(readBoundedFile(dev)).toBeNull();
       expect(Date.now() - started).toBeLessThan(2000);
     } finally {
-      fs.rmSync(dir, { recursive: true, force: true });
+      if (dir) fs.rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it("refuses a character device that reads as empty", () => {
+    // /dev/null returns EOF immediately, so the cap never fires on it: without
+    // the isFile() check it reads as "" rather than being refused. Every other
+    // non-regular case in this suite is now caught by the cap instead, so this
+    // is the one that pins the type check itself.
+    expect(readBoundedFile("/dev/null")).toBeNull();
+  });
+});
+
+/**
+ * The defect this module exists for, reproduced through the public API and
+ * therefore pinned on every platform.
+ *
+ * `accept` runs between the fstat and the read, so a test can grow the file at
+ * exactly the moment the real bug needs it to grow. That single assertion kills
+ * both ways of getting this wrong: reverting to `fs.readFileSync(handle)` (which
+ * re-stats and reads the NEW size), and reordering so the content is read before
+ * `accept` decides (which would return the pre-growth content instead of null).
+ * The /proc case covers the other half of the same defect — a size that was
+ * never right to begin with — but exists on one of the four platforms this
+ * suite runs on, and skips itself on an lxcfs or gVisor overlay.
+ */
+describe("the cap binds against a file that changes under it", () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = fs.mkdtempSync(nodePath.join(os.tmpdir(), "ix-grow-"));
+  });
+
+  afterAll(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("refuses a file that grows past the cap after its size was checked", () => {
+    const p = nodePath.join(root, "grows.json");
+    fs.writeFileSync(p, "x".repeat(10));
+    let grew = false;
+    const out = readBoundedFile(p, {
+      maxBytes: 1024,
+      accept: () => {
+        fs.appendFileSync(p, "y".repeat(4096));
+        grew = true;
+        return true;
+      },
+    });
+    expect(grew).toBe(true);
+    expect(out).toBeNull();
+  });
+
+  it("still returns the content when the growth stays under the cap", () => {
+    // The control: the refusal above is the cap reacting to the new size, not
+    // the write itself upsetting the read.
+    const p = nodePath.join(root, "grows-a-little.json");
+    fs.writeFileSync(p, "x".repeat(10));
+    const out = readBoundedFile(p, {
+      maxBytes: 1024,
+      accept: () => {
+        fs.appendFileSync(p, "y".repeat(100));
+        return true;
+      },
+    });
+    expect(out).toBe("x".repeat(10) + "y".repeat(100));
   });
 });

--- a/ix-cli/src/cli/__tests__/system.test.ts
+++ b/ix-cli/src/cli/__tests__/system.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as nodePath from "node:path";
+import { execFileSync } from "node:child_process";
 
 import { buildPackageRegistry, detectSystem, readPackageNames, readPackageDeps, repoWorkspaceIdFor, workspaceIdForPath } from "../system.js";
 
@@ -179,5 +180,83 @@ describe("workspace_id convergence (solo vs co-ingest)", () => {
     expect(workspaceIdForPath(nodePath.join(root, "app")))
       .not.toBe(workspaceIdForPath(nodePath.join(root, "lib")));
     expect(workspaceIdForPath(root)).toMatch(/^[0-9a-f]{8}$/); // 8-hex, not a random UUID slice
+  });
+});
+
+// ── Manifest reads are bounded ───────────────────────────────────────────────
+//
+// Every path this module reads is named by the *scanned repository*, so a
+// hostile or merely broken one decides what `ix map` opens. `readFileSync` on
+// `/dev/zero` does not throw — it consumes memory until the process dies — and
+// a 2 GB `Cargo.toml` needs no symlink to do the same.
+describe("manifest reads are bounded and typed", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = fs.mkdtempSync(nodePath.join(os.tmpdir(), "ix-manifest-"));
+  });
+
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("still reads an ordinary manifest", () => {
+    const ok = nodePath.join(dir, "ok");
+    fs.mkdirSync(ok, { recursive: true });
+    fs.writeFileSync(nodePath.join(ok, "package.json"), '{ "name": "reads-fine" }');
+    expect(readPackageNames(ok)).toContain("reads-fine");
+  });
+
+  it("refuses a manifest larger than the cap instead of loading it", () => {
+    const big = nodePath.join(dir, "big");
+    fs.mkdirSync(big, { recursive: true });
+    // Just over 1 MB, and valid JSON, so only the size can be what rejects it.
+    const padding = "x".repeat(1024 * 1024);
+    fs.writeFileSync(
+      nodePath.join(big, "package.json"),
+      JSON.stringify({ name: "too-big", description: padding }),
+    );
+    expect(readPackageNames(big)).toEqual([]);
+  });
+
+  it("refuses a manifest that is a directory", () => {
+    const weird = nodePath.join(dir, "weird");
+    fs.mkdirSync(nodePath.join(weird, "package.json"), { recursive: true });
+    expect(() => readPackageNames(weird)).not.toThrow();
+    expect(readPackageNames(weird)).toEqual([]);
+  });
+
+  // POSIX only: /dev/zero has no Windows equivalent, and creating a symlink
+  // there needs privileges the runner does not have.
+  it.skipIf(process.platform === "win32")(
+    "refuses a manifest symlinked to a character device, rather than reading it forever",
+    () => {
+      const dev = nodePath.join(dir, "dev");
+      fs.mkdirSync(dev, { recursive: true });
+      fs.symlinkSync("/dev/zero", nodePath.join(dev, "package.json"));
+
+      // The assertion that matters is that this returns at all: unguarded,
+      // the read never does.
+      const started = Date.now();
+      expect(readPackageNames(dev)).toEqual([]);
+      expect(readPackageDeps(dev)).toEqual([]);
+      expect(Date.now() - started).toBeLessThan(2000);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")("refuses a manifest that is a FIFO, without blocking on it", () => {
+    const fifoDir = nodePath.join(dir, "fifo");
+    fs.mkdirSync(fifoDir, { recursive: true });
+    const fifo = nodePath.join(fifoDir, "package.json");
+    try {
+      execFileSync("mkfifo", [fifo]);
+    } catch {
+      return; // no mkfifo on this runner; the device case already covers the shape
+    }
+    // Opening a FIFO blocks until a writer appears, which is why the guard
+    // stats rather than opens.
+    const started = Date.now();
+    expect(readPackageNames(fifoDir)).toEqual([]);
+    expect(Date.now() - started).toBeLessThan(2000);
   });
 });

--- a/ix-cli/src/cli/__tests__/system.test.ts
+++ b/ix-cli/src/cli/__tests__/system.test.ts
@@ -222,7 +222,8 @@ describe("manifest reads are bounded and typed", () => {
   it("refuses a manifest that is a directory", () => {
     const weird = nodePath.join(dir, "weird");
     fs.mkdirSync(nodePath.join(weird, "package.json"), { recursive: true });
-    expect(() => readPackageNames(weird)).not.toThrow();
+    // A throw would fail the test on its own, so one call proves both that it
+    // does not throw and that it yields nothing.
     expect(readPackageNames(weird)).toEqual([]);
   });
 
@@ -251,10 +252,15 @@ describe("manifest reads are bounded and typed", () => {
     try {
       execFileSync("mkfifo", [fifo]);
     } catch {
-      return; // no mkfifo on this runner; the device case already covers the shape
+      // Returning here would report a pass having asserted nothing, which is
+      // indistinguishable from a working guard. Fail loudly instead: every
+      // POSIX runner this suite targets has mkfifo.
+      throw new Error("mkfifo is required to exercise the FIFO guard on this platform");
     }
-    // Opening a FIFO blocks until a writer appears, which is why the guard
-    // stats rather than opens.
+    // Opening a FIFO for reading blocks until a writer appears, so the guard
+    // cannot stat-then-open: it opens with O_NONBLOCK and fstats the handle.
+    // Drop that flag and this test does not go red, it HANGS — the open blocks
+    // the same event loop vitest would fire its timeout on.
     const started = Date.now();
     expect(readPackageNames(fifoDir)).toEqual([]);
     expect(Date.now() - started).toBeLessThan(2000);

--- a/ix-cli/src/cli/bounded-read.ts
+++ b/ix-cli/src/cli/bounded-read.ts
@@ -45,8 +45,10 @@ const MAX_REPO_FILE_BYTES = 1024 * 1024;
  * decode happens after the concat, so a multi-byte character straddling a chunk
  * boundary round-trips intact.
  *
- * Exported so the cap can be pinned directly on every platform; the wiring that
- * uses it can only be pinned where a size-0 regular file exists.
+ * @internal Exported only so the cap can be pinned directly on every platform.
+ * Not a reader: it does no open, no type check and no containment, so nothing
+ * outside this module should call it. {@link readBoundedFile} is the entry
+ * point.
  */
 export function readCapped(handle: number, maxBytes: number): string | null {
   const chunks: Buffer[] = [];

--- a/ix-cli/src/cli/bounded-read.ts
+++ b/ix-cli/src/cli/bounded-read.ts
@@ -1,85 +1,26 @@
 // Bounded reads of repository-controlled files (Ix#465).
 //
-// Ingestion opens files whose *paths and contents the scanned repository
-// chooses*: build manifests (`package.json`, `Cargo.toml`, `go.mod`, ...) and
-// TypeScript configs. Both are read while the resolver and the system map are
-// built, which happens before ingestion's own size gate, so they need their
-// own — and the guard has to survive a repo that is hostile rather than merely
-// large.
+// Ingestion opens files whose paths AND contents the scanned repository
+// chooses: build manifests (`package.json`, `Cargo.toml`, `go.mod`, ...) and
+// TypeScript configs. Both are read while the system map and the module
+// resolver are built, which happens before ingestion's own size gate, so they
+// need their own — and the guard has to survive a repo that is hostile rather
+// than merely large.
 //
-// This module is the one place that guard lives. It previously existed twice,
-// in `ts-module-resolution.ts` and `system.ts`, which is how the two defects
-// below came to be fixed in one copy and not the other.
+// This module is only the READ. Containment is the caller's, via `accept`:
+// what counts as "inside" differs per caller, and getting it wrong silently
+// deletes input rather than failing, so it does not belong behind a default.
 
 import * as fs from "node:fs";
-import * as nodePath from "node:path";
 
 /**
  * How much of a repository-controlled file is worth reading, in bytes.
  *
- * Mirrors `MAX_FILE_BYTES` in `ingest.ts`. A `package.json` or a `tsconfig.json`
- * past this is not one anybody wrote, and parsing one is how a 64 MB file takes
- * the process out with an uncatchable OOM.
+ * Mirrors `MAX_FILE_BYTES` in `ingest.ts`. A `package.json` or a
+ * `tsconfig.json` past this is not one anybody wrote, and parsing one is how a
+ * 64 MB file takes the process out with an uncatchable OOM.
  */
-export const MAX_REPO_FILE_BYTES = 1024 * 1024;
-
-/**
- * Lexical containment: `candidate` names a path under `root`.
- *
- * Not sufficient on its own — see {@link openedWithinRoot} — but it is the
- * right check for a path that has not been opened yet.
- */
-export function isWithinRoot(root: string, candidate: string): boolean {
-  const relative = nodePath.relative(nodePath.resolve(root), candidate);
-  // Compare path *segments*: a bare `..startsWith` also rejects a legitimate
-  // sibling directory whose name merely begins with dots, e.g. `..shared/`.
-  return (
-    relative !== "" &&
-    relative !== ".." &&
-    !relative.startsWith(`..${nodePath.sep}`) &&
-    !nodePath.isAbsolute(relative)
-  );
-}
-
-/**
- * True when the file we are *holding open* lives inside `root`.
- *
- * The lexical check in {@link isWithinRoot} cannot see through a symlinked
- * file: every segment of `./pkg/package.json` is inside the root by path
- * arithmetic even when `package.json` points somewhere else entirely. Only the
- * resolved path shows that, so resolve it and re-check.
- *
- * Resolving the name a second time reopens the question of whether it still
- * denotes the file we hold, so the resolved path is confirmed to be the same
- * inode as the open handle. Without that, swapping the symlink between the open
- * and the resolve would let an outside file be read under an inside name.
- * (`ino` is 0 on filesystems that do not report one — chiefly some Windows
- * configurations — where this degrades to the plain resolved-path check.)
- *
- * The ROOT is resolved too, and that is not symmetry for its own sake: a
- * resolved file compared against an unresolved root rejects every file whenever
- * the root is itself reached through a link — macOS `/var` -> `/private/var`, a
- * home directory on a network mount, a `~/code` symlink, or a pnpm workspace
- * whose package directory is a symlink. That would silently switch manifest and
- * tsconfig reading off for those users, and no CI runner here has a symlinked
- * root to notice it.
- */
-function openedWithinRoot(root: string, filePath: string, opened: fs.Stats): boolean {
-  try {
-    const resolved = fs.realpathSync(filePath);
-    const viaResolved = fs.statSync(resolved);
-    if (viaResolved.dev !== opened.dev || viaResolved.ino !== opened.ino) return false;
-    let resolvedRoot: string;
-    try {
-      resolvedRoot = fs.realpathSync(root);
-    } catch {
-      resolvedRoot = root; // unreadable root: fall back to the lexical check
-    }
-    return isWithinRoot(resolvedRoot, resolved);
-  } catch {
-    return false;
-  }
-}
+const MAX_REPO_FILE_BYTES = 1024 * 1024;
 
 /**
  * Read at most `maxBytes` from an open handle; null when the file holds more.
@@ -88,21 +29,26 @@ function openedWithinRoot(root: string, filePath: string, opened: fs.Stats): boo
  * check, because it re-stats the handle and reads *that* size instead:
  *
  * - a file that grows between the check and the read is read at its new size.
- *   Measured: an fstat that saw 50 bytes followed by a `readFileSync` on the
+ *   Measured: an fstat that saw 50 bytes, followed by a `readFileSync` on the
  *   same handle that returned 550;
  * - a regular file reporting size 0 makes it fall back to reading 8 KB chunks
  *   until EOF with no limit at all. `isFile()` is true and `size` is 0 for
  *   every `/proc` and `/sys` entry, and for size-0 regular files on some FUSE
  *   and network mounts.
  *
- * So the outer size check bounds nothing by itself. Reading the handle here is
+ * So the fstat size check bounds nothing on its own. Reading the handle here is
  * what makes the cap bind.
  *
  * Refuses rather than truncates: half a manifest is neither valid JSON nor a
  * trustworthy `name = "..."`, and a silent truncation is a worse answer than
- * none.
+ * none. The per-chunk copy is required — the scratch buffer is reused — and the
+ * decode happens after the concat, so a multi-byte character straddling a chunk
+ * boundary round-trips intact.
+ *
+ * Exported so the cap can be pinned directly on every platform; the wiring that
+ * uses it can only be pinned where a size-0 regular file exists.
  */
-function readCapped(handle: number, maxBytes: number): string | null {
+export function readCapped(handle: number, maxBytes: number): string | null {
   const chunks: Buffer[] = [];
   const chunk = Buffer.allocUnsafe(64 * 1024);
   let total = 0;
@@ -117,36 +63,37 @@ function readCapped(handle: number, maxBytes: number): string | null {
 }
 
 /**
- * Read a repository-controlled file under `root`, bounded, or null.
+ * Read a repository-controlled file, bounded and type-checked, or null.
  *
  * Open once and ask the handle:
  *
- * - `O_NONBLOCK` so opening a FIFO returns instead of waiting for a writer.
- *   It is the one case a guard placed after the open cannot cover, because
- *   without it the open never returns. Undefined on Windows, where `|` with
- *   undefined degrades to a plain read — and Windows has no FIFO to open this
- *   way.
+ * - `O_NONBLOCK` so opening a FIFO returns instead of waiting for a writer. It
+ *   is the one case a guard placed after the open cannot cover, because without
+ *   it the open never returns. Undefined on Windows, where `|` with undefined
+ *   degrades to a plain read — and Windows has no FIFO to open this way.
  * - `fstat` on the handle rather than `stat` on the path, so the checks and the
  *   read observe the same inode (CodeQL js/file-system-race).
  * - `openSync` follows symlinks, so fstat describes the *target*. `isFile()`
- *   refuses a device, a FIFO and a directory — neither of which a size check
+ *   refuses a device, a FIFO and a directory — none of which a size check
  *   catches, since `/dev/zero` and a FIFO both report size 0.
- * - containment, so a manifest symlinked to `~/.aws/credentials` is refused
- *   rather than read into the graph under the repository's own name.
+ * - `accept`, if given, is the caller's own check on that same open file. It
+ *   runs before any content is read, and is where a containment rule belongs:
+ *   it needs the `fs.Stats` of the handle to tie a resolved path back to the
+ *   file actually held.
  * - the read itself is capped; see {@link readCapped} for why the size check
- *   above does not do that on its own.
+ *   does not do that on its own.
  */
-export function readRepoFile(
-  root: string,
+export function readBoundedFile(
   filePath: string,
-  maxBytes: number = MAX_REPO_FILE_BYTES,
+  opts: { maxBytes?: number; accept?: (opened: fs.Stats) => boolean } = {},
 ): string | null {
+  const { maxBytes = MAX_REPO_FILE_BYTES, accept } = opts;
   try {
     const handle = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
     try {
       const stats = fs.fstatSync(handle);
       if (!stats.isFile() || stats.size > maxBytes) return null;
-      if (!openedWithinRoot(root, filePath, stats)) return null;
+      if (accept && !accept(stats)) return null;
       return readCapped(handle, maxBytes);
     } finally {
       fs.closeSync(handle);

--- a/ix-cli/src/cli/bounded-read.ts
+++ b/ix-cli/src/cli/bounded-read.ts
@@ -1,0 +1,157 @@
+// Bounded reads of repository-controlled files (Ix#465).
+//
+// Ingestion opens files whose *paths and contents the scanned repository
+// chooses*: build manifests (`package.json`, `Cargo.toml`, `go.mod`, ...) and
+// TypeScript configs. Both are read while the resolver and the system map are
+// built, which happens before ingestion's own size gate, so they need their
+// own — and the guard has to survive a repo that is hostile rather than merely
+// large.
+//
+// This module is the one place that guard lives. It previously existed twice,
+// in `ts-module-resolution.ts` and `system.ts`, which is how the two defects
+// below came to be fixed in one copy and not the other.
+
+import * as fs from "node:fs";
+import * as nodePath from "node:path";
+
+/**
+ * How much of a repository-controlled file is worth reading, in bytes.
+ *
+ * Mirrors `MAX_FILE_BYTES` in `ingest.ts`. A `package.json` or a `tsconfig.json`
+ * past this is not one anybody wrote, and parsing one is how a 64 MB file takes
+ * the process out with an uncatchable OOM.
+ */
+export const MAX_REPO_FILE_BYTES = 1024 * 1024;
+
+/**
+ * Lexical containment: `candidate` names a path under `root`.
+ *
+ * Not sufficient on its own — see {@link openedWithinRoot} — but it is the
+ * right check for a path that has not been opened yet.
+ */
+export function isWithinRoot(root: string, candidate: string): boolean {
+  const relative = nodePath.relative(nodePath.resolve(root), candidate);
+  // Compare path *segments*: a bare `..startsWith` also rejects a legitimate
+  // sibling directory whose name merely begins with dots, e.g. `..shared/`.
+  return (
+    relative !== "" &&
+    relative !== ".." &&
+    !relative.startsWith(`..${nodePath.sep}`) &&
+    !nodePath.isAbsolute(relative)
+  );
+}
+
+/**
+ * True when the file we are *holding open* lives inside `root`.
+ *
+ * The lexical check in {@link isWithinRoot} cannot see through a symlinked
+ * file: every segment of `./pkg/package.json` is inside the root by path
+ * arithmetic even when `package.json` points somewhere else entirely. Only the
+ * resolved path shows that, so resolve it and re-check.
+ *
+ * Resolving the name a second time reopens the question of whether it still
+ * denotes the file we hold, so the resolved path is confirmed to be the same
+ * inode as the open handle. Without that, swapping the symlink between the open
+ * and the resolve would let an outside file be read under an inside name.
+ * (`ino` is 0 on filesystems that do not report one — chiefly some Windows
+ * configurations — where this degrades to the plain resolved-path check.)
+ *
+ * The ROOT is resolved too, and that is not symmetry for its own sake: a
+ * resolved file compared against an unresolved root rejects every file whenever
+ * the root is itself reached through a link — macOS `/var` -> `/private/var`, a
+ * home directory on a network mount, a `~/code` symlink, or a pnpm workspace
+ * whose package directory is a symlink. That would silently switch manifest and
+ * tsconfig reading off for those users, and no CI runner here has a symlinked
+ * root to notice it.
+ */
+function openedWithinRoot(root: string, filePath: string, opened: fs.Stats): boolean {
+  try {
+    const resolved = fs.realpathSync(filePath);
+    const viaResolved = fs.statSync(resolved);
+    if (viaResolved.dev !== opened.dev || viaResolved.ino !== opened.ino) return false;
+    let resolvedRoot: string;
+    try {
+      resolvedRoot = fs.realpathSync(root);
+    } catch {
+      resolvedRoot = root; // unreadable root: fall back to the lexical check
+    }
+    return isWithinRoot(resolvedRoot, resolved);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read at most `maxBytes` from an open handle; null when the file holds more.
+ *
+ * `fs.readFileSync(handle)` cannot be used here, even behind an fstat size
+ * check, because it re-stats the handle and reads *that* size instead:
+ *
+ * - a file that grows between the check and the read is read at its new size.
+ *   Measured: an fstat that saw 50 bytes followed by a `readFileSync` on the
+ *   same handle that returned 550;
+ * - a regular file reporting size 0 makes it fall back to reading 8 KB chunks
+ *   until EOF with no limit at all. `isFile()` is true and `size` is 0 for
+ *   every `/proc` and `/sys` entry, and for size-0 regular files on some FUSE
+ *   and network mounts.
+ *
+ * So the outer size check bounds nothing by itself. Reading the handle here is
+ * what makes the cap bind.
+ *
+ * Refuses rather than truncates: half a manifest is neither valid JSON nor a
+ * trustworthy `name = "..."`, and a silent truncation is a worse answer than
+ * none.
+ */
+function readCapped(handle: number, maxBytes: number): string | null {
+  const chunks: Buffer[] = [];
+  const chunk = Buffer.allocUnsafe(64 * 1024);
+  let total = 0;
+  for (;;) {
+    const bytes = fs.readSync(handle, chunk, 0, chunk.length, null);
+    if (bytes === 0) break;
+    total += bytes;
+    if (total > maxBytes) return null;
+    chunks.push(Buffer.from(chunk.subarray(0, bytes)));
+  }
+  return Buffer.concat(chunks, total).toString("utf8");
+}
+
+/**
+ * Read a repository-controlled file under `root`, bounded, or null.
+ *
+ * Open once and ask the handle:
+ *
+ * - `O_NONBLOCK` so opening a FIFO returns instead of waiting for a writer.
+ *   It is the one case a guard placed after the open cannot cover, because
+ *   without it the open never returns. Undefined on Windows, where `|` with
+ *   undefined degrades to a plain read — and Windows has no FIFO to open this
+ *   way.
+ * - `fstat` on the handle rather than `stat` on the path, so the checks and the
+ *   read observe the same inode (CodeQL js/file-system-race).
+ * - `openSync` follows symlinks, so fstat describes the *target*. `isFile()`
+ *   refuses a device, a FIFO and a directory — neither of which a size check
+ *   catches, since `/dev/zero` and a FIFO both report size 0.
+ * - containment, so a manifest symlinked to `~/.aws/credentials` is refused
+ *   rather than read into the graph under the repository's own name.
+ * - the read itself is capped; see {@link readCapped} for why the size check
+ *   above does not do that on its own.
+ */
+export function readRepoFile(
+  root: string,
+  filePath: string,
+  maxBytes: number = MAX_REPO_FILE_BYTES,
+): string | null {
+  try {
+    const handle = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+    try {
+      const stats = fs.fstatSync(handle);
+      if (!stats.isFile() || stats.size > maxBytes) return null;
+      if (!openedWithinRoot(root, filePath, stats)) return null;
+      return readCapped(handle, maxBytes);
+    } finally {
+      fs.closeSync(handle);
+    }
+  } catch {
+    return null;
+  }
+}

--- a/ix-cli/src/cli/system.ts
+++ b/ix-cli/src/cli/system.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as nodePath from "node:path";
 import { createHash } from "node:crypto";
-import { MAX_REPO_FILE_BYTES, readRepoFile } from "./bounded-read.js";
+import { readBoundedFile } from "./bounded-read.js";
 
 /**
  * Multi-repo system auto-detection (Ix#225 Path 1).
@@ -50,11 +50,17 @@ function isRepoRoot(dir: string): boolean {
  * `Cargo.toml` does the same without needing a symlink.
  *
  * The guard is shared with the module resolver, which reads tsconfigs under
- * exactly these conditions; `readRepoFile` documents what each part of it is
+ * exactly these conditions; `readBoundedFile` documents what each part of it is
  * for, and why a size check alone bounds nothing.
+ *
+ * No containment check: the only root available here is the scanned directory
+ * itself, and rooting there both refuses manifests a repo legitimately symlinks
+ * within itself AND fails to refuse the case worth refusing, since a symlinked
+ * member directory resolves to its own target. Containment for this path needs
+ * the ingest root, which this module is not given.
  */
 function readManifest(dir: string, file: string): string | null {
-  return readRepoFile(dir, nodePath.join(dir, file), MAX_REPO_FILE_BYTES);
+  return readBoundedFile(nodePath.join(dir, file));
 }
 
 /** A directory is its own git repository iff it contains a `.git` entry (a dir

--- a/ix-cli/src/cli/system.ts
+++ b/ix-cli/src/cli/system.ts
@@ -42,6 +42,57 @@ function isRepoRoot(dir: string): boolean {
  *  for a normal clone, or a file for a submodule/worktree). This is the
  *  ground-truth signal that a child is a DISTINCT repository — a monorepo's
  *  package dirs never have their own .git (they share the root's). */
+/**
+ * How much of a build manifest is worth reading, in bytes.
+ *
+ * The same 1 MB the ingest walker gives a source file and the module resolver
+ * gives a tsconfig. A `package.json` past that is not a manifest anyone wrote.
+ */
+const MAX_MANIFEST_BYTES = 1024 * 1024;
+
+/**
+ * Read a manifest out of a scanned directory, or null.
+ *
+ * Every path this module reads is *named by the repository being scanned*, and
+ * these three readers were the last ones in the ingest path with no guard on
+ * what came back. `readFileSync(path, "utf8")` will happily follow
+ * `package.json -> /dev/zero` and never return — verified: it does not throw,
+ * it consumes memory until the process dies — and a plain 2 GB `Cargo.toml`
+ * does the same without needing a symlink.
+ *
+ * The same shape as `readObject` in ts-module-resolution.ts, whose comment
+ * makes the point this file missed: manifests "sit outside ingestion's own
+ * size gate, so they need their own". Open once and ask the handle:
+ *
+ * - `O_NONBLOCK` so opening a FIFO returns instead of waiting for a writer.
+ *   Undefined on Windows, where it degrades to a plain read — and Windows has
+ *   no FIFO to open this way.
+ * - `fstat` on the handle rather than `stat` on the path: same open file, so
+ *   there is no window between the check and the read for the file to change
+ *   (CodeQL js/file-system-race).
+ * - `isFile()` refuses a device, a FIFO and a directory. A size check cannot:
+ *   `/dev/zero` and a FIFO both report size 0.
+ * - `size` refuses the honest-but-enormous file, at the same 1 MB the ingest
+ *   walker gives a source file.
+ */
+function readManifest(dir: string, file: string): string | null {
+  try {
+    const handle = fs.openSync(
+      nodePath.join(dir, file),
+      fs.constants.O_RDONLY | fs.constants.O_NONBLOCK,
+    );
+    try {
+      const stats = fs.fstatSync(handle);
+      if (!stats.isFile() || stats.size > MAX_MANIFEST_BYTES) return null;
+      return fs.readFileSync(handle, "utf8");
+    } finally {
+      fs.closeSync(handle);
+    }
+  } catch {
+    return null;
+  }
+}
+
 function hasOwnGit(dir: string): boolean {
   try { return fs.existsSync(nodePath.join(dir, ".git")); } catch { return false; }
 }
@@ -54,7 +105,7 @@ function hasOwnGit(dir: string): boolean {
  */
 function hasWorkspaceMarker(dir: string): boolean {
   const has = (f: string) => { try { return fs.existsSync(nodePath.join(dir, f)); } catch { return false; } };
-  const reads = (f: string): string | null => { try { return fs.readFileSync(nodePath.join(dir, f), "utf8"); } catch { return null; } };
+  const reads = (f: string): string | null => readManifest(dir, f);
   // Dedicated workspace/monorepo config files.
   if (has("pnpm-workspace.yaml") || has("lerna.json") || has("nx.json") ||
       has("turbo.json") || has("rush.json") || has("go.work") ||
@@ -97,9 +148,7 @@ function isInsideSingleRepo(dir: string): boolean {
  */
 export function readPackageNames(dir: string): string[] {
   const names = new Set<string>();
-  const read = (f: string): string | null => {
-    try { return fs.readFileSync(nodePath.join(dir, f), "utf8"); } catch { return null; }
-  };
+  const read = (f: string): string | null => readManifest(dir, f);
   const add = (n: unknown) => { if (typeof n === "string" && n.trim()) names.add(n.trim()); };
 
   const pkg = read("package.json");                                  // JS / TS
@@ -192,9 +241,7 @@ export function lookupPackage(registry: Record<string, string>, mod: string): st
  */
 export function readPackageDeps(dir: string): string[] {
   const deps = new Set<string>();
-  const read = (f: string): string | null => {
-    try { return fs.readFileSync(nodePath.join(dir, f), "utf8"); } catch { return null; }
-  };
+  const read = (f: string): string | null => readManifest(dir, f);
   const add = (n: unknown) => { if (typeof n === "string" && n.trim()) deps.add(n.trim()); };
 
   // PRODUCTION deps only. The declared-dependency graph gates cross-repo edges,

--- a/ix-cli/src/cli/system.ts
+++ b/ix-cli/src/cli/system.ts
@@ -53,11 +53,21 @@ function isRepoRoot(dir: string): boolean {
  * exactly these conditions; `readBoundedFile` documents what each part of it is
  * for, and why a size check alone bounds nothing.
  *
- * No containment check: the only root available here is the scanned directory
- * itself, and rooting there both refuses manifests a repo legitimately symlinks
- * within itself AND fails to refuse the case worth refusing, since a symlinked
- * member directory resolves to its own target. Containment for this path needs
- * the ingest root, which this module is not given.
+ * No containment check, deliberately. Both roots that could be used here break
+ * a layout that works today, and break it silently:
+ *
+ * - the scanned directory itself refuses a manifest a repo legitimately
+ *   symlinks within itself, and does not refuse the case worth refusing — a
+ *   symlinked member directory resolves root and file to the same outside tree;
+ * - the mapped root refuses every symlinked member repo, which `detectSystem`
+ *   has admitted on purpose since Ix#225 (see the `isSymbolicLink()` filter
+ *   below): a folder collecting independently-cloned repos is exactly what it
+ *   is for, and collecting them by symlink is the ordinary way to do it.
+ *
+ * A refusal here is indistinguishable from "no manifest", so either choice
+ * deletes a package from the registry with nothing said. Confining what a
+ * scanned repo may name is worth doing, but it needs a diagnostic and a way
+ * out, not a silent default bolted onto a read.
  */
 function readManifest(dir: string, file: string): string | null {
   return readBoundedFile(nodePath.join(dir, file));

--- a/ix-cli/src/cli/system.ts
+++ b/ix-cli/src/cli/system.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as nodePath from "node:path";
 import { createHash } from "node:crypto";
+import { MAX_REPO_FILE_BYTES, readRepoFile } from "./bounded-read.js";
 
 /**
  * Multi-repo system auto-detection (Ix#225 Path 1).
@@ -38,61 +39,28 @@ function isRepoRoot(dir: string): boolean {
   }
 }
 
+/**
+ * Read a build manifest out of a scanned directory, or null.
+ *
+ * Every path this module reads is *named by the repository being scanned*, so a
+ * hostile or merely broken one decides what `ix map` opens. These three readers
+ * were the last ones in the ingest path with no guard on what came back: a bare
+ * `readFileSync` follows `package.json -> /dev/zero` and never returns — it does
+ * not throw, it consumes memory until the process dies — and a plain 2 GB
+ * `Cargo.toml` does the same without needing a symlink.
+ *
+ * The guard is shared with the module resolver, which reads tsconfigs under
+ * exactly these conditions; `readRepoFile` documents what each part of it is
+ * for, and why a size check alone bounds nothing.
+ */
+function readManifest(dir: string, file: string): string | null {
+  return readRepoFile(dir, nodePath.join(dir, file), MAX_REPO_FILE_BYTES);
+}
+
 /** A directory is its own git repository iff it contains a `.git` entry (a dir
  *  for a normal clone, or a file for a submodule/worktree). This is the
  *  ground-truth signal that a child is a DISTINCT repository — a monorepo's
  *  package dirs never have their own .git (they share the root's). */
-/**
- * How much of a build manifest is worth reading, in bytes.
- *
- * The same 1 MB the ingest walker gives a source file and the module resolver
- * gives a tsconfig. A `package.json` past that is not a manifest anyone wrote.
- */
-const MAX_MANIFEST_BYTES = 1024 * 1024;
-
-/**
- * Read a manifest out of a scanned directory, or null.
- *
- * Every path this module reads is *named by the repository being scanned*, and
- * these three readers were the last ones in the ingest path with no guard on
- * what came back. `readFileSync(path, "utf8")` will happily follow
- * `package.json -> /dev/zero` and never return — verified: it does not throw,
- * it consumes memory until the process dies — and a plain 2 GB `Cargo.toml`
- * does the same without needing a symlink.
- *
- * The same shape as `readObject` in ts-module-resolution.ts, whose comment
- * makes the point this file missed: manifests "sit outside ingestion's own
- * size gate, so they need their own". Open once and ask the handle:
- *
- * - `O_NONBLOCK` so opening a FIFO returns instead of waiting for a writer.
- *   Undefined on Windows, where it degrades to a plain read — and Windows has
- *   no FIFO to open this way.
- * - `fstat` on the handle rather than `stat` on the path: same open file, so
- *   there is no window between the check and the read for the file to change
- *   (CodeQL js/file-system-race).
- * - `isFile()` refuses a device, a FIFO and a directory. A size check cannot:
- *   `/dev/zero` and a FIFO both report size 0.
- * - `size` refuses the honest-but-enormous file, at the same 1 MB the ingest
- *   walker gives a source file.
- */
-function readManifest(dir: string, file: string): string | null {
-  try {
-    const handle = fs.openSync(
-      nodePath.join(dir, file),
-      fs.constants.O_RDONLY | fs.constants.O_NONBLOCK,
-    );
-    try {
-      const stats = fs.fstatSync(handle);
-      if (!stats.isFile() || stats.size > MAX_MANIFEST_BYTES) return null;
-      return fs.readFileSync(handle, "utf8");
-    } finally {
-      fs.closeSync(handle);
-    }
-  } catch {
-    return null;
-  }
-}
-
 function hasOwnGit(dir: string): boolean {
   try { return fs.existsSync(nodePath.join(dir, ".git")); } catch { return false; }
 }

--- a/ix-cli/src/cli/ts-module-resolution.ts
+++ b/ix-cli/src/cli/ts-module-resolution.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as nodePath from "node:path";
+import { MAX_REPO_FILE_BYTES, isWithinRoot, readRepoFile } from "./bounded-read.js";
 
 interface PathRule {
   pattern: string;
@@ -133,82 +134,17 @@ function parseJsonc(text: string): unknown {
 }
 
 /**
+ * Read and parse a tsconfig, or undefined.
+ *
  * Config files are read while the resolver is built, which happens *before*
- * ingestion's own size gate, so they need their own. Mirrors `MAX_FILE_BYTES`
- * in `ingest.ts`: anything larger is not a tsconfig, and parsing one is how a
- * 64 MB JSONC file takes the process out with an uncatchable OOM.
+ * ingestion's own size gate, and their paths are named by the repository being
+ * ingested — so the read needs its own bound and its own containment check.
+ * Both live in `readRepoFile`, which the ingest-path manifest readers share.
  */
-const MAX_CONFIG_BYTES = 1024 * 1024;
-
-/**
- * True when the file we are *holding open* lives inside the workspace.
- *
- * The lexical check in {@link isWithinWorkspace} cannot see through a symlinked
- * directory: every segment of `./linked/tsconfig.json` is inside the workspace
- * by path arithmetic even when `linked/` points somewhere else entirely. Only
- * the resolved path shows that, so resolve it and re-check.
- *
- * Resolving the name a second time reopens the question of whether it still
- * denotes the file we hold, so the resolved path is confirmed to be the same
- * inode as the open handle. Without that, swapping the symlink between the open
- * and the resolve would let an outside file be read under an inside name.
- * (`ino` is 0 on filesystems that do not report one — chiefly some Windows
- * configurations — where this degrades to the plain resolved-path check.)
- *
- * The ROOT is resolved too, and that is not symmetry for its own sake: a
- * resolved file compared against an unresolved root rejects every config
- * whenever the workspace is itself reached through a link — macOS `/var` ->
- * `/private/var`, a home directory on a network mount, a `~/code` symlink. That
- * would silently switch tsconfig resolution off for those users, and no CI
- * runner here has a symlinked root to notice it.
- */
-function openedWithinWorkspace(
-  workspaceRoot: string,
-  filePath: string,
-  opened: fs.Stats,
-): boolean {
-  try {
-    const resolved = fs.realpathSync(filePath);
-    const viaResolved = fs.statSync(resolved);
-    if (viaResolved.dev !== opened.dev || viaResolved.ino !== opened.ino) return false;
-    let resolvedRoot: string;
-    try {
-      resolvedRoot = fs.realpathSync(workspaceRoot);
-    } catch {
-      resolvedRoot = workspaceRoot; // unreadable root: fall back to the lexical check
-    }
-    return isWithinWorkspace(resolvedRoot, resolved);
-  } catch {
-    return false;
-  }
-}
-
 function readObject(workspaceRoot: string, filePath: string): Record<string, unknown> | undefined {
+  const text = readRepoFile(workspaceRoot, filePath, MAX_REPO_FILE_BYTES);
+  if (text === null) return undefined;
   try {
-    // Open once and fstat the same handle so the checks and the read observe the
-    // same inode — no stat-then-read window (CodeQL js/file-system-race). This is
-    // the pattern ingest.ts already uses.
-    //
-    // O_NONBLOCK is load-bearing, not tidiness: opening a FIFO for reading
-    // *blocks until a writer appears*, so without it the open never returns and
-    // no later check can help. It is the one case a guard placed after the open
-    // cannot cover. Undefined on Windows, where `|` with undefined degrades to
-    // a plain read — and Windows has no FIFO to open this way.
-    const handle = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
-    let text: string;
-    try {
-      const stats = fs.fstatSync(handle);
-      // `openSync` follows symlinks, so fstat describes the *target*. Refusing
-      // anything that is not a regular file is what stops a link to /dev/zero
-      // (an unbounded read) and a FIFO (which would otherwise deliver no data
-      // and no EOF) — neither of which a size check catches, since both
-      // report size 0.
-      if (!stats.isFile() || stats.size > MAX_CONFIG_BYTES) return undefined;
-      if (!openedWithinWorkspace(workspaceRoot, filePath, stats)) return undefined;
-      text = fs.readFileSync(handle, "utf8");
-    } finally {
-      fs.closeSync(handle);
-    }
     const parsed = parseJsonc(text);
     return parsed && typeof parsed === "object" && !Array.isArray(parsed)
       ? (parsed as Record<string, unknown>)
@@ -232,19 +168,7 @@ function resolveExtends(workspaceRoot: string, configPath: string, value: unknow
     // filesystem root, so "../../../../../../.." names any absolute path from
     // any depth. The config is repo content, so without this an ingested repo
     // chooses which files on the machine get read.
-    (candidate) => isWithinWorkspace(workspaceRoot, candidate),
-  );
-}
-
-function isWithinWorkspace(workspaceRoot: string, candidate: string): boolean {
-  const relative = nodePath.relative(nodePath.resolve(workspaceRoot), candidate);
-  // Compare path *segments*: a bare `..startsWith` also rejects a legitimate
-  // sibling directory whose name merely begins with dots, e.g. `..shared/`.
-  return (
-    relative !== "" &&
-    relative !== ".." &&
-    !relative.startsWith(`..${nodePath.sep}`) &&
-    !nodePath.isAbsolute(relative)
+    (candidate) => isWithinRoot(workspaceRoot, candidate),
   );
 }
 

--- a/ix-cli/src/cli/ts-module-resolution.ts
+++ b/ix-cli/src/cli/ts-module-resolution.ts
@@ -134,14 +134,6 @@ function parseJsonc(text: string): unknown {
 }
 
 /**
- * Config files are read while the resolver is built, which happens *before*
- * ingestion's own size gate, so they need their own. Mirrors `MAX_FILE_BYTES`
- * in `ingest.ts`: anything larger is not a tsconfig, and parsing one is how a
- * 64 MB JSONC file takes the process out with an uncatchable OOM.
- */
-const MAX_CONFIG_BYTES = 1024 * 1024;
-
-/**
  * True when the file we are *holding open* lives inside the workspace.
  *
  * The lexical check in {@link isWithinWorkspace} cannot see through a symlinked
@@ -191,7 +183,6 @@ function readObject(workspaceRoot: string, filePath: string): Record<string, unk
   // it is measured against is this caller's, and it runs on the same open
   // handle, before any content is read.
   const text = readBoundedFile(filePath, {
-    maxBytes: MAX_CONFIG_BYTES,
     accept: (stats) => openedWithinWorkspace(workspaceRoot, filePath, stats),
   });
   if (text === null) return undefined;

--- a/ix-cli/src/cli/ts-module-resolution.ts
+++ b/ix-cli/src/cli/ts-module-resolution.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as nodePath from "node:path";
-import { MAX_REPO_FILE_BYTES, isWithinRoot, readRepoFile } from "./bounded-read.js";
+import { readBoundedFile } from "./bounded-read.js";
 
 interface PathRule {
   pattern: string;
@@ -134,15 +134,66 @@ function parseJsonc(text: string): unknown {
 }
 
 /**
- * Read and parse a tsconfig, or undefined.
- *
  * Config files are read while the resolver is built, which happens *before*
- * ingestion's own size gate, and their paths are named by the repository being
- * ingested — so the read needs its own bound and its own containment check.
- * Both live in `readRepoFile`, which the ingest-path manifest readers share.
+ * ingestion's own size gate, so they need their own. Mirrors `MAX_FILE_BYTES`
+ * in `ingest.ts`: anything larger is not a tsconfig, and parsing one is how a
+ * 64 MB JSONC file takes the process out with an uncatchable OOM.
  */
+const MAX_CONFIG_BYTES = 1024 * 1024;
+
+/**
+ * True when the file we are *holding open* lives inside the workspace.
+ *
+ * The lexical check in {@link isWithinWorkspace} cannot see through a symlinked
+ * directory: every segment of `./linked/tsconfig.json` is inside the workspace
+ * by path arithmetic even when `linked/` points somewhere else entirely. Only
+ * the resolved path shows that, so resolve it and re-check.
+ *
+ * Resolving the name a second time reopens the question of whether it still
+ * denotes the file we hold, so the resolved path is confirmed to be the same
+ * inode as the open handle. Without that, swapping the symlink between the open
+ * and the resolve would let an outside file be read under an inside name.
+ * (`ino` is 0 on filesystems that do not report one — chiefly some Windows
+ * configurations — where this degrades to the plain resolved-path check.)
+ *
+ * The ROOT is resolved too, and that is not symmetry for its own sake: a
+ * resolved file compared against an unresolved root rejects every config
+ * whenever the workspace is itself reached through a link — macOS `/var` ->
+ * `/private/var`, a home directory on a network mount, a `~/code` symlink. That
+ * would silently switch tsconfig resolution off for those users, and no CI
+ * runner here has a symlinked root to notice it.
+ */
+function openedWithinWorkspace(
+  workspaceRoot: string,
+  filePath: string,
+  opened: fs.Stats,
+): boolean {
+  try {
+    const resolved = fs.realpathSync(filePath);
+    const viaResolved = fs.statSync(resolved);
+    if (viaResolved.dev !== opened.dev || viaResolved.ino !== opened.ino) return false;
+    let resolvedRoot: string;
+    try {
+      resolvedRoot = fs.realpathSync(workspaceRoot);
+    } catch {
+      resolvedRoot = workspaceRoot; // unreadable root: fall back to the lexical check
+    }
+    return isWithinWorkspace(resolvedRoot, resolved);
+  } catch {
+    return false;
+  }
+}
+
 function readObject(workspaceRoot: string, filePath: string): Record<string, unknown> | undefined {
-  const text = readRepoFile(workspaceRoot, filePath, MAX_REPO_FILE_BYTES);
+  // The FIFO-safe open, the regular-file check and the bound are shared with
+  // the manifest readers — see bounded-read.ts, which also explains why the
+  // size check alone does not bound the read. Containment stays here: the root
+  // it is measured against is this caller's, and it runs on the same open
+  // handle, before any content is read.
+  const text = readBoundedFile(filePath, {
+    maxBytes: MAX_CONFIG_BYTES,
+    accept: (stats) => openedWithinWorkspace(workspaceRoot, filePath, stats),
+  });
   if (text === null) return undefined;
   try {
     const parsed = parseJsonc(text);
@@ -168,7 +219,19 @@ function resolveExtends(workspaceRoot: string, configPath: string, value: unknow
     // filesystem root, so "../../../../../../.." names any absolute path from
     // any depth. The config is repo content, so without this an ingested repo
     // chooses which files on the machine get read.
-    (candidate) => isWithinRoot(workspaceRoot, candidate),
+    (candidate) => isWithinWorkspace(workspaceRoot, candidate),
+  );
+}
+
+function isWithinWorkspace(workspaceRoot: string, candidate: string): boolean {
+  const relative = nodePath.relative(nodePath.resolve(workspaceRoot), candidate);
+  // Compare path *segments*: a bare `..startsWith` also rejects a legitimate
+  // sibling directory whose name merely begins with dots, e.g. `..shared/`.
+  return (
+    relative !== "" &&
+    relative !== ".." &&
+    !relative.startsWith(`..${nodePath.sep}`) &&
+    !nodePath.isAbsolute(relative)
   );
 }
 


### PR DESCRIPTION
Found while sweeping for 0.10.0. Not filed as an issue; it is the last unguarded read in the ingest path.

## The problem

`system.ts` reads `package.json`, `Cargo.toml`, `pom.xml`, `go.mod` and the rest **by name, out of whatever directory is being scanned**, with a bare `fs.readFileSync(path, "utf8")` in three places.

`readFileSync` does not fail on `package.json -> /dev/zero`. It does not return either — it consumes memory until the process dies. Measured: the call had to be killed after 15s. A plain 2 GB `Cargo.toml` does the same without needing a symlink, and a FIFO blocks whatever opens it.

This is reachable from `ix map`, `ix ingest` and `ix view` — anywhere a repository the user did not write gets scanned.

## The fix

One `readManifest`, `statSync` before the read, in that order:

- it **follows** the symlink, so the check applies to what would actually be read rather than to the link;
- `isFile()` refuses a device, a FIFO and a directory. **Stat rather than open** — opening a FIFO blocks until a writer appears, so a guard that opened would be the thing that hung;
- `size` refuses the honest-but-enormous file, at the same 1 MB the ingest walker already gives a source file.

That shape is `loadConfig`'s in `ts-module-resolution.ts`, whose comment makes the point this file missed: manifests *"sit outside ingestion's own size gate, so they need their own"*. `system.ts` was the third such reader and never got one.

## Tests

- an ordinary manifest still reads
- an oversized one is refused — **and the test goes red with the cap removed**, so it is the cap doing the work, not the JSON parse failing
- a manifest that is a directory is refused
- POSIX only: a manifest symlinked to `/dev/zero`, and a manifest that is a FIFO, both return promptly rather than never. Skipped on Windows, which has neither.

The device and FIFO guards are the two I could not prove by removal without hanging or OOM-ing the runner; they are covered by `isFile()` and by the direct measurement above.

1000 tests green, lint, typecheck and knip clean.