### PR TITLE
feat(upgrade): take the backend's word for which release is running

### DIFF
--- a/ix-cli/src/cli/__tests__/backend-release-report.test.ts
+++ b/ix-cli/src/cli/__tests__/backend-release-report.test.ts
@@ -133,7 +133,9 @@ describe("recordBackendRelease", () => {
     // release pipeline. Absent must leave whatever was tracked alone.
     writeFileSync(stamp(), "1.0.13");
     const { recordBackendRelease } = await load();
-    for (const nothing of [undefined, null, "", "   "]) {
+    // 1016 and {} are what a backend can actually send: HealthResponse types
+    // the field, but nothing validates the JSON at runtime.
+    for (const nothing of [undefined, null, "", "   ", 1016 as any, {} as any]) {
       expect(recordBackendRelease(nothing, FEED, isNewer)).toBe(false);
       expect(tracked()).toBe("1.0.13");
     }
@@ -187,10 +189,134 @@ describe("recordBackendRelease", () => {
   });
 });
 
+/**
+ * The ceiling comes from the BACKEND release feed, not the CLI's own.
+ *
+ * One word apart, and the two are different version series — so taking `latest`
+ * would make the ceiling the CLI's version (0.9.x), refuse every legitimate
+ * container report for ever, and silently reinstate the bug this exists to fix.
+ */
+describe("backendCeiling", () => {
+  let home: string;
+  let priorHome: string | undefined;
+
+  beforeEach(() => {
+    priorHome = process.env.IX_HOME;
+    home = mkdtempSync(join(tmpdir(), "ix-ceiling-"));
+    process.env.IX_HOME = home;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    if (priorHome === undefined) delete process.env.IX_HOME;
+    else process.env.IX_HOME = priorHome;
+    rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  });
+
+  it("reads the backend release, not the CLI release", async () => {
+    writeFileSync(
+      join(home, ".version-check.json"),
+      // Deliberately different series, the way they are in reality.
+      JSON.stringify({ latest: "0.9.3", backendLatest: "1.0.16", checkedAt: Date.now() }),
+    );
+    const { backendCeiling } = await import("../commands/upgrade.js");
+    expect(backendCeiling()).toBe("1.0.16");
+  });
+
+  it("is null when nothing is cached yet", async () => {
+    const { backendCeiling } = await import("../commands/upgrade.js");
+    expect(backendCeiling()).toBeNull();
+  });
+});
+
+/**
+ * The wiring, not the helpers. Every other test here calls recordBackendRelease
+ * or isLocalEndpoint directly with hand-built arguments — so gutting the one
+ * line in fetchBackendHealth that connects them left the whole suite green.
+ */
+describe("fetchBackendHealth records what it read", () => {
+  let home: string;
+  let priorHome: string | undefined;
+
+  beforeEach(() => {
+    priorHome = process.env.IX_HOME;
+    home = mkdtempSync(join(tmpdir(), "ix-fetch-health-"));
+    process.env.IX_HOME = home;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    if (priorHome === undefined) delete process.env.IX_HOME;
+    else process.env.IX_HOME = priorHome;
+    rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  });
+
+  const stamp = () => join(home, ".backend-version");
+  const tracked = () => (existsSync(stamp()) ? readFileSync(stamp(), "utf-8") : null);
+
+  /** Only what fetchBackendHealth touches: the endpoint and health(). */
+  const fakeClient = (endpoint: string, health: unknown) =>
+    ({ endpoint, health: async () => health }) as never;
+
+  it("records the release for a local backend", async () => {
+    writeFileSync(stamp(), "1.0.13");
+    const { fetchBackendHealth } = await import("../backend-version.js");
+    const got = await fetchBackendHealth(
+      fakeClient("http://localhost:8090", { status: "ok", release_version: "1.0.16" }),
+      "1.0.16",
+      isNewer,
+    );
+    expect(got).toMatchObject({ status: "ok" }); // still returns the response
+    expect(tracked()).toBe("1.0.16");
+  });
+
+  it("does NOT record for a remote endpoint", async () => {
+    writeFileSync(stamp(), "1.0.13");
+    const { fetchBackendHealth } = await import("../backend-version.js");
+    await fetchBackendHealth(
+      fakeClient("http://staging:8090", { status: "ok", release_version: "1.0.16" }),
+      "1.0.16",
+      isNewer,
+    );
+    expect(tracked()).toBe("1.0.13");
+  });
+
+  it("records nothing when the backend omits the field", async () => {
+    writeFileSync(stamp(), "1.0.13");
+    const { fetchBackendHealth } = await import("../backend-version.js");
+    await fetchBackendHealth(
+      fakeClient("http://localhost:8090", { status: "ok" }),
+      "1.0.16",
+      isNewer,
+    );
+    expect(tracked()).toBe("1.0.13");
+  });
+
+  it("still refuses a claim above the ceiling, through this path too", async () => {
+    writeFileSync(stamp(), "1.0.13");
+    const { fetchBackendHealth } = await import("../backend-version.js");
+    await fetchBackendHealth(
+      fakeClient("http://localhost:8090", { status: "ok", release_version: "99.0.0" }),
+      "1.0.16",
+      isNewer,
+    );
+    expect(tracked()).toBe("1.0.13");
+  });
+});
+
 describe("isLocalEndpoint", () => {
   it("accepts the local backend the notice is about", async () => {
     const { isLocalEndpoint } = await import("../backend-version.js");
-    for (const e of ["http://localhost:8090", "http://127.0.0.1:8090", "http://[::1]:8090"]) {
+    for (const e of [
+      "http://localhost:8090",
+      "http://127.0.0.1:8090",
+      "http://[::1]:8090",
+      "http://127.0.0.2:8090", // all of 127.0.0.0/8 is loopback
+      "http://0.0.0.0:8090", // what client/api.ts and errors.ts already accept
+      "http://localhost.:8090", // the fully-qualified form resolvers accept
+    ]) {
       expect(isLocalEndpoint(e)).toBe(true);
     }
   });
@@ -218,7 +344,7 @@ describe("isLocalEndpoint", () => {
  * exactly one such function — the property that makes the design work.
  */
 describe("health is fetched in exactly one place", () => {
-  const SRC = join(HERE, "..");
+  const SRC = join(HERE, "..", "..");
 
   const walk = (dir: string): string[] =>
     readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
@@ -231,6 +357,10 @@ describe("health is fetched in exactly one place", () => {
   // otherwise drop the file out of the search entirely.
   const callers = walk(SRC)
     .map((f) => ({ file: f, src: readFileSync(f, "utf-8") }))
+    // Comments stripped first: this codebase names functions in call syntax in
+    // prose constantly, and a doc comment mentioning client.health() would fail
+    // CI with a message pointing at the wrong problem.
+    .map((f) => ({ ...f, src: f.src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "") }))
     .filter((f) => /\.health\s*\(\s*\)/.test(f.src))
     .map((f) => f.file.slice(SRC.length + 1).replace(/\\/g, "/"));
 
@@ -240,10 +370,11 @@ describe("health is fetched in exactly one place", () => {
   });
 
   it("has only backend-version.ts and backend-status.ts calling .health()", () => {
-    // backend-version.ts is the recording chokepoint. backend-status.ts's
-    // checkBackendSchema is called only by `ix doctor`, which records through
-    // its own reachable check; it cannot import the chokepoint because
-    // upgrade.ts imports IT. Everything else must go through readBackendHealth.
-    expect(callers.sort()).toEqual(["backend-status.ts", "backend-version.ts"]);
+    // Exactly one, across the WHOLE src tree — not just src/cli, which left
+    // src/mcp (it already exposes an ix_health tool) and src/client invisible.
+    // backend-status.ts used to be exempted on a cycle that does not exist:
+    // backend-version.ts imports only node builtins and two erased type
+    // imports, so it now goes through the chokepoint like everything else.
+    expect(callers.sort()).toEqual(["cli/backend-version.ts"]);
   });
 });

--- a/ix-cli/src/cli/__tests__/backend-release-report.test.ts
+++ b/ix-cli/src/cli/__tests__/backend-release-report.test.ts
@@ -14,6 +14,8 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { isNewer } from "../commands/upgrade.js";
+
 const HERE = dirname(fileURLToPath(import.meta.url));
 
 /**
@@ -46,13 +48,16 @@ describe("recordBackendRelease", () => {
   });
 
   /** Re-imported so IX_HOME above is the one the module resolves the stamp from. */
-  const load = () => import("../commands/upgrade.js");
+  const load = () => import("../backend-version.js");
   const stamp = () => join(home, ".backend-version");
   const tracked = () => (existsSync(stamp()) ? readFileSync(stamp(), "utf-8") : null);
 
+  /** The newest release the CLI knows about, from its own version cache. */
+  const FEED = "1.0.16";
+
   it("writes what the backend reports", async () => {
     const { recordBackendRelease } = await load();
-    recordBackendRelease("1.0.16");
+    expect(recordBackendRelease("1.0.16", FEED, isNewer)).toBe(true);
     expect(tracked()).toBe("1.0.16");
   });
 
@@ -61,123 +66,184 @@ describe("recordBackendRelease", () => {
     // the release that was installed and the notice nags for ever.
     writeFileSync(stamp(), "1.0.13");
     const { recordBackendRelease } = await load();
-    recordBackendRelease("1.0.16");
+    recordBackendRelease("1.0.16", FEED, isNewer);
     expect(tracked()).toBe("1.0.16");
   });
 
   it("corrects a stamp that is AHEAD of the running container", async () => {
-    // The direction no local inspection can fix, and the one that is dangerous:
-    // an ahead stamp silences the notice through the next release the user
-    // should have been told about. The container's own answer settles it.
+    // The direction no local inspection can fix, and the dangerous one: an ahead
+    // stamp silences the notice through the next release the user should have
+    // been told about.
     writeFileSync(stamp(), "1.0.17");
     const { recordBackendRelease } = await load();
-    recordBackendRelease("1.0.16");
+    recordBackendRelease("1.0.16", FEED, isNewer);
+    expect(tracked()).toBe("1.0.16");
+  });
+
+  it("REFUSES a container claiming to be newer than any published release", async () => {
+    // The whole reason this value is bounded. A typo in a compose override, or a
+    // tampered image, reporting 99.0.0 would otherwise be written straight in —
+    // after which backendUpdateAvailable is false for ever and `ix upgrade`
+    // reports "already on the latest version" without ever pulling, so a
+    // security release can never reach that machine.
+    writeFileSync(stamp(), "1.0.13");
+    const { recordBackendRelease } = await load();
+    expect(recordBackendRelease("99.0.0", FEED, isNewer)).toBe(false);
+    expect(tracked()).toBe("1.0.13");
+  });
+
+  it("still repairs an ahead stamp when no release is known yet", async () => {
+    // With no cache there is no ceiling, so only corrections that do not move
+    // the stamp FORWARD are taken. That still fixes the dangerous direction and
+    // defers the rest until checkForUpdate populates the cache.
+    writeFileSync(stamp(), "1.0.17");
+    const { recordBackendRelease } = await load();
+    expect(recordBackendRelease("1.0.16", null, isNewer)).toBe(true);
+    expect(tracked()).toBe("1.0.16");
+  });
+
+  it("will not move the stamp forward when no release is known yet", async () => {
+    writeFileSync(stamp(), "1.0.13");
+    const { recordBackendRelease } = await load();
+    expect(recordBackendRelease("1.0.16", null, isNewer)).toBe(false);
+    expect(tracked()).toBe("1.0.13");
+  });
+
+  it("ignores a corrupt ceiling rather than trusting it", async () => {
+    // readCache only checks backendLatest is a string. A garbage ceiling must
+    // fall back to the no-ceiling rule, not admit anything.
+    writeFileSync(stamp(), "1.0.13");
+    const { recordBackendRelease } = await load();
+    expect(recordBackendRelease("99.0.0", "not-a-version", isNewer)).toBe(false);
+    expect(tracked()).toBe("1.0.13");
+  });
+
+  it("trims before matching, so a value with a trailing newline still lands", async () => {
+    // JS `$` does not match before a trailing newline. A value from an
+    // --env-file or a ConfigMap carries one, and without the trim the whole
+    // feature no-ops with nothing to see. getTrackedVersion already trims on
+    // the way out, so the two halves have to agree.
+    const { recordBackendRelease } = await load();
+    expect(recordBackendRelease("1.0.16\n", FEED, isNewer)).toBe(true);
     expect(tracked()).toBe("1.0.16");
   });
 
   it("writes nothing when the backend does not report a release", async () => {
     // Every backend older than Ix-memory#157, and every image not built by the
-    // release pipeline. Absent must leave whatever was tracked alone rather
-    // than clearing it — the old behaviour is the correct fallback.
+    // release pipeline. Absent must leave whatever was tracked alone.
     writeFileSync(stamp(), "1.0.13");
     const { recordBackendRelease } = await load();
-    for (const nothing of [undefined, null, ""]) {
-      recordBackendRelease(nothing);
+    for (const nothing of [undefined, null, "", "   "]) {
+      expect(recordBackendRelease(nothing, FEED, isNewer)).toBe(false);
       expect(tracked()).toBe("1.0.13");
     }
   });
 
-  it("refuses a value that is not version-shaped", async () => {
-    // It is a container env var, so an operator can set it to anything. The
-    // notice compares this file against the release feed; arbitrary text in it
-    // is worse than the stale value it would replace.
+  it("refuses a value that is not version-shaped, or is absurdly long", async () => {
     writeFileSync(stamp(), "1.0.13");
     const { recordBackendRelease } = await load();
     for (const junk of ["latest", "not a version", "../../evil", "9.9.9/../../evil"]) {
-      recordBackendRelease(junk);
+      expect(recordBackendRelease(junk, FEED, isNewer)).toBe(false);
       expect(tracked()).toBe("1.0.13");
     }
+    // Version-shaped the whole way, rejected only by length — so deleting the
+    // bound is caught rather than being masked by the shape test.
+    expect(recordBackendRelease("1.0.0-" + "a".repeat(100), "99.0.0", isNewer)).toBe(false);
+    expect(tracked()).toBe("1.0.13");
   });
 
   it("accepts a release carrying a pre-release and build metadata", async () => {
     // The shape that once broke `ix upgrade`; VERSION_RE admits it deliberately
     // and the backend validates against the same pattern.
     const { recordBackendRelease } = await load();
-    recordBackendRelease("0.9.0-rc.1+abc1234");
+    expect(recordBackendRelease("0.9.0-rc.1+abc1234", "0.9.0-rc.1+abc1234", isNewer)).toBe(true);
     expect(tracked()).toBe("0.9.0-rc.1+abc1234");
   });
 
   it("does not rewrite a stamp that already agrees", async () => {
-    // Runs on every `ix status` / `ix map`, and the write is not atomic: a
-    // needless truncate-and-rewrite on the hot path is a window for a torn read
-    // in another process for no gain.
-    //
-    // Asserted on the MTIME, not the contents: rewriting the same string leaves
-    // the contents identical, so a contents check passes whether or not the
-    // write happened. The mtime is pinned to a known past value first, which a
-    // write would reset to now.
+    // Runs on every `ix status` / `ix map`. Asserted on the MTIME, not the
+    // contents: rewriting the same string leaves the contents identical, so a
+    // contents check passes whether or not the write happened.
     writeFileSync(stamp(), "1.0.16");
     const pinned = new Date("2020-01-02T03:04:05Z");
     utimesSync(stamp(), pinned, pinned);
     const before = statSync(stamp()).mtimeMs;
 
     const { recordBackendRelease } = await load();
-    recordBackendRelease("1.0.16");
-
+    expect(recordBackendRelease("1.0.16", FEED, isNewer)).toBe(false);
     expect(statSync(stamp()).mtimeMs).toBe(before);
-    expect(readFileSync(stamp(), "utf-8")).toBe("1.0.16");
 
-    // ...and the control: a DIFFERENT version does rewrite it, so the assertion
-    // above is the short-circuit and not an mtime that never moves.
-    recordBackendRelease("1.0.17");
+    // ...and the control: a different version DOES rewrite it.
+    recordBackendRelease("1.0.15", FEED, isNewer);
     expect(statSync(stamp()).mtimeMs).not.toBe(before);
-    expect(readFileSync(stamp(), "utf-8")).toBe("1.0.17");
   });
 
-  it("never throws, whatever the stamp path is", async () => {
+  it("never throws when the write fails", async () => {
     // Attached to commands the user actually ran — `ix status` must not fail
     // because IX_HOME is read-only.
     mkdirSync(stamp(), { recursive: true }); // a directory where the file goes
     const { recordBackendRelease } = await load();
-    expect(() => recordBackendRelease("1.0.16")).not.toThrow();
+    expect(() => recordBackendRelease("1.0.16", FEED, isNewer)).not.toThrow();
+  });
+});
+
+describe("isLocalEndpoint", () => {
+  it("accepts the local backend the notice is about", async () => {
+    const { isLocalEndpoint } = await import("../backend-version.js");
+    for (const e of ["http://localhost:8090", "http://127.0.0.1:8090", "http://[::1]:8090"]) {
+      expect(isLocalEndpoint(e)).toBe(true);
+    }
+  });
+
+  it("rejects a remote deployment", async () => {
+    // The stamp is global but the endpoint is per invocation, so
+    // `IX_ENDPOINT=http://staging:8090 ix status` would otherwise record a
+    // different deployment's release into the file that governs the LOCAL
+    // docker image notice.
+    const { isLocalEndpoint } = await import("../backend-version.js");
+    for (const e of ["http://staging:8090", "https://ix.example.com", "http://10.0.0.5:8090"]) {
+      expect(isLocalEndpoint(e)).toBe(false);
+    }
+  });
+
+  it("rejects an unparseable endpoint rather than assuming local", async () => {
+    const { isLocalEndpoint } = await import("../backend-version.js");
+    expect(isLocalEndpoint("not a url")).toBe(false);
   });
 });
 
 /**
- * The recorder is only worth anything at the sites that already hold a health
- * response, and adding one is the kind of thing that gets forgotten. This
- * enumerates them from the source rather than trusting a list in a comment.
+ * Recording happens inside the one function that fetches health, so forgetting
+ * it is not a mistake a new call site can make. This pins that there is still
+ * exactly one such function — the property that makes the design work.
  */
-describe("every site that reads /v1/health records the release", () => {
-  const CMDS = join(HERE, "..", "commands");
+describe("health is fetched in exactly one place", () => {
+  const SRC = join(HERE, "..");
 
-  /** Files that call client.health(), found rather than listed. */
-  const callers = readdirSync(CMDS)
-    .filter((f) => f.endsWith(".ts"))
-    .map((f) => ({ file: f, src: readFileSync(join(CMDS, f), "utf-8") }))
-    .filter((f) => /\bclient\.health\(\)/.test(f.src));
+  const walk = (dir: string): string[] =>
+    readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+      if (e.name === "__tests__" || e.name === "node_modules") return [];
+      const full = join(dir, e.name);
+      return e.isDirectory() ? walk(full) : full.endsWith(".ts") ? [full] : [];
+    });
+
+  // Any receiver, not just one literally named `client`: a renamed local would
+  // otherwise drop the file out of the search entirely.
+  const callers = walk(SRC)
+    .map((f) => ({ file: f, src: readFileSync(f, "utf-8") }))
+    .filter((f) => /\.health\s*\(\s*\)/.test(f.src))
+    .map((f) => f.file.slice(SRC.length + 1).replace(/\\/g, "/"));
 
   it("finds the health callers at all", () => {
-    // Guards the two tests below: an empty list would satisfy any `every`.
-    expect(callers.map((c) => c.file).sort()).toContain("status.ts");
-    expect(callers.length).toBeGreaterThanOrEqual(2);
+    // Guards the assertion below: an empty list would satisfy any comparison.
+    expect(callers.length).toBeGreaterThan(0);
   });
 
-  it("has each of them record what it read", () => {
-    const missing = callers
-      .filter((c) => !/recordBackendRelease\(/.test(c.src))
-      .map((c) => c.file);
-    expect(missing).toEqual([]);
-  });
-
-  it("keeps checkBackendSchema carrying the value out, since it cannot record it itself", () => {
-    // backend-status.ts fetches health too, but importing upgrade.ts there is a
-    // cycle — upgrade.ts already imports it. So it returns the value and its
-    // caller records. If that stops, doctor silently loses the correction.
-    const src = readFileSync(join(HERE, "..", "backend-status.ts"), "utf-8");
-    expect(src).toMatch(/releaseVersion\s*:\s*string\s*\|\s*null/);
-    expect(src).toMatch(/health\.release_version/);
-    const doctor = readFileSync(join(CMDS, "doctor.ts"), "utf-8");
-    expect(doctor).toMatch(/recordBackendRelease\(\s*s\.releaseVersion\s*\)/);
+  it("has only backend-version.ts and backend-status.ts calling .health()", () => {
+    // backend-version.ts is the recording chokepoint. backend-status.ts's
+    // checkBackendSchema is called only by `ix doctor`, which records through
+    // its own reachable check; it cannot import the chokepoint because
+    // upgrade.ts imports IT. Everything else must go through readBackendHealth.
+    expect(callers.sort()).toEqual(["backend-status.ts", "backend-version.ts"]);
   });
 });

--- a/ix-cli/src/cli/__tests__/backend-release-report.test.ts
+++ b/ix-cli/src/cli/__tests__/backend-release-report.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * `.backend-version` used to be a record of what the CLI last INSTALLED, which
+ * is the same thing as what is RUNNING only while nothing else moves the image.
+ * Pull through docker compose and the file names an older release than the
+ * container, so "Backend update available" fires on every command for ever.
+ *
+ * Ix#466 fixed the paths that run our code by recording at the pull.
+ * Ix-memory#157 makes the container report the release it was built as, so the
+ * remaining paths can be fixed by asking it. This is that consumer.
+ */
+describe("recordBackendRelease", () => {
+  let home: string;
+  let priorHome: string | undefined;
+
+  beforeEach(() => {
+    priorHome = process.env.IX_HOME;
+    home = mkdtempSync(join(tmpdir(), "ix-release-report-"));
+    process.env.IX_HOME = home;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    if (priorHome === undefined) delete process.env.IX_HOME;
+    else process.env.IX_HOME = priorHome;
+    rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  });
+
+  /** Re-imported so IX_HOME above is the one the module resolves the stamp from. */
+  const load = () => import("../commands/upgrade.js");
+  const stamp = () => join(home, ".backend-version");
+  const tracked = () => (existsSync(stamp()) ? readFileSync(stamp(), "utf-8") : null);
+
+  it("writes what the backend reports", async () => {
+    const { recordBackendRelease } = await load();
+    recordBackendRelease("1.0.16");
+    expect(tracked()).toBe("1.0.16");
+  });
+
+  it("corrects a stamp that is BEHIND the running container", async () => {
+    // The reported bug: pulled a newer image outside the CLI, so the file names
+    // the release that was installed and the notice nags for ever.
+    writeFileSync(stamp(), "1.0.13");
+    const { recordBackendRelease } = await load();
+    recordBackendRelease("1.0.16");
+    expect(tracked()).toBe("1.0.16");
+  });
+
+  it("corrects a stamp that is AHEAD of the running container", async () => {
+    // The direction no local inspection can fix, and the one that is dangerous:
+    // an ahead stamp silences the notice through the next release the user
+    // should have been told about. The container's own answer settles it.
+    writeFileSync(stamp(), "1.0.17");
+    const { recordBackendRelease } = await load();
+    recordBackendRelease("1.0.16");
+    expect(tracked()).toBe("1.0.16");
+  });
+
+  it("writes nothing when the backend does not report a release", async () => {
+    // Every backend older than Ix-memory#157, and every image not built by the
+    // release pipeline. Absent must leave whatever was tracked alone rather
+    // than clearing it — the old behaviour is the correct fallback.
+    writeFileSync(stamp(), "1.0.13");
+    const { recordBackendRelease } = await load();
+    for (const nothing of [undefined, null, ""]) {
+      recordBackendRelease(nothing);
+      expect(tracked()).toBe("1.0.13");
+    }
+  });
+
+  it("refuses a value that is not version-shaped", async () => {
+    // It is a container env var, so an operator can set it to anything. The
+    // notice compares this file against the release feed; arbitrary text in it
+    // is worse than the stale value it would replace.
+    writeFileSync(stamp(), "1.0.13");
+    const { recordBackendRelease } = await load();
+    for (const junk of ["latest", "not a version", "../../evil", "9.9.9/../../evil"]) {
+      recordBackendRelease(junk);
+      expect(tracked()).toBe("1.0.13");
+    }
+  });
+
+  it("accepts a release carrying a pre-release and build metadata", async () => {
+    // The shape that once broke `ix upgrade`; VERSION_RE admits it deliberately
+    // and the backend validates against the same pattern.
+    const { recordBackendRelease } = await load();
+    recordBackendRelease("0.9.0-rc.1+abc1234");
+    expect(tracked()).toBe("0.9.0-rc.1+abc1234");
+  });
+
+  it("does not rewrite a stamp that already agrees", async () => {
+    // Runs on every `ix status` / `ix map`, and the write is not atomic: a
+    // needless truncate-and-rewrite on the hot path is a window for a torn read
+    // in another process for no gain.
+    //
+    // Asserted on the MTIME, not the contents: rewriting the same string leaves
+    // the contents identical, so a contents check passes whether or not the
+    // write happened. The mtime is pinned to a known past value first, which a
+    // write would reset to now.
+    writeFileSync(stamp(), "1.0.16");
+    const pinned = new Date("2020-01-02T03:04:05Z");
+    utimesSync(stamp(), pinned, pinned);
+    const before = statSync(stamp()).mtimeMs;
+
+    const { recordBackendRelease } = await load();
+    recordBackendRelease("1.0.16");
+
+    expect(statSync(stamp()).mtimeMs).toBe(before);
+    expect(readFileSync(stamp(), "utf-8")).toBe("1.0.16");
+
+    // ...and the control: a DIFFERENT version does rewrite it, so the assertion
+    // above is the short-circuit and not an mtime that never moves.
+    recordBackendRelease("1.0.17");
+    expect(statSync(stamp()).mtimeMs).not.toBe(before);
+    expect(readFileSync(stamp(), "utf-8")).toBe("1.0.17");
+  });
+
+  it("never throws, whatever the stamp path is", async () => {
+    // Attached to commands the user actually ran — `ix status` must not fail
+    // because IX_HOME is read-only.
+    mkdirSync(stamp(), { recursive: true }); // a directory where the file goes
+    const { recordBackendRelease } = await load();
+    expect(() => recordBackendRelease("1.0.16")).not.toThrow();
+  });
+});
+
+/**
+ * The recorder is only worth anything at the sites that already hold a health
+ * response, and adding one is the kind of thing that gets forgotten. This
+ * enumerates them from the source rather than trusting a list in a comment.
+ */
+describe("every site that reads /v1/health records the release", () => {
+  const CMDS = join(HERE, "..", "commands");
+
+  /** Files that call client.health(), found rather than listed. */
+  const callers = readdirSync(CMDS)
+    .filter((f) => f.endsWith(".ts"))
+    .map((f) => ({ file: f, src: readFileSync(join(CMDS, f), "utf-8") }))
+    .filter((f) => /\bclient\.health\(\)/.test(f.src));
+
+  it("finds the health callers at all", () => {
+    // Guards the two tests below: an empty list would satisfy any `every`.
+    expect(callers.map((c) => c.file).sort()).toContain("status.ts");
+    expect(callers.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("has each of them record what it read", () => {
+    const missing = callers
+      .filter((c) => !/recordBackendRelease\(/.test(c.src))
+      .map((c) => c.file);
+    expect(missing).toEqual([]);
+  });
+
+  it("keeps checkBackendSchema carrying the value out, since it cannot record it itself", () => {
+    // backend-status.ts fetches health too, but importing upgrade.ts there is a
+    // cycle — upgrade.ts already imports it. So it returns the value and its
+    // caller records. If that stops, doctor silently loses the correction.
+    const src = readFileSync(join(HERE, "..", "backend-status.ts"), "utf-8");
+    expect(src).toMatch(/releaseVersion\s*:\s*string\s*\|\s*null/);
+    expect(src).toMatch(/health\.release_version/);
+    const doctor = readFileSync(join(CMDS, "doctor.ts"), "utf-8");
+    expect(doctor).toMatch(/recordBackendRelease\(\s*s\.releaseVersion\s*\)/);
+  });
+});

--- a/ix-cli/src/cli/__tests__/backend-release-report.test.ts
+++ b/ix-cli/src/cli/__tests__/backend-release-report.test.ts
@@ -494,7 +494,10 @@ describe("health is fetched in exactly one place", () => {
     .map((f) => f.file.slice(SRC.length + 1).replace(/\\/g, "/"));
 
   it("finds the health callers at all", () => {
-    // Guards the assertion below: an empty list would satisfy any comparison.
+    // NOT a vacuity guard — the assertion below is an exact toEqual against a
+    // one-element literal, which rejects [] on its own. This exists only so a
+    // broken `walk` fails saying "found nothing" instead of producing a deep
+    // -equal diff that reads like the chokepoint moved.
     expect(callers.length).toBeGreaterThan(0);
   });
 
@@ -504,7 +507,7 @@ describe("health is fetched in exactly one place", () => {
   // READ THIS BEFORE TRUSTING IT. Three rounds of review have established what
   // this does and does not catch, and the honest summary is narrow:
   //
-  //   CAUGHT: a new file that names the path. A second INLINE use of the path
+  //   CAUGHT: a new file that names the path INLINE. A second inline use of it
   //   inside a listed file. Removing a listed use (so the list cannot go stale
   //   silently, which is the whole reason it is here and not in a comment).
   //

--- a/ix-cli/src/cli/__tests__/backend-release-report.test.ts
+++ b/ix-cli/src/cli/__tests__/backend-release-report.test.ts
@@ -14,6 +14,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import type { IxClient } from "../../client/api.js";
 import { isNewer } from "../commands/upgrade.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -258,7 +259,7 @@ describe("fetchBackendHealth records what it read", () => {
 
   /** Only what fetchBackendHealth touches: the endpoint and health(). */
   const fakeClient = (endpoint: string, health: unknown) =>
-    ({ endpoint, health: async () => health }) as never;
+    ({ endpoint, health: async () => health }) as unknown as IxClient;
 
   it("records the release for a local backend", async () => {
     writeFileSync(stamp(), "1.0.13");
@@ -269,6 +270,32 @@ describe("fetchBackendHealth records what it read", () => {
       isNewer,
     );
     expect(got).toMatchObject({ status: "ok" }); // still returns the response
+    expect(tracked()).toBe("1.0.16");
+  });
+
+  it("applies the ceiling through readBackendHealth, the path commands take", async () => {
+    // The JOIN, not the pieces. backendCeiling() is pinned on its own and
+    // fetchBackendHealth's use of knownLatest is pinned on its own — but
+    // swapping `backendCeiling()` for `null` in readBackendHealth left the whole
+    // suite green, and with a null ceiling the stamp can never move forward
+    // again, which is the original bug back.
+    writeFileSync(stamp(), "1.0.13");
+    writeFileSync(
+      join(home, ".version-check.json"),
+      JSON.stringify({ latest: "0.9.3", backendLatest: "1.0.16", checkedAt: Date.now() }),
+    );
+    const { readBackendHealth } = await import("../commands/upgrade.js");
+
+    // Above the ceiling -> refused.
+    await readBackendHealth(
+      fakeClient("http://localhost:8090", { status: "ok", release_version: "99.0.0" }),
+    );
+    expect(tracked()).toBe("1.0.13");
+
+    // At the ceiling -> taken, which is only possible if the ceiling was read.
+    await readBackendHealth(
+      fakeClient("http://localhost:8090", { status: "ok", release_version: "1.0.16" }),
+    );
     expect(tracked()).toBe("1.0.16");
   });
 
@@ -327,7 +354,15 @@ describe("isLocalEndpoint", () => {
     // different deployment's release into the file that governs the LOCAL
     // docker image notice.
     const { isLocalEndpoint } = await import("../backend-version.js");
-    for (const e of ["http://staging:8090", "https://ix.example.com", "http://10.0.0.5:8090"]) {
+    for (const e of [
+      "http://staging:8090",
+      "https://ix.example.com",
+      "http://10.0.0.5:8090",
+      // Remote NAMES that merely start "127." — a prefix match on the hostname
+      // made these local, which is the opposite of what this function is for.
+      "http://127.0.0.1.evil.com:8090",
+      "http://127.example.com:8090",
+    ]) {
       expect(isLocalEndpoint(e)).toBe(false);
     }
   });
@@ -360,7 +395,14 @@ describe("health is fetched in exactly one place", () => {
     // Comments stripped first: this codebase names functions in call syntax in
     // prose constantly, and a doc comment mentioning client.health() would fail
     // CI with a message pointing at the wrong problem.
-    .map((f) => ({ ...f, src: f.src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "") }))
+    //
+    // Only comments that START a line. A blanket `//` strip is string-blind:
+    // the `//` inside `http://localhost:8090` — the most common literal in this
+    // file family — swallowed the rest of that line, so a real `.health()` call
+    // sharing a line with a URL became invisible to the guard. Verified. Block
+    // comments are left alone for the same reason: a `**/*.ts` glob literal ate
+    // from the string to the next `*/` and dropped the chokepoint itself.
+    .map((f) => ({ ...f, src: f.src.replace(/^\s*(\/\/|\*|\/\*).*$/gm, "") }))
     .filter((f) => /\.health\s*\(\s*\)/.test(f.src))
     .map((f) => f.file.slice(SRC.length + 1).replace(/\\/g, "/"));
 
@@ -369,7 +411,7 @@ describe("health is fetched in exactly one place", () => {
     expect(callers.length).toBeGreaterThan(0);
   });
 
-  it("has only backend-version.ts and backend-status.ts calling .health()", () => {
+  it("has only backend-version.ts calling .health()", () => {
     // Exactly one, across the WHOLE src tree — not just src/cli, which left
     // src/mcp (it already exposes an ix_health tool) and src/client invisible.
     // backend-status.ts used to be exempted on a cycle that does not exist:

--- a/ix-cli/src/cli/__tests__/backend-release-report.test.ts
+++ b/ix-cli/src/cli/__tests__/backend-release-report.test.ts
@@ -467,7 +467,10 @@ describe("health is fetched in exactly one place", () => {
     readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
       if (e.name === "__tests__" || e.name === "node_modules") return [];
       const full = join(dir, e.name);
-      return e.isDirectory() ? walk(full) : full.endsWith(".ts") ? [full] : [];
+      // Every module extension, not just .ts: src/ happens to be all .ts today,
+      // so a future .mts or .js under it would be invisible to BOTH guards
+      // below and neither would report anything missing.
+      return e.isDirectory() ? walk(full) : /\.(m|c)?(t|j)s$/.test(e.name) ? [full] : [];
     });
 
   // Any receiver, not just one literally named `client`: a renamed local would
@@ -494,34 +497,43 @@ describe("health is fetched in exactly one place", () => {
   });
 
   // The `.health()` search above cannot see a raw `fetch(`${e}/v1/health`)`, so
-  // pin who may name the path at all. An allowlist, but an EXACT one: a new
-  // reader fails it, and so does removing a listed use, which is what stops it
-  // quietly becoming the stale list-in-a-comment this guard exists to replace.
+  // pin who may name the path at all, and how many times.
   //
-  // COUNTS, not just filenames. A file-granular check makes the allowlisted
-  // files blind spots: adding a body-reading `fetch(HEALTH_URL).json()` to
-  // docker.ts left the list identical and the whole suite green. Verified.
+  // READ THIS BEFORE TRUSTING IT. Three rounds of review have established what
+  // this does and does not catch, and the honest summary is narrow:
   //
-  // Comment handling is stricter here than for `.health()` above, because a
-  // path is named in prose far more readily than a call is:
+  //   CAUGHT: a new file that names the path. A second INLINE use of the path
+  //   inside a listed file. Removing a listed use (so the list cannot go stale
+  //   silently, which is the whole reason it is here and not in a comment).
   //
-  // - trailing `//` is stripped, but ONLY where not preceded by `:`. A blanket
-  //   strip is the string-blind trap documented below — `const HEALTH_URL =
-  //   "http://localhost:8090/v1/health"` truncates at `http:`, the file drops
-  //   off the list, and this guard silently disarms itself.
-  // - block comments are stripped only when the `/*` STARTS a line, i.e. doc
-  //   comments. That covers a continuation line with no leading `*` (which
-  //   otherwise fails CI with a message pointing at the wrong problem) without
-  //   reintroducing the mid-line `**/*.ts` glob problem, since a glob lives
-  //   inside a string, never at line start.
+  //   NOT CAUGHT: a new reader inside a listed file that reuses the existing
+  //   constant — `fetch(HEALTH_URL).json()` added to docker.ts counts zero new
+  //   literals and passes. Nor a path assembled from fragments
+  //   (`"/v1" + "/health"`). Both verified. The three listed files are
+  //   therefore TRUSTED, not checked; what stops a body read there is that all
+  //   three use `curl` with stdio ignored, and review of any change to them.
+  //
+  // Comment handling: line-start block comments and line-start `//` are
+  // stripped. Trailing `//` is deliberately NOT, and that is a considered
+  // trade. A `(^|[^:])//` rule was tried and silently erased three real
+  // spellings — `` `${proto}//${host}/v1/health` ``, `"//localhost:8090/..."`,
+  // and a doubled-slash template — because the `//` sat after `}` or `"`.
+  // A guard that quietly stops seeing real calls is far worse than one that
+  // trips on prose: a false positive is a confusing red CI, a false negative is
+  // no guard at all. So prose naming the path in a trailing comment WILL fail
+  // this test. That is intended; move it to a line-start comment.
+  //
+  // Known false positive, unfixed: a block comment containing a `**/` glob ends
+  // the strip early, because `**/` CONTAINS `*/` — position has nothing to do
+  // with it — leaving the rest of the comment visible. Same for a block comment
+  // opened mid-line. Both fail red rather than silently, so they are left.
   const pathCounts = Object.fromEntries(
     walk(SRC)
       .map((f) => ({
         file: f,
         src: readFileSync(f, "utf-8")
           .replace(/^[ \t]*\/\*[\s\S]*?\*\//gm, "")
-          .replace(/^\s*(\/\/|\*|\/\*).*$/gm, "")
-          .replace(/(^|[^:])\/\/.*$/gm, "$1"),
+          .replace(/^\s*(\/\/|\*|\/\*).*$/gm, ""),
       }))
       .map((f) => ({ ...f, n: (f.src.match(/v1\/health/g) ?? []).length }))
       .filter((f) => f.n > 0)
@@ -536,8 +548,7 @@ describe("health is fetched in exactly one place", () => {
     expect(pathCounts).toEqual({
       // The two readiness polls. Both `curl -sf` with stdio ignored, so they
       // discard the response: there is no body to record and they are correctly
-      // outside the chokepoint. Counted, so a second use in either file — the
-      // one that might read a body — has to come past this test.
+      // outside the chokepoint.
       "cli/commands/docker.ts": 1,
       "cli/commands/upgrade.ts": 1,
       // The one real request. Everything that reads a body reaches it through

--- a/ix-cli/src/cli/__tests__/backend-release-report.test.ts
+++ b/ix-cli/src/cli/__tests__/backend-release-report.test.ts
@@ -467,9 +467,11 @@ describe("health is fetched in exactly one place", () => {
     readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
       if (e.name === "__tests__" || e.name === "node_modules") return [];
       const full = join(dir, e.name);
-      // Every module extension, not just .ts: src/ happens to be all .ts today,
-      // so a future .mts or .js under it would be invisible to BOTH guards
-      // below and neither would report anything missing.
+      // .ts .js .mts .cts .mjs .cjs — not just .ts. src/ happens to be all .ts
+      // today, so a future .mts or .js under it would be invisible to BOTH
+      // guards below and neither would report anything missing. Not .tsx/.jsx:
+      // there is no JSX in this CLI, and adding some would be the point at
+      // which to revisit this.
       return e.isDirectory() ? walk(full) : /\.(m|c)?(t|j)s$/.test(e.name) ? [full] : [];
     });
 
@@ -509,24 +511,31 @@ describe("health is fetched in exactly one place", () => {
   //   NOT CAUGHT: a new reader inside a listed file that reuses the existing
   //   constant — `fetch(HEALTH_URL).json()` added to docker.ts counts zero new
   //   literals and passes. Nor a path assembled from fragments
-  //   (`"/v1" + "/health"`). Both verified. The three listed files are
-  //   therefore TRUSTED, not checked; what stops a body read there is that all
-  //   three use `curl` with stdio ignored, and review of any change to them.
+  //   (`"/v1" + "/health"`). Both verified. So the three listed files are
+  //   checked against INLINE uses and trusted against INDIRECTION.
   //
-  // Comment handling: line-start block comments and line-start `//` are
-  // stripped. Trailing `//` is deliberately NOT, and that is a considered
-  // trade. A `(^|[^:])//` rule was tried and silently erased three real
-  // spellings — `` `${proto}//${host}/v1/health` ``, `"//localhost:8090/..."`,
-  // and a doubled-slash template — because the `//` sat after `}` or `"`.
-  // A guard that quietly stops seeing real calls is far worse than one that
-  // trips on prose: a false positive is a confusing red CI, a false negative is
-  // no guard at all. So prose naming the path in a trailing comment WILL fail
-  // this test. That is intended; move it to a line-start comment.
+  // What actually stops a body read in the two readiness-poll files is that
+  // both use `curl` with stdio ignored and discard the response. That is not
+  // true of the third: `client/api.ts` is the one place that DOES read a health
+  // body, via `get()` → `resp.json()`, and it is listed precisely because
+  // everything legitimate goes through it.
   //
-  // Known false positive, unfixed: a block comment containing a `**/` glob ends
-  // the strip early, because `**/` CONTAINS `*/` — position has nothing to do
-  // with it — leaving the rest of the comment visible. Same for a block comment
-  // opened mid-line. Both fail red rather than silently, so they are left.
+  // Comment handling: line-start block comments, line-start `//`, and line-start
+  // `*` (doc-continuation lines) are stripped. Trailing `//` is deliberately NOT,
+  // and that is a considered trade. A `(^|[^:])//` rule was tried and silently
+  // erased three real spellings — `` `${proto}//${host}/v1/health` ``,
+  // `"//localhost:8090/..."`, and a doubled-slash template — because the `//`
+  // sat after `}` or `"`. A guard that quietly stops seeing real calls is far
+  // worse than one that trips on prose: a false positive is a confusing red CI,
+  // a false negative is no guard at all. So prose naming the path in a trailing
+  // comment WILL fail this test. That is intended; move it to a line-start one.
+  //
+  // Known false positives, unfixed, both failing red rather than silently:
+  // a block comment containing a `**/` glob ends the strip early, because `**/`
+  // CONTAINS `*/` — position has nothing to do with it. That only surfaces when
+  // the block's continuation lines do NOT begin with `*`, since the line-start
+  // `*` rule strips those anyway, so ordinary JSDoc is unaffected. A block
+  // comment opened mid-line is never stripped at all.
   const pathCounts = Object.fromEntries(
     walk(SRC)
       .map((f) => ({
@@ -551,8 +560,11 @@ describe("health is fetched in exactly one place", () => {
       // outside the chokepoint.
       "cli/commands/docker.ts": 1,
       "cli/commands/upgrade.ts": 1,
-      // The one real request. Everything that reads a body reaches it through
-      // IxClient.health(), which the assertion below routes through this module.
+      // The one real request, and the one place a health body is read. As the
+      // code stands today everything reaches it through IxClient.health(),
+      // which the assertion below routes through this module — but that is a
+      // fact about the current tree, not something this guard enforces: a body
+      // read added to a listed file is documented above as not caught.
       "client/api.ts": 1,
     });
   });

--- a/ix-cli/src/cli/__tests__/backend-release-report.test.ts
+++ b/ix-cli/src/cli/__tests__/backend-release-report.test.ts
@@ -387,24 +387,11 @@ describe("checkBackendSchema forwards its bounds rather than dropping them", () 
   const localClient = (health: unknown) =>
     ({ endpoint: "http://localhost:8090", health: async () => health }) as unknown as IxClient;
 
-  it("passes the ceiling through, so a claim above it is still refused", async () => {
-    writeFileSync(stamp(), "1.0.13");
-    const { checkBackendSchema } = await import("../backend-status.js");
-    await checkBackendSchema(
-      localClient({ status: "ok", schema_version: 3, release_version: "99.0.0" }),
-      "1.0.16",
-      isNewer,
-    );
-    // Dropped ceiling => no ceiling => compared against the stamp instead, and
-    // 99.0.0 is newer than 1.0.13, so it would still be refused. The ceiling
-    // only shows itself when the stamp is ALSO ahead — see the next case.
-    expect(tracked()).toBe("1.0.13");
-  });
-
   it("passes the ceiling through even when the stamp is already ahead", async () => {
-    // This is the case that separates "forwarded the ceiling" from "forwarded
-    // null": with the stamp at 99.9.9, the no-ceiling rule would ACCEPT 5.0.0
-    // as a correction downward. Only a real ceiling of 1.0.16 refuses it.
+    // With the stamp at 99.9.9 the no-ceiling rule would ACCEPT 5.0.0 as a
+    // correction downward, so only a real ceiling of 1.0.16 refuses it. What
+    // this case uniquely catches is a WRONG non-null ceiling: forwarding a
+    // permissive "99.0.0" kills it while the recording case below stays green.
     writeFileSync(stamp(), "99.9.9");
     const { checkBackendSchema } = await import("../backend-status.js");
     await checkBackendSchema(
@@ -510,27 +497,53 @@ describe("health is fetched in exactly one place", () => {
   // pin who may name the path at all. An allowlist, but an EXACT one: a new
   // reader fails it, and so does removing a listed use, which is what stops it
   // quietly becoming the stale list-in-a-comment this guard exists to replace.
-  const pathUsers = walk(SRC)
-    .map((f) => ({ file: f, src: readFileSync(f, "utf-8").replace(/^\s*(\/\/|\*|\/\*).*$/gm, "") }))
-    .filter((f) => /v1\/health/.test(f.src))
-    .map((f) => f.file.slice(SRC.length + 1).replace(/\\/g, "/"))
-    .sort();
+  //
+  // COUNTS, not just filenames. A file-granular check makes the allowlisted
+  // files blind spots: adding a body-reading `fetch(HEALTH_URL).json()` to
+  // docker.ts left the list identical and the whole suite green. Verified.
+  //
+  // Comment handling is stricter here than for `.health()` above, because a
+  // path is named in prose far more readily than a call is:
+  //
+  // - trailing `//` is stripped, but ONLY where not preceded by `:`. A blanket
+  //   strip is the string-blind trap documented below — `const HEALTH_URL =
+  //   "http://localhost:8090/v1/health"` truncates at `http:`, the file drops
+  //   off the list, and this guard silently disarms itself.
+  // - block comments are stripped only when the `/*` STARTS a line, i.e. doc
+  //   comments. That covers a continuation line with no leading `*` (which
+  //   otherwise fails CI with a message pointing at the wrong problem) without
+  //   reintroducing the mid-line `**/*.ts` glob problem, since a glob lives
+  //   inside a string, never at line start.
+  const pathCounts = Object.fromEntries(
+    walk(SRC)
+      .map((f) => ({
+        file: f,
+        src: readFileSync(f, "utf-8")
+          .replace(/^[ \t]*\/\*[\s\S]*?\*\//gm, "")
+          .replace(/^\s*(\/\/|\*|\/\*).*$/gm, "")
+          .replace(/(^|[^:])\/\/.*$/gm, "$1"),
+      }))
+      .map((f) => ({ ...f, n: (f.src.match(/v1\/health/g) ?? []).length }))
+      .filter((f) => f.n > 0)
+      .map((f) => [f.file.slice(SRC.length + 1).replace(/\\/g, "/"), f.n]),
+  );
 
   it("finds the health-path users at all", () => {
-    expect(pathUsers.length).toBeGreaterThan(0);
+    expect(Object.keys(pathCounts).length).toBeGreaterThan(0);
   });
 
   it("has only the readiness polls and the client naming /v1/health", () => {
-    expect(pathUsers).toEqual([
-      // The two readiness polls. Both `curl -sf` with stdio ignored: they
-      // discard the response, so there is no body to record and they are
-      // correctly outside the chokepoint.
-      "cli/commands/docker.ts",
-      "cli/commands/upgrade.ts",
+    expect(pathCounts).toEqual({
+      // The two readiness polls. Both `curl -sf` with stdio ignored, so they
+      // discard the response: there is no body to record and they are correctly
+      // outside the chokepoint. Counted, so a second use in either file — the
+      // one that might read a body — has to come past this test.
+      "cli/commands/docker.ts": 1,
+      "cli/commands/upgrade.ts": 1,
       // The one real request. Everything that reads a body reaches it through
       // IxClient.health(), which the assertion below routes through this module.
-      "client/api.ts",
-    ]);
+      "client/api.ts": 1,
+    });
   });
 
   it("has only backend-version.ts calling .health()", () => {

--- a/ix-cli/src/cli/__tests__/backend-release-report.test.ts
+++ b/ix-cli/src/cli/__tests__/backend-release-report.test.ts
@@ -113,9 +113,14 @@ describe("recordBackendRelease", () => {
   it("ignores a corrupt ceiling rather than trusting it", async () => {
     // readCache only checks backendLatest is a string. A garbage ceiling must
     // fall back to the no-ceiling rule, not admit anything.
+    //
+    // "99999" and not "not-a-version": splitVersion parses the latter to major
+    // 0, so isNewer("99.0.0", "not-a-version") is true with or WITHOUT the
+    // shape check and the test passed for the wrong reason. A garbage ceiling
+    // that parses to a large major is the one that needs the guard.
     writeFileSync(stamp(), "1.0.13");
     const { recordBackendRelease } = await load();
-    expect(recordBackendRelease("99.0.0", "not-a-version", isNewer)).toBe(false);
+    expect(recordBackendRelease("99.0.0", "99999", isNewer)).toBe(false);
     expect(tracked()).toBe("1.0.13");
   });
 
@@ -331,6 +336,96 @@ describe("fetchBackendHealth records what it read", () => {
     );
     expect(tracked()).toBe("1.0.13");
   });
+
+  it("does not throw when a 200 carries a literally null body", async () => {
+    // A reachable backend answering 200 with `null` parses to null. If this
+    // bookkeeping threw, every caller catches (status.ts:53, ingest.ts:943) —
+    // and would report "backend not reachable" for a backend that answered.
+    // That wrong diagnosis would be produced by the recording step itself.
+    // None of the other fakes here return a non-object, so `health?.` was
+    // unpinned: dropping the `?` left all 25 tests green.
+    writeFileSync(stamp(), "1.0.13");
+    const { fetchBackendHealth } = await import("../backend-version.js");
+    const got = await fetchBackendHealth(
+      fakeClient("http://localhost:8090", null),
+      "1.0.16",
+      isNewer,
+    );
+    expect(got).toBeNull();
+    expect(tracked()).toBe("1.0.13");
+  });
+});
+
+/**
+ * The bounds are required parameters so that a CALL SITE cannot omit them. That
+ * says nothing about the callee: `checkBackendSchema` could accept both and
+ * quietly forward `null`, and every one of its own tests would still pass —
+ * backend-status.test.ts deliberately uses a remote endpoint, so the recorder
+ * never runs there at all. Mutating its forwarding call to pass `null` survived
+ * the entire src/cli/__tests__ suite before this block existed.
+ */
+describe("checkBackendSchema forwards its bounds rather than dropping them", () => {
+  let home: string;
+  let priorHome: string | undefined;
+
+  beforeEach(() => {
+    priorHome = process.env.IX_HOME;
+    home = mkdtempSync(join(tmpdir(), "ix-schema-bounds-"));
+    process.env.IX_HOME = home;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    if (priorHome === undefined) delete process.env.IX_HOME;
+    else process.env.IX_HOME = priorHome;
+    rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  });
+
+  const stamp = () => join(home, ".backend-version");
+  const tracked = () => (existsSync(stamp()) ? readFileSync(stamp(), "utf-8") : null);
+  const localClient = (health: unknown) =>
+    ({ endpoint: "http://localhost:8090", health: async () => health }) as unknown as IxClient;
+
+  it("passes the ceiling through, so a claim above it is still refused", async () => {
+    writeFileSync(stamp(), "1.0.13");
+    const { checkBackendSchema } = await import("../backend-status.js");
+    await checkBackendSchema(
+      localClient({ status: "ok", schema_version: 3, release_version: "99.0.0" }),
+      "1.0.16",
+      isNewer,
+    );
+    // Dropped ceiling => no ceiling => compared against the stamp instead, and
+    // 99.0.0 is newer than 1.0.13, so it would still be refused. The ceiling
+    // only shows itself when the stamp is ALSO ahead — see the next case.
+    expect(tracked()).toBe("1.0.13");
+  });
+
+  it("passes the ceiling through even when the stamp is already ahead", async () => {
+    // This is the case that separates "forwarded the ceiling" from "forwarded
+    // null": with the stamp at 99.9.9, the no-ceiling rule would ACCEPT 5.0.0
+    // as a correction downward. Only a real ceiling of 1.0.16 refuses it.
+    writeFileSync(stamp(), "99.9.9");
+    const { checkBackendSchema } = await import("../backend-status.js");
+    await checkBackendSchema(
+      localClient({ status: "ok", schema_version: 3, release_version: "5.0.0" }),
+      "1.0.16",
+      isNewer,
+    );
+    expect(tracked()).toBe("99.9.9");
+  });
+
+  it("still records a legitimate release through this path", async () => {
+    // ...and the block above is not passing merely because nothing records.
+    writeFileSync(stamp(), "1.0.13");
+    const { checkBackendSchema } = await import("../backend-status.js");
+    await checkBackendSchema(
+      localClient({ status: "ok", schema_version: 3, release_version: "1.0.16" }),
+      "1.0.16",
+      isNewer,
+    );
+    expect(tracked()).toBe("1.0.16");
+  });
 });
 
 describe("isLocalEndpoint", () => {
@@ -409,6 +504,33 @@ describe("health is fetched in exactly one place", () => {
   it("finds the health callers at all", () => {
     // Guards the assertion below: an empty list would satisfy any comparison.
     expect(callers.length).toBeGreaterThan(0);
+  });
+
+  // The `.health()` search above cannot see a raw `fetch(`${e}/v1/health`)`, so
+  // pin who may name the path at all. An allowlist, but an EXACT one: a new
+  // reader fails it, and so does removing a listed use, which is what stops it
+  // quietly becoming the stale list-in-a-comment this guard exists to replace.
+  const pathUsers = walk(SRC)
+    .map((f) => ({ file: f, src: readFileSync(f, "utf-8").replace(/^\s*(\/\/|\*|\/\*).*$/gm, "") }))
+    .filter((f) => /v1\/health/.test(f.src))
+    .map((f) => f.file.slice(SRC.length + 1).replace(/\\/g, "/"))
+    .sort();
+
+  it("finds the health-path users at all", () => {
+    expect(pathUsers.length).toBeGreaterThan(0);
+  });
+
+  it("has only the readiness polls and the client naming /v1/health", () => {
+    expect(pathUsers).toEqual([
+      // The two readiness polls. Both `curl -sf` with stdio ignored: they
+      // discard the response, so there is no body to record and they are
+      // correctly outside the chokepoint.
+      "cli/commands/docker.ts",
+      "cli/commands/upgrade.ts",
+      // The one real request. Everything that reads a body reaches it through
+      // IxClient.health(), which the assertion below routes through this module.
+      "client/api.ts",
+    ]);
   });
 
   it("has only backend-version.ts calling .health()", () => {

--- a/ix-cli/src/cli/__tests__/backend-status.test.ts
+++ b/ix-cli/src/cli/__tests__/backend-status.test.ts
@@ -9,9 +9,13 @@ import {
   type BackendContainer,
 } from "../backend-status.js";
 import type { IxClient } from "../../client/api.js";
+import { isNewer } from "../commands/upgrade.js";
 
+// `endpoint` matters now: checkBackendSchema records through the shared health
+// fetch, and the recorder is gated on the endpoint being local. A remote one
+// keeps these unit tests from touching any stamp file at all.
 function fakeClient(health: () => Promise<any>): IxClient {
-  return { health } as unknown as IxClient;
+  return { endpoint: "http://schema-spec.invalid:8090", health } as unknown as IxClient;
 }
 
 function container(overrides: Partial<BackendContainer>): BackendContainer {
@@ -28,24 +32,28 @@ function container(overrides: Partial<BackendContainer>): BackendContainer {
 
 describe("checkBackendSchema", () => {
   it("matches when the backend reports the expected version", async () => {
-    const s = await checkBackendSchema(fakeClient(async () => ({ status: "ok", schema_version: CLIENT_EXPECTED_SCHEMA_VERSION })));
+    const s = await checkBackendSchema(fakeClient(async () => ({ status: "ok", schema_version: CLIENT_EXPECTED_SCHEMA_VERSION })), null, isNewer);
     expect(s).toEqual({ reachable: true, serverVersion: CLIENT_EXPECTED_SCHEMA_VERSION, expected: CLIENT_EXPECTED_SCHEMA_VERSION, matches: true });
   });
 
   it("flags a mismatch when the persisted graph predates the engine", async () => {
-    const s = await checkBackendSchema(fakeClient(async () => ({ status: "ok", schema_version: CLIENT_EXPECTED_SCHEMA_VERSION - 1 })));
+    const s = await checkBackendSchema(fakeClient(async () => ({ status: "ok", schema_version: CLIENT_EXPECTED_SCHEMA_VERSION - 1 })), null, isNewer);
     expect(s.matches).toBe(false);
     expect(s.serverVersion).toBe(CLIENT_EXPECTED_SCHEMA_VERSION - 1);
   });
 
   it("does not flag when the backend reports no schema version (can't prove stale)", async () => {
-    const s = await checkBackendSchema(fakeClient(async () => ({ status: "ok" })));
+    const s = await checkBackendSchema(fakeClient(async () => ({ status: "ok" })), null, isNewer);
     expect(s.matches).toBe(true);
     expect(s.serverVersion).toBeNull();
   });
 
   it("reports unreachable (and does not flag) when health throws", async () => {
-    const s = await checkBackendSchema(fakeClient(async () => { throw new Error("ECONNREFUSED"); }));
+    const s = await checkBackendSchema(
+      fakeClient(async () => { throw new Error("ECONNREFUSED"); }),
+      null,
+      isNewer,
+    );
     expect(s).toEqual({ reachable: false, serverVersion: null, expected: CLIENT_EXPECTED_SCHEMA_VERSION, matches: true });
   });
 });

--- a/ix-cli/src/cli/__tests__/backend-status.test.ts
+++ b/ix-cli/src/cli/__tests__/backend-status.test.ts
@@ -29,7 +29,7 @@ function container(overrides: Partial<BackendContainer>): BackendContainer {
 describe("checkBackendSchema", () => {
   it("matches when the backend reports the expected version", async () => {
     const s = await checkBackendSchema(fakeClient(async () => ({ status: "ok", schema_version: CLIENT_EXPECTED_SCHEMA_VERSION })));
-    expect(s).toEqual({ reachable: true, serverVersion: CLIENT_EXPECTED_SCHEMA_VERSION, expected: CLIENT_EXPECTED_SCHEMA_VERSION, matches: true });
+    expect(s).toEqual({ reachable: true, serverVersion: CLIENT_EXPECTED_SCHEMA_VERSION, expected: CLIENT_EXPECTED_SCHEMA_VERSION, matches: true, releaseVersion: null });
   });
 
   it("flags a mismatch when the persisted graph predates the engine", async () => {
@@ -44,9 +44,32 @@ describe("checkBackendSchema", () => {
     expect(s.serverVersion).toBeNull();
   });
 
+  it("carries out the release the backend reports, for its caller to record", async () => {
+    // Read here because the health response is already in hand; RECORDED by the
+    // caller, because writing the stamp lives in upgrade.ts and importing that
+    // from this module is a cycle.
+    const s = await checkBackendSchema(
+      fakeClient(async () => ({ status: "ok", schema_version: CLIENT_EXPECTED_SCHEMA_VERSION, release_version: "1.0.16" })),
+    );
+    expect(s.releaseVersion).toBe("1.0.16");
+  });
+
+  it("reports no release for a backend that does not report one", async () => {
+    // Any backend older than Ix-memory#157, and any image not built by the
+    // release pipeline. Must be null rather than undefined so the caller's
+    // check is on one shape.
+    const s = await checkBackendSchema(fakeClient(async () => ({ status: "ok" })));
+    expect(s.releaseVersion).toBeNull();
+  });
+
+  it("ignores a non-string release_version", async () => {
+    const s = await checkBackendSchema(fakeClient(async () => ({ status: "ok", release_version: 1016 })));
+    expect(s.releaseVersion).toBeNull();
+  });
+
   it("reports unreachable (and does not flag) when health throws", async () => {
     const s = await checkBackendSchema(fakeClient(async () => { throw new Error("ECONNREFUSED"); }));
-    expect(s).toEqual({ reachable: false, serverVersion: null, expected: CLIENT_EXPECTED_SCHEMA_VERSION, matches: true });
+    expect(s).toEqual({ reachable: false, serverVersion: null, expected: CLIENT_EXPECTED_SCHEMA_VERSION, matches: true, releaseVersion: null });
   });
 });
 

--- a/ix-cli/src/cli/__tests__/backend-status.test.ts
+++ b/ix-cli/src/cli/__tests__/backend-status.test.ts
@@ -29,7 +29,7 @@ function container(overrides: Partial<BackendContainer>): BackendContainer {
 describe("checkBackendSchema", () => {
   it("matches when the backend reports the expected version", async () => {
     const s = await checkBackendSchema(fakeClient(async () => ({ status: "ok", schema_version: CLIENT_EXPECTED_SCHEMA_VERSION })));
-    expect(s).toEqual({ reachable: true, serverVersion: CLIENT_EXPECTED_SCHEMA_VERSION, expected: CLIENT_EXPECTED_SCHEMA_VERSION, matches: true, releaseVersion: null });
+    expect(s).toEqual({ reachable: true, serverVersion: CLIENT_EXPECTED_SCHEMA_VERSION, expected: CLIENT_EXPECTED_SCHEMA_VERSION, matches: true });
   });
 
   it("flags a mismatch when the persisted graph predates the engine", async () => {
@@ -44,32 +44,9 @@ describe("checkBackendSchema", () => {
     expect(s.serverVersion).toBeNull();
   });
 
-  it("carries out the release the backend reports, for its caller to record", async () => {
-    // Read here because the health response is already in hand; RECORDED by the
-    // caller, because writing the stamp lives in upgrade.ts and importing that
-    // from this module is a cycle.
-    const s = await checkBackendSchema(
-      fakeClient(async () => ({ status: "ok", schema_version: CLIENT_EXPECTED_SCHEMA_VERSION, release_version: "1.0.16" })),
-    );
-    expect(s.releaseVersion).toBe("1.0.16");
-  });
-
-  it("reports no release for a backend that does not report one", async () => {
-    // Any backend older than Ix-memory#157, and any image not built by the
-    // release pipeline. Must be null rather than undefined so the caller's
-    // check is on one shape.
-    const s = await checkBackendSchema(fakeClient(async () => ({ status: "ok" })));
-    expect(s.releaseVersion).toBeNull();
-  });
-
-  it("ignores a non-string release_version", async () => {
-    const s = await checkBackendSchema(fakeClient(async () => ({ status: "ok", release_version: 1016 })));
-    expect(s.releaseVersion).toBeNull();
-  });
-
   it("reports unreachable (and does not flag) when health throws", async () => {
     const s = await checkBackendSchema(fakeClient(async () => { throw new Error("ECONNREFUSED"); }));
-    expect(s).toEqual({ reachable: false, serverVersion: null, expected: CLIENT_EXPECTED_SCHEMA_VERSION, matches: true, releaseVersion: null });
+    expect(s).toEqual({ reachable: false, serverVersion: null, expected: CLIENT_EXPECTED_SCHEMA_VERSION, matches: true });
   });
 });
 

--- a/ix-cli/src/cli/backend-status.ts
+++ b/ix-cli/src/cli/backend-status.ts
@@ -16,6 +16,7 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import type { IxClient } from "../client/api.js";
+import { fetchBackendHealth } from "./backend-version.js";
 
 export const BACKEND_IMAGE = "ghcr.io/ix-infrastructure/ix-memory-layer";
 const BACKEND_PORT = "8090";
@@ -137,10 +138,17 @@ export interface BackendSchemaStatus {
 }
 
 /** Read the backend's reported schema_version and compare to what we expect. */
-export async function checkBackendSchema(client: IxClient): Promise<BackendSchemaStatus> {
+export async function checkBackendSchema(
+  client: IxClient,
+  knownLatest: string | null | undefined = null,
+  isNewer: (a: string, b: string) => boolean = () => false,
+): Promise<BackendSchemaStatus> {
   const expected = CLIENT_EXPECTED_SCHEMA_VERSION;
   try {
-    const health = await client.health();
+    // Through the chokepoint, so this records like every other health fetch —
+    // there is no cycle: backend-version.ts imports only node builtins and two
+    // erased `import type`s.
+    const health = await fetchBackendHealth(client, knownLatest, isNewer);
     const serverVersion = typeof health.schema_version === "number" ? health.schema_version : null;
     // No reported version (older backend) is treated as a match: we can't prove
     // staleness, and the ingest path already forces a re-ingest when it can.

--- a/ix-cli/src/cli/backend-status.ts
+++ b/ix-cli/src/cli/backend-status.ts
@@ -134,6 +134,14 @@ export interface BackendSchemaStatus {
   serverVersion: number | null;
   expected: number;
   matches: boolean;
+  /**
+   * The release the backend says it is, or null when it does not say.
+   *
+   * Carried out rather than acted on here: recording it belongs to upgrade.ts,
+   * which owns the stamp file, and this module cannot import that one without
+   * a cycle.
+   */
+  releaseVersion: string | null;
 }
 
 /** Read the backend's reported schema_version and compare to what we expect. */
@@ -145,8 +153,10 @@ export async function checkBackendSchema(client: IxClient): Promise<BackendSchem
     // No reported version (older backend) is treated as a match: we can't prove
     // staleness, and the ingest path already forces a re-ingest when it can.
     const matches = serverVersion === null || serverVersion === expected;
-    return { reachable: true, serverVersion, expected, matches };
+    const releaseVersion =
+      typeof health.release_version === "string" ? health.release_version : null;
+    return { reachable: true, serverVersion, expected, matches, releaseVersion };
   } catch {
-    return { reachable: false, serverVersion: null, expected, matches: true };
+    return { reachable: false, serverVersion: null, expected, matches: true, releaseVersion: null };
   }
 }

--- a/ix-cli/src/cli/backend-status.ts
+++ b/ix-cli/src/cli/backend-status.ts
@@ -134,14 +134,6 @@ export interface BackendSchemaStatus {
   serverVersion: number | null;
   expected: number;
   matches: boolean;
-  /**
-   * The release the backend says it is, or null when it does not say.
-   *
-   * Carried out rather than acted on here: recording it belongs to upgrade.ts,
-   * which owns the stamp file, and this module cannot import that one without
-   * a cycle.
-   */
-  releaseVersion: string | null;
 }
 
 /** Read the backend's reported schema_version and compare to what we expect. */
@@ -153,10 +145,8 @@ export async function checkBackendSchema(client: IxClient): Promise<BackendSchem
     // No reported version (older backend) is treated as a match: we can't prove
     // staleness, and the ingest path already forces a re-ingest when it can.
     const matches = serverVersion === null || serverVersion === expected;
-    const releaseVersion =
-      typeof health.release_version === "string" ? health.release_version : null;
-    return { reachable: true, serverVersion, expected, matches, releaseVersion };
+    return { reachable: true, serverVersion, expected, matches };
   } catch {
-    return { reachable: false, serverVersion: null, expected, matches: true, releaseVersion: null };
+    return { reachable: false, serverVersion: null, expected, matches: true };
   }
 }

--- a/ix-cli/src/cli/backend-status.ts
+++ b/ix-cli/src/cli/backend-status.ts
@@ -137,11 +137,22 @@ export interface BackendSchemaStatus {
   matches: boolean;
 }
 
-/** Read the backend's reported schema_version and compare to what we expect. */
+/**
+ * Read the backend's reported schema_version and compare to what we expect.
+ *
+ * Also RECORDS the release the backend reports, as a side effect of going
+ * through the shared health fetch — the same as every other health call site.
+ */
 export async function checkBackendSchema(
   client: IxClient,
-  knownLatest: string | null | undefined = null,
-  isNewer: (a: string, b: string) => boolean = () => false,
+  // REQUIRED, not defaulted. Defaults of `null` + `() => false` turn off the
+  // ceiling AND the no-ceiling fallback at once, so a caller that omitted them
+  // would record any version-shaped claim a local container made — the exact
+  // 99.0.0 case recordBackendRelease exists to refuse. This is a published
+  // export, so "a call site can get it wrong" has to be impossible, not
+  // discouraged.
+  knownLatest: string | null,
+  isNewer: (a: string, b: string) => boolean,
 ): Promise<BackendSchemaStatus> {
   const expected = CLIENT_EXPECTED_SCHEMA_VERSION;
   try {

--- a/ix-cli/src/cli/backend-version.ts
+++ b/ix-cli/src/cli/backend-version.ts
@@ -137,7 +137,8 @@ export function isLocalEndpoint(endpoint: string): boolean {
     const host = new URL(endpoint).hostname.toLowerCase().replace(/\.$/, "");
     return (
       host === "localhost" ||
-      host.startsWith("127.") || // all of 127.0.0.0/8 is loopback
+      /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host) || // 127.0.0.0/8, as an ADDRESS
+      // ...not a prefix: `127.0.0.1.evil.com` is a remote name that starts "127."
       host === "0.0.0.0" || // what client/api.ts and errors.ts already accept
       host === "[::1]" // new URL() always brackets IPv6, so bare "::1" is unreachable
     );
@@ -162,8 +163,11 @@ export async function fetchBackendHealth(
   // From the client the request actually went to. Taking it as a second
   // argument reintroduced exactly the "a call site can get it wrong" mistake
   // this module exists to make impossible.
+  // `health?.` because a 200 whose body is literally `null` parses to null, and
+  // status.ts / ingest.ts do not catch — they would exit on a stack trace rather
+  // than report an unhealthy backend.
   if (isLocalEndpoint(client.endpoint)) {
-    recordBackendRelease(health.release_version, knownLatest, isNewer);
+    recordBackendRelease(health?.release_version, knownLatest, isNewer);
   }
   return health;
 }

--- a/ix-cli/src/cli/backend-version.ts
+++ b/ix-cli/src/cli/backend-version.ts
@@ -179,11 +179,12 @@ export async function fetchBackendHealth(
   // From the client the request actually went to. Taking it as a second
   // argument reintroduced exactly the "a call site can get it wrong" mistake
   // this module exists to make impossible.
-  // `health?.` because a 200 whose body is literally `null` parses to null, and
-  // this bookkeeping must never be what turns a reachable-but-odd backend into a
-  // thrown error. Callers do catch (status.ts:53, ingest.ts:943), but they would
-  // report "backend not reachable" for a backend that answered 200 — a wrong
-  // diagnosis produced by the recording step, not by the backend.
+  // `health?.` because a 200 whose body is literally `null` parses to null.
+  // The contract of this function is "return whatever the backend sent"; adding
+  // a throw of its own would be this bookkeeping changing the outcome of a
+  // request that succeeded. Nothing more is claimed: status.ts dereferences
+  // health.status unguarded moments later, so on a null body it fails either
+  // way — the `?.` keeps the failure the caller's, not ours.
   if (isLocalEndpoint(client.endpoint)) {
     recordBackendRelease(health?.release_version, knownLatest, isNewer);
   }

--- a/ix-cli/src/cli/backend-version.ts
+++ b/ix-cli/src/cli/backend-version.ts
@@ -1,0 +1,153 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { homedir } from "os";
+
+import type { IxClient } from "../client/api.js";
+import type { HealthResponse } from "../client/types.js";
+
+/**
+ * Everything that reads or writes `~/.ix/.backend-version`.
+ *
+ * A leaf on purpose. `upgrade.ts` owns the update notice and imports
+ * `backend-status.ts`, so the stamp could not live in either without a cycle the
+ * moment `backend-status` needed to write it. Keeping it here lets the ONE
+ * function that fetches health also record what it read, which is what stops a
+ * future call site from silently forgetting to.
+ */
+
+const IX_HOME = process.env.IX_HOME || join(homedir(), ".ix");
+
+/** The release the backend is believed to be running. */
+export const BACKEND_VERSION_FILE = join(IX_HOME, ".backend-version");
+
+/** Same shape the release feed is validated against in upgrade.ts. */
+const VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+/** Longer than any plausible tag; bounds a value the container controls. */
+const MAX_VERSION_LENGTH = 64;
+
+export function getTrackedVersion(versionFile: string): string {
+  try {
+    if (!existsSync(versionFile)) return "0.0.0";
+    return readFileSync(versionFile, "utf-8").trim() || "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+/**
+ * Record a version stamp. Returns whether it was written.
+ *
+ * `mkdirSync` because IX_HOME may not exist yet. A falsy version is refused: not
+ * knowing which release we are on is not the same as being on none of them.
+ *
+ * NOT atomic, deliberately. `writeFileSync` opens with O_TRUNC, so a reader
+ * landing mid-write sees "" and is told a current backend is out of date — and
+ * this is now reachable from `ix status`/`ix map` while `checkForUpdate` reads
+ * the file on every command. Two things make that the better trade anyway:
+ * `recordBackendRelease` short-circuits when the stamp already agrees, so a
+ * write happens only when the backend's version actually CHANGES, not per
+ * command; and a temp-file-plus-rename replaces a file the caller may not have
+ * permission to write, since rename needs the directory rather than the file.
+ * That would silently change when the stamp-failure warning fires and would
+ * force the tests that pin it onto read-only directories, which Windows does not
+ * honour. Worth revisiting with an injection that works on both platforms.
+ */
+export function writeVersionStamp(
+  versionFile: string,
+  version: string | null | undefined,
+): boolean {
+  if (!version) return false;
+  try {
+    mkdirSync(dirname(versionFile), { recursive: true });
+    writeFileSync(versionFile, version);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Record what the backend says it is running.
+ *
+ * `.backend-version` was a record of what the CLI last INSTALLED, which is the
+ * same thing as what is RUNNING only while nothing else moves the image. Pull
+ * through docker compose and the file names an older release than the container,
+ * so the update notice fires on every command for ever. The container is the one
+ * thing that always knows, so it is asked rather than inferred.
+ *
+ * Three things bound a value the container controls, because this file decides
+ * whether the user is ever told about an upgrade again:
+ *
+ * - it is trimmed before matching. `getTrackedVersion` trims on the way out, and
+ *   JavaScript's `$` does not match before a trailing newline, so without this a
+ *   value from an --env-file or a ConfigMap silently fails the shape test and
+ *   the whole feature no-ops with nothing to see.
+ * - it must be version-shaped and bounded in length. It is an env var an
+ *   operator can set to anything.
+ * - it may NOT claim to be newer than the newest release we know of. Otherwise
+ *   one container reporting `99.0.0` — a typo in a compose override, or a
+ *   tampered image — permanently silences the notice AND makes `ix upgrade`
+ *   report "already on the latest version" without ever pulling, so a security
+ *   release can never reach that machine. When no release is known yet, only
+ *   corrections that do not move the stamp forward are accepted, which still
+ *   repairs a stamp stuck ahead and defers the rest until the cache exists.
+ */
+export function recordBackendRelease(
+  reported: string | null | undefined,
+  knownLatest: string | null | undefined,
+  isNewer: (a: string, b: string) => boolean,
+): boolean {
+  const value = typeof reported === "string" ? reported.trim() : "";
+  if (!value || value.length > MAX_VERSION_LENGTH || !VERSION_RE.test(value)) return false;
+
+  const tracked = getTrackedVersion(BACKEND_VERSION_FILE);
+  if (value === tracked) return false; // already agrees; do not touch the file
+
+  const ceiling =
+    typeof knownLatest === "string" && VERSION_RE.test(knownLatest.trim())
+      ? knownLatest.trim()
+      : null;
+  // No published release can be older than what a container legitimately runs.
+  if (ceiling ? isNewer(value, ceiling) : isNewer(value, tracked)) return false;
+
+  return writeVersionStamp(BACKEND_VERSION_FILE, value);
+}
+
+/**
+ * True when this endpoint is the local backend the update notice is about.
+ *
+ * The stamp is global (`~/.ix/.backend-version`) but the endpoint is per
+ * invocation, so `IX_ENDPOINT=http://staging:8090 ix status` would otherwise
+ * record a different deployment's release into the file that governs the LOCAL
+ * docker image notice — a newer remote silencing a genuinely stale local
+ * backend, or an older one nagging about a current one.
+ */
+export function isLocalEndpoint(endpoint: string): boolean {
+  try {
+    const host = new URL(endpoint).hostname.toLowerCase();
+    return host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fetch `/v1/health` AND record the release it reports.
+ *
+ * The single place either happens. Every command that wants health goes through
+ * here, so "a new call site forgot to record" is not a mistake that can be made
+ * — which is worth more than the grep-based drift guard it replaces.
+ */
+export async function fetchBackendHealth(
+  client: IxClient,
+  endpoint: string,
+  knownLatest: string | null | undefined,
+  isNewer: (a: string, b: string) => boolean,
+): Promise<HealthResponse> {
+  const health = await client.health();
+  if (isLocalEndpoint(endpoint)) {
+    recordBackendRelease(health.release_version, knownLatest, isNewer);
+  }
+  return health;
+}

--- a/ix-cli/src/cli/backend-version.ts
+++ b/ix-cli/src/cli/backend-version.ts
@@ -20,8 +20,16 @@ const IX_HOME = process.env.IX_HOME || join(homedir(), ".ix");
 /** The release the backend is believed to be running. */
 export const BACKEND_VERSION_FILE = join(IX_HOME, ".backend-version");
 
-/** Same shape the release feed is validated against in upgrade.ts. */
-const VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+/**
+ * The one definition of a valid version string, imported by upgrade.ts too.
+ *
+ * Copied rather than shared once already, and this exact pattern has shipped
+ * broken: written as a single `(?:[-+]...)?` group whose class omitted `+`, it
+ * rejected the valid tag `0.9.0-rc.1+abc1234` and `ix upgrade` exited 1 with
+ * "Could not reach GitHub" against a perfectly reachable GitHub. Two copies mean
+ * the next correction lands in one of them.
+ */
+export const VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 
 /** Longer than any plausible tag; bounds a value the container controls. */
 const MAX_VERSION_LENGTH = 64;
@@ -125,8 +133,14 @@ export function recordBackendRelease(
  */
 export function isLocalEndpoint(endpoint: string): boolean {
   try {
-    const host = new URL(endpoint).hostname.toLowerCase();
-    return host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
+    // A trailing dot is the fully-qualified form and resolvers accept it.
+    const host = new URL(endpoint).hostname.toLowerCase().replace(/\.$/, "");
+    return (
+      host === "localhost" ||
+      host.startsWith("127.") || // all of 127.0.0.0/8 is loopback
+      host === "0.0.0.0" || // what client/api.ts and errors.ts already accept
+      host === "[::1]" // new URL() always brackets IPv6, so bare "::1" is unreachable
+    );
   } catch {
     return false;
   }
@@ -141,12 +155,14 @@ export function isLocalEndpoint(endpoint: string): boolean {
  */
 export async function fetchBackendHealth(
   client: IxClient,
-  endpoint: string,
   knownLatest: string | null | undefined,
   isNewer: (a: string, b: string) => boolean,
 ): Promise<HealthResponse> {
   const health = await client.health();
-  if (isLocalEndpoint(endpoint)) {
+  // From the client the request actually went to. Taking it as a second
+  // argument reintroduced exactly the "a call site can get it wrong" mistake
+  // this module exists to make impossible.
+  if (isLocalEndpoint(client.endpoint)) {
     recordBackendRelease(health.release_version, knownLatest, isNewer);
   }
   return health;

--- a/ix-cli/src/cli/backend-version.ts
+++ b/ix-cli/src/cli/backend-version.ts
@@ -100,6 +100,18 @@ export function writeVersionStamp(
  *   release can never reach that machine. When no release is known yet, only
  *   corrections that do not move the stamp forward are accepted, which still
  *   repairs a stamp stuck ahead and defers the rest until the cache exists.
+ *
+ * What the ceiling does NOT stop, stated plainly: a container that reports
+ * *exactly* the ceiling is accepted, and a compromised one has outbound network
+ * and can simply read the public release feed to learn that number rather than
+ * guess it. It then reaches the same silenced state by looking the answer up.
+ * This is a capability the feature introduces — before it, the stamp was
+ * written only by our own install/pull paths, so a container could not
+ * influence it at all. It is accepted deliberately: the alternative is to
+ * distrust the only component that actually knows what it is running, and the
+ * fail-safe direction (a container under-reporting, causing an unnecessary
+ * pull) is the one that stays open. `ix doctor`'s digest comparison remains the
+ * check that does not ask the container what it is.
  */
 export function recordBackendRelease(
   reported: string | null | undefined,
@@ -150,9 +162,13 @@ export function isLocalEndpoint(endpoint: string): boolean {
 /**
  * Fetch `/v1/health` AND record the release it reports.
  *
- * The single place either happens. Every command that wants health goes through
- * here, so "a new call site forgot to record" is not a mistake that can be made
- * — which is worth more than the grep-based drift guard it replaces.
+ * The single place either happens. Every command that READS a health body goes
+ * through here, so "a new call site forgot to record" is not a mistake that can
+ * be made — which is worth more than the grep-based drift guard it replaces.
+ *
+ * Precisely: reads of the body. docker.ts and upgrade.ts also hit /v1/health via
+ * `curl -sf` with stdio ignored, purely as a readiness poll; they discard the
+ * response, so there is nothing there to record.
  */
 export async function fetchBackendHealth(
   client: IxClient,
@@ -164,8 +180,10 @@ export async function fetchBackendHealth(
   // argument reintroduced exactly the "a call site can get it wrong" mistake
   // this module exists to make impossible.
   // `health?.` because a 200 whose body is literally `null` parses to null, and
-  // status.ts / ingest.ts do not catch — they would exit on a stack trace rather
-  // than report an unhealthy backend.
+  // this bookkeeping must never be what turns a reachable-but-odd backend into a
+  // thrown error. Callers do catch (status.ts:53, ingest.ts:943), but they would
+  // report "backend not reachable" for a backend that answered 200 — a wrong
+  // diagnosis produced by the recording step, not by the backend.
   if (isLocalEndpoint(client.endpoint)) {
     recordBackendRelease(health?.release_version, knownLatest, isNewer);
   }

--- a/ix-cli/src/cli/bootstrap.ts
+++ b/ix-cli/src/cli/bootstrap.ts
@@ -6,6 +6,7 @@ import chalk from "chalk";
 import { IxClient } from "../client/api.js";
 import { getEndpoint, loadConfig, saveConfig, findWorkspaceForCwd, getDefaultWorkspace, type WorkspaceConfig } from "./config.js";
 import { workspaceIdForPath } from "./system.js";
+import { readBackendHealth } from "./commands/upgrade.js";
 
 export interface BootstrapResult {
   createdConfig: boolean;
@@ -124,9 +125,13 @@ export function resolveWorkspaceId(cwd = process.cwd()): string | undefined {
  * Ensure the backend is reachable. If not, auto-start via ix docker start.
  */
 export async function ensureBackendAvailable(): Promise<void> {
-  const client = new IxClient(getEndpoint());
+  const endpoint = getEndpoint();
+  const client = new IxClient(endpoint);
   try {
-    await client.health();
+    // Through readBackendHealth so this probe records the release the backend
+    // reports, like every other health fetch. `ix init` never reaches the
+    // ingest path, so without this it would never record at all.
+    await readBackendHealth(client, endpoint);
   } catch {
     try {
       execFileSync("ix", ["docker", "start"], { stdio: "inherit", timeout: 120000 });

--- a/ix-cli/src/cli/bootstrap.ts
+++ b/ix-cli/src/cli/bootstrap.ts
@@ -131,7 +131,7 @@ export async function ensureBackendAvailable(): Promise<void> {
     // Through readBackendHealth so this probe records the release the backend
     // reports, like every other health fetch. `ix init` never reaches the
     // ingest path, so without this it would never record at all.
-    await readBackendHealth(client, endpoint);
+    await readBackendHealth(client);
   } catch {
     try {
       execFileSync("ix", ["docker", "start"], { stdio: "inherit", timeout: 120000 });

--- a/ix-cli/src/cli/commands/doctor.ts
+++ b/ix-cli/src/cli/commands/doctor.ts
@@ -13,7 +13,7 @@ import {
   checkBackendSchema,
   isNonStandardBackend,
 } from "../backend-status.js";
-import { recordBackendRelease } from "./upgrade.js";
+import { readBackendHealth } from "./upgrade.js";
 
 interface CheckResult {
   ok: boolean;
@@ -125,7 +125,9 @@ export function registerDoctorCommand(program: Command): void {
           name: "Server reachable",
           run: async () => {
             try {
-              const h = await client.health();
+              // Records what the backend says it is running; see
+               // backend-version.ts. Free — this response is already needed.
+              const h = await readBackendHealth(client, endpoint);
               return { ok: h.status === "ok", detail: `${endpoint} → ${h.status}` };
             } catch (e: any) {
               return { ok: false, detail: e.message ?? "unreachable" };
@@ -209,9 +211,6 @@ export function registerDoctorCommand(program: Command): void {
           name: "Graph schema matches engine",
           run: async () => {
             const s = await checkBackendSchema(client);
-            // Free: the health response is already in hand. Corrects the stamp
-            // the update notice reads, without a request or a command of its own.
-            recordBackendRelease(s.releaseVersion);
             if (!s.reachable) return { ok: true, detail: "backend unreachable (skipped)" };
             if (s.serverVersion === null) return { ok: true, detail: "backend does not report a schema version" };
             if (s.matches) return { ok: true, detail: `schema v${s.serverVersion}` };

--- a/ix-cli/src/cli/commands/doctor.ts
+++ b/ix-cli/src/cli/commands/doctor.ts
@@ -13,6 +13,7 @@ import {
   checkBackendSchema,
   isNonStandardBackend,
 } from "../backend-status.js";
+import { recordBackendRelease } from "./upgrade.js";
 
 interface CheckResult {
   ok: boolean;
@@ -208,6 +209,9 @@ export function registerDoctorCommand(program: Command): void {
           name: "Graph schema matches engine",
           run: async () => {
             const s = await checkBackendSchema(client);
+            // Free: the health response is already in hand. Corrects the stamp
+            // the update notice reads, without a request or a command of its own.
+            recordBackendRelease(s.releaseVersion);
             if (!s.reachable) return { ok: true, detail: "backend unreachable (skipped)" };
             if (s.serverVersion === null) return { ok: true, detail: "backend does not report a schema version" };
             if (s.matches) return { ok: true, detail: `schema v${s.serverVersion}` };

--- a/ix-cli/src/cli/commands/doctor.ts
+++ b/ix-cli/src/cli/commands/doctor.ts
@@ -13,7 +13,7 @@ import {
   checkBackendSchema,
   isNonStandardBackend,
 } from "../backend-status.js";
-import { readBackendHealth } from "./upgrade.js";
+import { backendCeiling, isNewer, readBackendHealth } from "./upgrade.js";
 
 interface CheckResult {
   ok: boolean;
@@ -127,7 +127,7 @@ export function registerDoctorCommand(program: Command): void {
             try {
               // Records what the backend says it is running; see
                // backend-version.ts. Free — this response is already needed.
-              const h = await readBackendHealth(client, endpoint);
+              const h = await readBackendHealth(client);
               return { ok: h.status === "ok", detail: `${endpoint} → ${h.status}` };
             } catch (e: any) {
               return { ok: false, detail: e.message ?? "unreachable" };
@@ -210,7 +210,7 @@ export function registerDoctorCommand(program: Command): void {
           // Ix#271: a graph written by an older engine fails scoped reads silently.
           name: "Graph schema matches engine",
           run: async () => {
-            const s = await checkBackendSchema(client);
+            const s = await checkBackendSchema(client, backendCeiling(), isNewer);
             if (!s.reachable) return { ok: true, detail: "backend unreachable (skipped)" };
             if (s.serverVersion === null) return { ok: true, detail: "backend does not report a schema version" };
             if (s.matches) return { ok: true, detail: `schema v${s.serverVersion}` };

--- a/ix-cli/src/cli/commands/doctor.ts
+++ b/ix-cli/src/cli/commands/doctor.ts
@@ -126,7 +126,7 @@ export function registerDoctorCommand(program: Command): void {
           run: async () => {
             try {
               // Records what the backend says it is running; see
-               // backend-version.ts. Free — this response is already needed.
+              // backend-version.ts. Free — this response is already needed.
               const h = await readBackendHealth(client);
               return { ok: h.status === "ok", detail: `${endpoint} → ${h.status}` };
             } catch (e: any) {

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -18,6 +18,7 @@ import { loadIngestionModules } from './ingestion-loader.js';
 import { ensureWorkspaceIdState } from '../bootstrap.js';
 import { detectSystem, repoWorkspaceIdFor, lookupPackage, readPackageNames, readPackageDeps } from '../system.js';
 import { CLIENT_EXPECTED_SCHEMA_VERSION } from '../backend-status.js';
+import { recordBackendRelease } from './upgrade.js';
 import { SUPPORTED_EXTENSIONS } from '../supported-extensions.js';
 import { canRenderProgress } from '../stderr.js';
 import { createTypeScriptModuleResolver } from '../ts-module-resolution.js';
@@ -941,6 +942,9 @@ export async function ingestFiles(
   // CLIENT_EXPECTED_SCHEMA_VERSION is shared with doctor/upgrade (backend-status).
   try {
     const health = await client.health();
+    // Free: this response is already in hand. Corrects the stamp the update
+    // notice reads, without a request or a command of its own.
+    recordBackendRelease((health as any)?.release_version);
     const serverVersion = (health as any)?.schema_version;
     if (typeof serverVersion === 'number' && serverVersion !== CLIENT_EXPECTED_SCHEMA_VERSION) {
       process.stderr.write(

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -941,7 +941,7 @@ export async function ingestFiles(
   // absolute→relative source_uri migration, or folding workspace_id into ids).
   // CLIENT_EXPECTED_SCHEMA_VERSION is shared with doctor/upgrade (backend-status).
   try {
-    const health = await readBackendHealth(client, getEndpoint());
+    const health = await readBackendHealth(client);
     const serverVersion = (health as any)?.schema_version;
     if (typeof serverVersion === 'number' && serverVersion !== CLIENT_EXPECTED_SCHEMA_VERSION) {
       process.stderr.write(

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -18,7 +18,7 @@ import { loadIngestionModules } from './ingestion-loader.js';
 import { ensureWorkspaceIdState } from '../bootstrap.js';
 import { detectSystem, repoWorkspaceIdFor, lookupPackage, readPackageNames, readPackageDeps } from '../system.js';
 import { CLIENT_EXPECTED_SCHEMA_VERSION } from '../backend-status.js';
-import { recordBackendRelease } from './upgrade.js';
+import { readBackendHealth } from './upgrade.js';
 import { SUPPORTED_EXTENSIONS } from '../supported-extensions.js';
 import { canRenderProgress } from '../stderr.js';
 import { createTypeScriptModuleResolver } from '../ts-module-resolution.js';
@@ -941,10 +941,7 @@ export async function ingestFiles(
   // absolute→relative source_uri migration, or folding workspace_id into ids).
   // CLIENT_EXPECTED_SCHEMA_VERSION is shared with doctor/upgrade (backend-status).
   try {
-    const health = await client.health();
-    // Free: this response is already in hand. Corrects the stamp the update
-    // notice reads, without a request or a command of its own.
-    recordBackendRelease((health as any)?.release_version);
+    const health = await readBackendHealth(client, getEndpoint());
     const serverVersion = (health as any)?.schema_version;
     if (typeof serverVersion === 'number' && serverVersion !== CLIENT_EXPECTED_SCHEMA_VERSION) {
       process.stderr.write(

--- a/ix-cli/src/cli/commands/status.ts
+++ b/ix-cli/src/cli/commands/status.ts
@@ -51,7 +51,7 @@ export function registerStatusCommand(program: Command): void {
     .action(async (opts: { format: string; root?: string }) => {
       const client = new IxClient(getEndpoint());
       try {
-        const health = await readBackendHealth(client, getEndpoint());
+        const health = await readBackendHealth(client);
         const root = resolveWorkspaceRoot(opts.root);
 
         // Detect stale files

--- a/ix-cli/src/cli/commands/status.ts
+++ b/ix-cli/src/cli/commands/status.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { renderSection, renderKeyValue, renderWarning, renderNote, renderSuccess } from "../ui.js";
 import { IxClient } from "../../client/api.js";
+import { recordBackendRelease } from "./upgrade.js";
 import { getEndpoint, resolveWorkspaceRoot } from "../config.js";
 import { detectStaleFiles } from "../stale.js";
 import { llmError, llmLine, printLlmLines } from "../llm.js";
@@ -51,6 +52,7 @@ export function registerStatusCommand(program: Command): void {
       const client = new IxClient(getEndpoint());
       try {
         const health = await client.health();
+        recordBackendRelease(health.release_version);
         const root = resolveWorkspaceRoot(opts.root);
 
         // Detect stale files

--- a/ix-cli/src/cli/commands/status.ts
+++ b/ix-cli/src/cli/commands/status.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import { renderSection, renderKeyValue, renderWarning, renderNote, renderSuccess } from "../ui.js";
 import { IxClient } from "../../client/api.js";
-import { recordBackendRelease } from "./upgrade.js";
+import { readBackendHealth } from "./upgrade.js";
 import { getEndpoint, resolveWorkspaceRoot } from "../config.js";
 import { detectStaleFiles } from "../stale.js";
 import { llmError, llmLine, printLlmLines } from "../llm.js";
@@ -51,8 +51,7 @@ export function registerStatusCommand(program: Command): void {
     .action(async (opts: { format: string; root?: string }) => {
       const client = new IxClient(getEndpoint());
       try {
-        const health = await client.health();
-        recordBackendRelease(health.release_version);
+        const health = await readBackendHealth(client, getEndpoint());
         const root = resolveWorkspaceRoot(opts.root);
 
         // Detect stale files

--- a/ix-cli/src/cli/commands/upgrade.ts
+++ b/ix-cli/src/cli/commands/upgrade.ts
@@ -10,12 +10,13 @@ import { canRenderProgress } from "../stderr.js";
 import type { IxClient } from "../../client/api.js";
 import {
   BACKEND_VERSION_FILE,
+  VERSION_RE,
   fetchBackendHealth,
   getTrackedVersion,
   writeVersionStamp,
 } from "../backend-version.js";
 
-export { BACKEND_VERSION_FILE, recordBackendRelease, writeVersionStamp } from "../backend-version.js";
+export { BACKEND_VERSION_FILE, VERSION_RE, recordBackendRelease, writeVersionStamp } from "../backend-version.js";
 
 /**
  * Fetch health and record what the backend says it is running.
@@ -25,8 +26,16 @@ export { BACKEND_VERSION_FILE, recordBackendRelease, writeVersionStamp } from ".
  * without recording, which is the mistake a grep-based guard could only detect
  * after the fact.
  */
-export async function readBackendHealth(client: IxClient, endpoint: string) {
-  return fetchBackendHealth(client, endpoint, readCache()?.backendLatest ?? null, isNewer);
+/** The newest backend release the CLI knows of; the ceiling a container may claim. */
+export function backendCeiling(): string | null {
+  return readCache()?.backendLatest ?? null;
+}
+
+export async function readBackendHealth(client: IxClient) {
+  // backendLatest, NOT latest: `latest` is the CLI's own release series, so a
+  // ceiling taken from it would refuse every legitimate container report for
+  // ever — silently reinstating the bug this exists to fix.
+  return fetchBackendHealth(client, backendCeiling(), isNewer);
 }
 
 const __filename = fileURLToPath(import.meta.url);
@@ -69,7 +78,6 @@ function getCurrentVersion(): string {
 // — `0.9.0-rc.1+abc1234`, valid semver — failed the test. fetchLatestRelease
 // then returned null and `ix upgrade` reported "Could not reach GitHub to check
 // for updates" and exited 1 against a perfectly reachable GitHub.
-export const VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 
 async function fetchLatestRelease(
   repo: string,

--- a/ix-cli/src/cli/commands/upgrade.ts
+++ b/ix-cli/src/cli/commands/upgrade.ts
@@ -7,6 +7,27 @@ import { homedir } from "os";
 import chalk from "chalk";
 import { BACKEND_IMAGE, checkBackendImage, isNonStandardBackend } from "../backend-status.js";
 import { canRenderProgress } from "../stderr.js";
+import type { IxClient } from "../../client/api.js";
+import {
+  BACKEND_VERSION_FILE,
+  fetchBackendHealth,
+  getTrackedVersion,
+  writeVersionStamp,
+} from "../backend-version.js";
+
+export { BACKEND_VERSION_FILE, recordBackendRelease, writeVersionStamp } from "../backend-version.js";
+
+/**
+ * Fetch health and record what the backend says it is running.
+ *
+ * The one entry point commands use, so the cache lookup and the version
+ * comparison live in exactly one place — and so no call site can fetch health
+ * without recording, which is the mistake a grep-based guard could only detect
+ * after the fact.
+ */
+export async function readBackendHealth(client: IxClient, endpoint: string) {
+  return fetchBackendHealth(client, endpoint, readCache()?.backendLatest ?? null, isNewer);
+}
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -19,7 +40,6 @@ const IX_HOME = process.env.IX_HOME || join(homedir(), ".ix");
 const VERSION_CACHE = join(IX_HOME, ".version-check.json");
 const COMPASS_DIR = join(IX_HOME, "cli", "compass");
 const COMPASS_VERSION_FILE = join(COMPASS_DIR, ".version");
-const BACKEND_VERSION_FILE = join(IX_HOME, ".backend-version");
 
 interface VersionCache {
   latest: string;
@@ -341,44 +361,7 @@ function shouldOfferCompassUpgrade(compassLatest: string | undefined): boolean {
   return shouldOfferCompassUpgradeFor(compassLatest, installedCompass());
 }
 
-function getTrackedVersion(versionFile: string): string {
-  try {
-    if (!existsSync(versionFile)) return "0.0.0";
-    return readFileSync(versionFile, "utf-8").trim() || "0.0.0";
-  } catch {
-    return "0.0.0";
-  }
-}
 
-/**
- * Record what the backend says it is.
- *
- * `.backend-version` was a record of what the CLI last installed, which is only
- * the same thing as what is RUNNING while nothing else moves the image. Pull
- * through docker compose, or through `ix docker start` after the tag moved, and
- * the file names an older release than the container — so the notice fires on
- * every command for ever. Ix#466 fixed the paths that run our code; this fixes
- * the rest, because the container is asked directly.
- *
- * Called wherever the CLI already has a health response, so it costs no extra
- * request and needs no new command: the stamp self-corrects the next time
- * anything touches the backend, in BOTH directions — a stamp stuck ahead is
- * repaired too, which no amount of local inspection could do.
- *
- * Validated with the same VERSION_RE the release feed is: the field is a
- * container env var the operator can set to anything, and writing arbitrary
- * text into the file the notice compares would be worse than not writing.
- * Older backends omit it entirely and arrive here as undefined.
- *
- * Silent and best-effort. It is bookkeeping attached to a command the user
- * actually ran, and a read-only IX_HOME must not make `ix status` fail; the
- * paths that can act on a failure already report it.
- */
-export function recordBackendRelease(reported: string | null | undefined): void {
-  if (!reported || !VERSION_RE.test(reported)) return;
-  if (reported === getTrackedVersion(BACKEND_VERSION_FILE)) return; // already agrees
-  writeVersionStamp(BACKEND_VERSION_FILE, reported);
-}
 
 /**
  * Whether to tell the user their backend is behind.
@@ -456,41 +439,6 @@ export function stampDisagreesWithPull(trackedVersion: string, pulled: string): 
   return isNewer(trackedVersion, pulled) || isNewer(pulled, trackedVersion);
 }
 
-/**
- * Record the backend release in its stamp file. Returns whether it was written.
- *
- * `mkdirSync` because IX_HOME may not exist yet — a stamp that fails to write
- * leaves the tracked version behind for ever, and the notice it drives says
- * "update available" on every command with no way for the user to see why.
- *
- * A falsy version is refused rather than written: not knowing which release we
- * are on is not the same as being on none of them. Being wrong *behind* costs a
- * nag, while being wrong *ahead* hides a genuinely stale backend and stops
- * `ix upgrade` from ever fetching it — so where there is a choice, this errs
- * behind. (It is not always a choice: the GHCR `:latest` tag and the
- * `ix-memory-layer-dist` release are separate publishing surfaces with nothing
- * correlating them, so a release cut between the two can be recorded ahead of
- * the image actually pulled. `ix upgrade` has always had that race; correcting
- * it needs the backend to report its own version.)
- *
- * The write does not throw — callers differ on whether a failure should be
- * fatal, so they decide from the return value rather than from an exception.
- * Not a general component-stamp writer: the compass stamp is written with a
- * trailing newline that `parseCompassStamp` depends on.
- */
-export function writeVersionStamp(
-  versionFile: string,
-  version: string | null | undefined,
-): boolean {
-  if (!version) return false;
-  try {
-    mkdirSync(dirname(versionFile), { recursive: true });
-    writeFileSync(versionFile, version);
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 /**
  * Whether this compose file runs the backend from the moving `:latest` tag.

--- a/ix-cli/src/cli/commands/upgrade.ts
+++ b/ix-cli/src/cli/commands/upgrade.ts
@@ -351,6 +351,36 @@ function getTrackedVersion(versionFile: string): string {
 }
 
 /**
+ * Record what the backend says it is.
+ *
+ * `.backend-version` was a record of what the CLI last installed, which is only
+ * the same thing as what is RUNNING while nothing else moves the image. Pull
+ * through docker compose, or through `ix docker start` after the tag moved, and
+ * the file names an older release than the container — so the notice fires on
+ * every command for ever. Ix#466 fixed the paths that run our code; this fixes
+ * the rest, because the container is asked directly.
+ *
+ * Called wherever the CLI already has a health response, so it costs no extra
+ * request and needs no new command: the stamp self-corrects the next time
+ * anything touches the backend, in BOTH directions — a stamp stuck ahead is
+ * repaired too, which no amount of local inspection could do.
+ *
+ * Validated with the same VERSION_RE the release feed is: the field is a
+ * container env var the operator can set to anything, and writing arbitrary
+ * text into the file the notice compares would be worse than not writing.
+ * Older backends omit it entirely and arrive here as undefined.
+ *
+ * Silent and best-effort. It is bookkeeping attached to a command the user
+ * actually ran, and a read-only IX_HOME must not make `ix status` fail; the
+ * paths that can act on a failure already report it.
+ */
+export function recordBackendRelease(reported: string | null | undefined): void {
+  if (!reported || !VERSION_RE.test(reported)) return;
+  if (reported === getTrackedVersion(BACKEND_VERSION_FILE)) return; // already agrees
+  writeVersionStamp(BACKEND_VERSION_FILE, reported);
+}
+
+/**
  * Whether to tell the user their backend is behind.
  *
  * The two branches of `checkForUpdate` — cached and freshly fetched — each made

--- a/ix-cli/src/cli/commands/upgrade.ts
+++ b/ix-cli/src/cli/commands/upgrade.ts
@@ -16,7 +16,11 @@ import {
   writeVersionStamp,
 } from "../backend-version.js";
 
-export { BACKEND_VERSION_FILE, VERSION_RE, recordBackendRelease, writeVersionStamp } from "../backend-version.js";
+// Re-exported for the existing importers of this module (tests and call sites
+// that predate backend-version.ts). recordBackendRelease is deliberately NOT
+// among them: it is reached only through fetchBackendHealth, and re-exporting
+// it here would advertise a second way in.
+export { BACKEND_VERSION_FILE, VERSION_RE, writeVersionStamp } from "../backend-version.js";
 
 /**
  * Fetch health and record what the backend says it is running.

--- a/ix-cli/src/client/api.ts
+++ b/ix-cli/src/client/api.ts
@@ -25,7 +25,9 @@ export class IxClient {
   // per-request timeouts (5-30 min each), the whole operation aborts and the
   // process exits instead of grinding for hours and stacking with re-launches.
   constructor(
-    private endpoint: string = "http://localhost:8090",
+    // readonly so callers can ask which endpoint a response came FROM, rather
+    // than being handed a second string that is only equal by inspection.
+    public readonly endpoint: string = "http://localhost:8090",
     private deadlineSignal?: AbortSignal,
   ) {}
 

--- a/ix-cli/src/client/types.ts
+++ b/ix-cli/src/client/types.ts
@@ -154,6 +154,14 @@ export interface HealthResponse {
   // differs from this, it forces a clean re-ingest (e.g. absolute→relative
   // source_uri migration changes every node ID).
   schema_version?: number;
+  // The published release the running container was built as, when it knows.
+  // Absent from any backend older than Ix-memory#157, and from any image not
+  // built by the release pipeline — both mean "fall back to what you tracked".
+  // This is the container's own claim, not proof: it is an env var, so
+  // `docker run -e` overrides it. It is the right answer to "what do you think
+  // you are" and the wrong one to "what are you really", which is what
+  // checkBackendImage's digest comparison is for.
+  release_version?: string;
 }
 
 export interface PatchSource {


### PR DESCRIPTION
The consumer for [Ix-memory#157](https://github.com/ix-infrastructure/Ix-memory/pull/157). **No new command, no new output** — you notice it because a wrong message stops appearing.

## The bug

`~/.ix/.backend-version` records what the CLI last **installed**. That is the same thing as what is **running** only while nothing else moves the image. Pull through `docker compose` and the file names an older release than the container, so "Backend update available" fires on every command for ever.

That nag is what started #466. #466 fixed it at the write, for the paths that run our code — it cannot help a plain `docker compose` user, because nothing of ours executes there.

## The fix

Ask the container. As of Ix-memory#157 it reports the release it was built as on `/v1/health`, so every site that **already holds a health response** records what it read — `ix status`, `ix doctor`, `ix map`/`ingest`. The stamp self-corrects the next time anything touches the backend, at the cost of no extra request. The notice keeps reading the same file; the file stops being a guess.

It corrects in **both** directions, which no local inspection can do. A stamp stuck *ahead* silences the notice through the next release the user should have been told about, and `docker image inspect ...:latest` is registry-blind so it cannot tell you that.

## Guards

The field is a container env var an operator can set to anything, so it is not taken on trust:

- validated against the same `VERSION_RE` the release feed is, and length-bounded before any of that
- ignored when absent — every backend older than #157, which must keep behaving exactly as today
- **only for a local endpoint**, checked against the exact string the request went to
- never rewritten when it already agrees: this is on the hot path and the write is not atomic
- silent and best-effort — bookkeeping attached to a command the user actually ran must not make `ix status` fail on a read-only `IX_HOME`

**One chokepoint.** `fetchBackendHealth` is the only place that reads a health body, and it fetches and records together, so "a new call site forgot to record" is not a mistake that can be made. `checkBackendSchema` reaches it too — the import cycle that used to force `backend-status.ts` to stay outside does not exist, since `backend-version.ts` imports only node builtins and two erased type imports.

**What the ceiling does and does not do.** A reported version may not exceed the newest release we know of, so a container reporting `99.0.0` cannot permanently silence the notice and make `ix upgrade` skip the pull. It does *not* stop a container reporting **exactly** the ceiling — a compromised one has outbound network and can read the public release feed rather than guess. That reaches the same silenced state by looking the answer up, and it is a capability this feature introduces: previously the stamp was written only by our own install/pull paths. Accepted deliberately, and now documented where the ceiling is: the alternative is to distrust the only component that knows what it is running, the fail-safe direction (under-reporting → an unnecessary pull) stays open, and `ix doctor`'s digest comparison remains the check that does not ask the container what it is.

## Validation

Against real containers, not stubs — a locally built backend image reporting `1.0.16`:

| scenario | backend reports | stamp before | after |
|---|---|---|---|
| `ix status` | `1.0.16` | `1.0.13` | **`1.0.16`**, notice gone |
| `ix doctor` | `1.0.16` | `1.0.13` | **`1.0.16`** |
| `ix status` | *(nothing)* | `1.0.13` | **`1.0.13`** untouched |

Mutation-checked throughout. The no-rewrite test asserts the **mtime** — rewriting the same string leaves the contents identical, so a contents check proves nothing there.

Adversarial review of this branch found four surviving mutants, all now killed:

- **the required bounds were pinned only against call sites.** `tsc` does reject an omitted argument (verified: `TS2554: Expected 3 arguments, but got 1`), but the *callee* could drop them — mutating `checkBackendSchema`'s forward to `fetchBackendHealth(client, null, isNewer)` survived the whole suite, because `backend-status.test.ts` uses a remote endpoint on purpose so the recorder never ran there. Three cases now drive it through a local fake; the load-bearing one puts the stamp *ahead*, where only a genuinely forwarded ceiling refuses the value.
- **the corrupt-ceiling test passed for the wrong reason.** `splitVersion` parses `"not-a-version"` to major `0`, so the assertion held with or without the shape check. Fixture is now `"99999"`.
- **`health?.` was unpinned** — no fake returned a non-object. A 200 with a literally `null` body is now a case.
- **the chokepoint guard was narrower than its prose.** A second guard now pins who may name `/v1/health`, and how many times, verified against a planted raw `fetch`.

Three review rounds went into that second guard, and the honest summary of it is narrow enough to be worth stating here rather than burying in the test. It **catches** a new file naming the path, a second *inline* use inside a listed file, and the removal of a listed use — so the allowlist cannot go stale silently, which is the only reason it is code and not a comment. It does **not** catch a reader inside a listed file that reuses the existing constant, or a path assembled from fragments. The three listed files are therefore *trusted, not checked*; what actually stops a body read there is that all three use `curl` with stdio ignored.

Two rounds of trying to make it stricter each made it worse in an instructive way. Stripping trailing `//` comments to stop prose tripping the guard silently erased three real spellings — a protocol-relative `` `${proto}//${host}/v1/health` ``, a `"//localhost:8090/…"` literal, and a doubled-slash template — because the `//` followed `}` or `"` rather than `:`. That rule is reverted: prose in a trailing comment now fails this test, deliberately, because a false positive is a confusing red CI while a false negative is no guard at all.

`isLocalEndpoint` was attacked with 38 hostile inputs — `127.0.0.1.evil.com`, `localhost.evil.com`, `http://127.0.0.1@evil.com/`, IDN `127。0。0。1`, `0x7f.1`, `2130706433`, `017700000001`, `[::ffff:127.0.0.1]`, uppercase and trailing dots. Every `true` is a real loopback after WHATWG normalisation; the two false negatives both fail closed. No path escape is reachable: the value is file *contents*, the destination is fixed, and `VERSION_RE` admits no separator, NUL or newline.

1167 passing / 18 skipped locally; the 3 failures are the known Windows symlink-EPERM in `read-containment.test.ts`. Green on all 21 CI checks including CodeQL, E2E and the platform matrix. Lint, typecheck and knip clean.

## Ordering

Safe to merge before or after #157 — with no backend reporting the field, every path is a no-op and behaviour is exactly as today.
