### PR TITLE
chore(release): 0.10.1

### DIFF
--- a/ix-cli/package-lock.json
+++ b/ix-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ix/cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ix/cli",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
         "chalk": "^6.0.0",

--- a/ix-cli/package-lock.json
+++ b/ix-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ix/cli",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ix/cli",
-      "version": "0.9.3",
+      "version": "0.10.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
         "chalk": "^6.0.0",

--- a/ix-cli/package.json
+++ b/ix-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ix/cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "type": "module",
   "description": "Ix Memory — Persistent Memory for LLM Systems",
   "main": "dist/index.js",

--- a/ix-cli/package.json
+++ b/ix-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ix/cli",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "type": "module",
   "description": "Ix Memory — Persistent Memory for LLM Systems",
   "main": "dist/index.js",

--- a/ix-cli/src/cli/__tests__/watch-dedup.test.ts
+++ b/ix-cli/src/cli/__tests__/watch-dedup.test.ts
@@ -98,12 +98,20 @@ describe("canonical watch refresh", () => {
 
   it("starts both the tsx source CLI and a normal built CLI child", () => {
     const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+    // Read, never hardcode. The literal that used to sit here made every
+    // `chore(release)` bump fail this test, which is about whether the child
+    // STARTS -- the number it prints is incidental. The same value seeds
+    // .version-check.json so the update notice cannot appear on stdout and be
+    // mistaken for the version.
+    const version = JSON.parse(
+      fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"),
+    ).version as string;
     const tempRoot = fs.mkdtempSync(path.join(packageRoot, ".watch-child-runtime-"));
     const ixHome = path.join(tempRoot, "ix-home");
     fs.mkdirSync(ixHome);
     fs.writeFileSync(
       path.join(ixHome, ".version-check.json"),
-      JSON.stringify({ latest: "0.9.3", checkedAt: Date.now() }),
+      JSON.stringify({ latest: version, checkedAt: Date.now() }),
     );
     const env = { ...process.env, IX_HOME: ixHome, NO_COLOR: "1" };
 
@@ -115,7 +123,7 @@ describe("canonical watch refresh", () => {
         { cwd: packageRoot, env, encoding: "utf8" },
       );
       expect(source.status, source.stderr).toBe(0);
-      expect(source.stdout.trim()).toBe("0.9.3");
+      expect(source.stdout.trim()).toBe(version);
       expect(source.stderr).not.toContain("Debugger listening");
 
       const outDir = path.join(tempRoot, "dist");


### PR DESCRIPTION
Bumps `ix-cli` to **0.10.1**.

Retargeted from 0.10.0, which this PR originally carried: v0.10.0 shipped while it sat in review. The release workflow runs `npm version "$VERSION"` at build time (`release.yml:205`), so that tag still produced a correct artifact — what an unbumped tree costs is a *source checkout* of `main`, which has reported 0.9.3 since GA.

## The trip-wire this also removes

`watch-dedup.test.ts` asserted the literal `"0.9.3"` from `ix --version`, so **every** `chore(release)` bump turned it red — including this one. It reads `package.json` now.

That test is about whether the watch child *starts*; the number it prints is incidental, which is why reading the value is not a weaker assertion than pinning it. The same value seeds `.version-check.json` so the update notice cannot appear on stdout and be mistaken for the version — see the note in the diff.

The change needed no retargeting of its own, which is the point of it: it is version-agnostic by construction, so 0.10.2 will not reopen this.

## Verified

- `watch-dedup.test.ts` — 15/15 green against the 0.10.1 tree
- The bump is `npm version`'s own output, so `package-lock.json` tracks it

## Note on the two commits

The retarget is a second commit rather than an amend, because rewriting the branch was not available to me here. It squash-merges to a single `chore(release): 0.10.1`, so nothing about the merged history changes.

Not a blocker for tagging v0.10.1 — a tag alone is sufficient, as v0.10.0 demonstrated. This is about `main` telling the truth about itself.
