### PR TITLE
fix(doctor): inspect backend behind compose proxy

### DIFF
--- a/ix-cli/src/cli/__tests__/backend-container-inspection.test.ts
+++ b/ix-cli/src/cli/__tests__/backend-container-inspection.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const execFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({ execFileSync }));
+
+import { BACKEND_IMAGE, checkBackendImage, inspectBackendContainer } from "../backend-status.js";
+
+describe("inspectBackendContainer", () => {
+  beforeEach(() => {
+    execFileSync.mockReset();
+  });
+
+  it("checks the memory-layer image behind a compose port proxy", () => {
+    execFileSync.mockImplementation((_command: string, args: string[]) => {
+      if (args[0] === "info") return "ok";
+      if (args[0] === "ps" && args.includes("publish=8090")) return "proxy-id";
+      if (args[0] === "inspect" && args[1] === "proxy-id") {
+        return "sha256:proxy|::|nginx:stable|::|ix|::|/tmp/docker-compose.yml";
+      }
+      if (args[0] === "image" && args[2] === "sha256:proxy") {
+        return '["nginx@sha256:proxy"]';
+      }
+      if (args[0] === "ps" && args.includes("label=com.docker.compose.service=memory-layer")) {
+        return "backend-id";
+      }
+      if (args[0] === "inspect" && args[1] === "backend-id") {
+        return `sha256:backend|::|${BACKEND_IMAGE}:latest|::|ix|::|/tmp/docker-compose.yml`;
+      }
+      if (args[0] === "image" && args[2] === "sha256:backend") {
+        return `["${BACKEND_IMAGE}@sha256:backend"]`;
+      }
+      if (args[0] === "image" && args[2] === `${BACKEND_IMAGE}:latest`) {
+        return "sha256:backend";
+      }
+      throw new Error(`unexpected docker invocation: ${args.join(" ")}`);
+    });
+
+    expect(checkBackendImage()).toMatchObject({
+      kind: "ok",
+      container: {
+        containerId: "backend-id",
+        imageRef: `${BACKEND_IMAGE}:latest`,
+        imageId: "sha256:backend",
+      },
+    });
+    expect(execFileSync).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining([
+        "label=com.docker.compose.project=ix",
+        "label=com.docker.compose.service=memory-layer",
+      ]),
+      expect.any(Object),
+    );
+  });
+
+  it("keeps a directly-published local backend available for freshness warnings", () => {
+    execFileSync.mockImplementation((_command: string, args: string[]) => {
+      if (args[0] === "ps" && args.includes("publish=8090")) return "local-id";
+      if (args[0] === "inspect" && args[1] === "local-id") {
+        return "sha256:local|::|ix-memory-layer-dev:latest|::||::|";
+      }
+      if (args[0] === "image" && args[2] === "sha256:local") return "[]";
+      throw new Error(`unexpected docker invocation: ${args.join(" ")}`);
+    });
+
+    expect(inspectBackendContainer()).toMatchObject({
+      containerId: "local-id",
+      imageRef: "ix-memory-layer-dev:latest",
+    });
+  });
+});

--- a/ix-cli/src/cli/backend-status.ts
+++ b/ix-cli/src/cli/backend-status.ts
@@ -52,13 +52,7 @@ export interface BackendContainer {
   composeConfigFiles: string | null;
 }
 
-/** Inspect the container currently publishing the backend port, if any. */
-export function inspectBackendContainer(): BackendContainer | null {
-  const ids = docker(["ps", "--filter", `publish=${BACKEND_PORT}`, "--format", "{{.ID}}"]);
-  if (!ids) return null;
-  const containerId = ids.split("\n")[0]?.trim();
-  if (!containerId) return null;
-
+function inspectContainer(containerId: string): BackendContainer | null {
   // A unique separator keeps Go-template parsing robust against odd image refs.
   const SEP = "|::|";
   const fmt =
@@ -88,6 +82,51 @@ export function inspectBackendContainer(): BackendContainer | null {
     composeProject: project || null,
     composeConfigFiles: configFiles || null,
   };
+}
+
+function containerIds(output: string | null): string[] {
+  return output?.split("\n").map((id) => id.trim()).filter(Boolean) ?? [];
+}
+
+function isReleasedBackendRef(imageRef: string): boolean {
+  return imageRef === BACKEND_IMAGE ||
+    imageRef.startsWith(`${BACKEND_IMAGE}:`) ||
+    imageRef.startsWith(`${BACKEND_IMAGE}@`);
+}
+
+/** Inspect the backend reached through the container publishing its port. */
+export function inspectBackendContainer(): BackendContainer | null {
+  const publisherIds = containerIds(
+    docker(["ps", "--filter", `publish=${BACKEND_PORT}`, "--format", "{{.ID}}"]),
+  );
+  if (publisherIds.length === 0) return null;
+
+  const publishers = publisherIds
+    .map((id) => inspectContainer(id))
+    .filter((container): container is BackendContainer => container !== null);
+  const directBackend = publishers.find((container) => isReleasedBackendRef(container.imageRef));
+  if (directBackend) return directBackend;
+
+  // A hardened compose may publish 8090 through nginx while the memory layer
+  // stays on an internal network. Follow the publisher's compose project to
+  // the service whose role is the backend instead of comparing nginx to GHCR.
+  for (const publisher of publishers) {
+    if (!publisher.composeProject) continue;
+    const backendIds = containerIds(docker([
+      "ps",
+      "--filter", `label=com.docker.compose.project=${publisher.composeProject}`,
+      "--filter", "label=com.docker.compose.service=memory-layer",
+      "--format", "{{.ID}}",
+    ]));
+    for (const id of backendIds) {
+      const backend = inspectContainer(id);
+      if (backend) return backend;
+    }
+  }
+
+  // Preserve local-development detection for a directly-published backend
+  // whose image does not use the released repository name.
+  return publishers[0] ?? null;
 }
 
 export type BackendImageStatus =


### PR DESCRIPTION
Closes #481.

## Summary
Make backend image checks inspect the memory-layer service behind a compose port proxy.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Prefer a directly published released backend when present.
- When 8090 is published by another service, follow its compose project to `com.docker.compose.service=memory-layer`.
- Preserve local-build warnings for directly published development backends.
- Add a regression test for a proxy-fronted compose project.

## Validation
- Backend container inspection and backend status tests
- `npm test`
- `npm run typecheck`
- ESLint on changed files
- `git diff --check`

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
