### PR TITLE
fix(upgrade): stop `--check` calling an out-of-date install up to date

### DIFF
--- a/ix-cli/src/cli/__tests__/upgrade-check-closing-line.test.ts
+++ b/ix-cli/src/cli/__tests__/upgrade-check-closing-line.test.ts
@@ -1,0 +1,99 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { closingStatus } from "../commands/upgrade.js";
+
+/**
+ * `ix upgrade --check` used to close with `[ok] ix is up to date` no matter what
+ * it had just found, two lines under `New CLI version available: 0.10.0` (#476).
+ *
+ * The decision is tested twice over, and deliberately so. `closingStatus` covers
+ * the rule; the command test below covers the wiring, because a branch that
+ * forgets to record what it found leaves the rule correct and the output wrong —
+ * which is the shape of the original bug.
+ */
+describe("closingStatus", () => {
+  it("refuses to call an out-of-date install up to date under --check", () => {
+    const status = closingStatus(true, ["CLI 0.9.2 → 0.10.0"]);
+    expect(status.upToDate).toBe(false);
+    expect(status).toHaveProperty("summary", "CLI 0.9.2 → 0.10.0");
+  });
+
+  it("lists every outstanding component, not just the first", () => {
+    const status = closingStatus(true, ["CLI 0.9.2 → 0.10.0", "backend 1.0.16 → 1.0.17"]);
+    // Reporting only the CLI would still be "not up to date" and still pass a
+    // looser assertion, while hiding the two components the user must also pull.
+    expect(status).toHaveProperty("summary", "CLI 0.9.2 → 0.10.0, backend 1.0.16 → 1.0.17");
+  });
+
+  it("says up to date under --check when nothing is outstanding", () => {
+    expect(closingStatus(true, []).upToDate).toBe(true);
+  });
+
+  it("keeps the flat line on an install run, which has already acted", () => {
+    // Not a shortcut: on this path every entry in the list has been installed by
+    // the time the line prints, so reporting them as outstanding would describe
+    // the work that just succeeded as still pending.
+    expect(closingStatus(false, ["CLI 0.9.2 → 0.10.0"]).upToDate).toBe(true);
+    expect(closingStatus(undefined, ["CLI 0.9.2 → 0.10.0"]).upToDate).toBe(true);
+  });
+});
+
+describe("ix upgrade --check output", () => {
+  let home: string;
+  let logs: string[];
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "ix-upgrade-check-"));
+    process.env.IX_HOME = home;
+    logs = [];
+    // console, not process.stdout.write: vitest replaces the console object, so
+    // patching the stream underneath it captures nothing and the assertion can
+    // never fail.
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete process.env.IX_HOME;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  async function runCheck(latestTag: string): Promise<string> {
+    vi.stubGlobal("fetch", async () =>
+      new Response(JSON.stringify({ tag_name: latestTag }), { status: 200 }),
+    );
+    // Imported after IX_HOME is set: the module reads it at load time.
+    const { Command } = await import("commander");
+    const { registerUpgradeCommand } = await import("../commands/upgrade.js");
+    const program = new Command();
+    program.exitOverride();
+    registerUpgradeCommand(program);
+    await program.parseAsync(["node", "ix", "upgrade", "--check"]);
+    return logs.join("\n");
+  }
+
+  it("does not claim to be up to date when it just announced a new version", async () => {
+    const out = await runCheck("v99.0.0");
+    expect(out).toContain("New CLI version available");
+    expect(out).toContain("Run: ix upgrade");
+    // The bug, stated as an assertion: these two cannot both be on screen.
+    expect(out).not.toContain("ix is up to date");
+
+    // Name the CLI *in the closing line*, not merely somewhere on screen. A
+    // throwaway IX_HOME has no backend or compass stamp either, so both of those
+    // are outstanding too and a bare `toContain("Update available")` passes even
+    // when the CLI branch records nothing — the exact wiring this test exists to
+    // hold. Matched by the fetched version rather than the current one, which
+    // moves with every release bump.
+    const closing = out.split("\n").find((l) => l.includes("Update available:"));
+    expect(closing).toBeDefined();
+    expect(closing).toMatch(/\bCLI\b/);
+    expect(closing).toContain("99.0.0");
+  });
+});

--- a/ix-cli/src/cli/commands/upgrade.ts
+++ b/ix-cli/src/cli/commands/upgrade.ts
@@ -1286,6 +1286,30 @@ function printUpdateNotice(
   console.error("");
 }
 
+/**
+ * How `ix upgrade` signs off.
+ *
+ * `--check` answers exactly one question — is there anything to install? — and
+ * the closing line was `[ok] ix is up to date` unconditionally, so it answered
+ * it wrong for every user who was behind. It printed two lines under
+ * `New CLI version available: 0.10.0` and contradicted it (#476). GA moving
+ * /releases/latest is what made that the common case rather than a rare one.
+ *
+ * An install run keeps the flat line, and that is not an oversight: by the time
+ * it prints, every branch that added to `outstanding` has already acted on it,
+ * so there the list says what was found and handled, not what is left. Reusing
+ * it there would report the work that just succeeded as still pending.
+ */
+export function closingStatus(
+  check: boolean | undefined,
+  outstanding: readonly string[],
+): { upToDate: true } | { upToDate: false; summary: string } {
+  if (check && outstanding.length > 0) {
+    return { upToDate: false, summary: outstanding.join(", ") };
+  }
+  return { upToDate: true };
+}
+
 export function registerUpgradeCommand(program: Command): void {
   program
     .command("upgrade")
@@ -1325,10 +1349,16 @@ export function registerUpgradeCommand(program: Command): void {
       if (!opts.check) sweepUpgradeOrphans(IX_HOME, join(IX_HOME, "cli"));
 
       // ── CLI upgrade ──────────────────────────────────────────────────
+      // What is still outstanding when the command ends. Only meaningful under
+      // --check: an install pass acts on each of these as it goes, so there the
+      // list describes what was found, not what is left. See the closing line.
+      const outstanding: string[] = [];
+
       const cliUpToDate = !isNewer(latest, current);
       if (cliUpToDate) {
         console.log(`[ok] CLI already on the latest version (${current})`);
       } else {
+        outstanding.push(`CLI ${current} → ${latest}`);
         console.log(`New CLI version available: ${chalk.green(latest)}`);
 
         if (!opts.check) {
@@ -1527,6 +1557,7 @@ export function registerUpgradeCommand(program: Command): void {
       const backendCurrent = getTrackedVersion(BACKEND_VERSION_FILE);
       let backendImageChanged = false;
       if (backendLatest && backendUpdateAvailable(backendLatest, backendCurrent)) {
+        outstanding.push(`backend ${backendCurrent === "0.0.0" ? "none" : backendCurrent} → ${backendLatest}`);
         console.log(
           `Backend update available: ${backendCurrent === "0.0.0" ? "none" : backendCurrent} → ${chalk.green(backendLatest)}`
         );
@@ -1623,6 +1654,9 @@ export function registerUpgradeCommand(program: Command): void {
       // ── Compass upgrade ──────────────────────────────────────────────
       const compassCurrent = getInstalledCompassVersion();
       if (shouldOfferCompassUpgrade(compassLatest ?? undefined)) {
+        outstanding.push(
+          `Compass ${compassCurrent === "0.0.0" ? "none" : compassCurrent} → ${compassLatest}`
+        );
         console.log(
           `Compass update available: ${compassCurrent === "0.0.0" ? "none" : compassCurrent} → ${chalk.green(compassLatest)}`
         );
@@ -1716,6 +1750,12 @@ export function registerUpgradeCommand(program: Command): void {
       writeCache(latest, compassLatest ?? undefined, backendLatest ?? undefined);
 
       console.log("");
-      console.log("[ok] ix is up to date");
+      const closing = closingStatus(opts.check, outstanding);
+      if (closing.upToDate) {
+        console.log("[ok] ix is up to date");
+      } else {
+        console.log(chalk.yellow(`[!!] Update available: ${closing.summary}`));
+        console.log(chalk.dim("  Run: ix upgrade"));
+      }
     });
 }


### PR DESCRIPTION
Closes #476.

## The bug

`ix upgrade --check` closed with `[ok] ix is up to date` unconditionally — two
lines under `New CLI version available: 0.10.0`:

```
Current version: 0.9.2
New CLI version available: 0.10.0
[ok] Backend already on the latest version (1.0.17)
[ok] Compass already on the latest version (0.9.2)

[ok] ix is up to date        <-- it is not
```

`--check` exists to answer one question — is there anything to install? — and it
answered it wrong for every user who was behind.

## After

```
Current version: 0.9.3
New CLI version available: 0.10.0
Backend update available: none → 1.0.17
Compass update available: none → 0.3.0

[!!] Update available: CLI 0.9.3 → 0.10.0, backend none → 1.0.17, Compass none → 0.3.0
  Run: ix upgrade
```

A current install is unchanged: `[ok] ix is up to date`. Both verified against
the live v0.10.0 release, not a stub.

## The install path deliberately keeps the flat line

`ix upgrade` without `--check` still closes with `[ok] ix is up to date`, and
that is not an oversight. Every branch that adds to `outstanding` has already
acted on it by the time the line prints, so reusing the list there would report
the work that just succeeded as still pending.

## Tests

Five, in `upgrade-check-closing-line.test.ts`, covering the rule (`closingStatus`)
and the wiring (the real command, driven through commander with `fetch` stubbed
and a throwaway `IX_HOME`).

Mutation-checked both ways:

| mutation | result |
|---|---|
| restore the unconditional closing line | ✗ red |
| keep the fix, drop the CLI branch's `outstanding.push` | ✗ red |

The second one matters. The first version of that test asserted only
`toContain("Update available")` and **passed** with the CLI branch broken — a
throwaway `IX_HOME` has no backend or compass stamp either, so those two are
outstanding regardless and kept the line on screen. It now matches the closing
line itself and requires the CLI named in it, keyed to the fetched version rather
than the current one so a release bump does not rot it.

## Not a 0.10.0 regression

0.9.x has the same bug. GA moving `/releases/latest` to v0.10.0 is what turned it
from a rare case into the one most installs now hit, which is why it is worth a
patch release rather than waiting.