### PR TITLE
fix(status): flag workspaces without a completed map

### DIFF
--- a/ix-cli/src/cli/__tests__/llm-tier5.test.ts
+++ b/ix-cli/src/cli/__tests__/llm-tier5.test.ts
@@ -137,6 +137,7 @@ describe("read --format llm", () => {
 describe("status --format llm", () => {
   it("answers 'can I trust the graph' in one field", () => {
     const lines = renderStatusLlm("ok", "http://localhost:8090", {
+      mapCompleted: true,
       currentRev: 11, lastIngestAt: "2026-08-09T12:00:00.000Z",
       staleFiles: 2, sampleChangedFiles: ["src/a.ts", "src/b.ts"],
     });
@@ -150,11 +151,22 @@ describe("status --format llm", () => {
 
   it("says stale=false rather than omitting it when the graph is current", () => {
     const lines = renderStatusLlm("ok", "http://localhost:8090", {
+      mapCompleted: true,
       currentRev: 11, lastIngestAt: null, staleFiles: 0, sampleChangedFiles: [],
     });
 
     expect(lines[0]).toContain("stale=false");
     expect(lines[0]).toContain("stale_files=0");
+  });
+
+  it("does not call a workspace current before any map completed", () => {
+    const lines = renderStatusLlm("ok", "http://localhost:8090", {
+      mapCompleted: false,
+      currentRev: 0, lastIngestAt: null, staleFiles: 0, sampleChangedFiles: [],
+    });
+
+    expect(lines[0]).toContain("map_complete=false");
+    expect(lines[0]).toContain("stale=true");
   });
 
   it("omits the staleness fields entirely when there is no baseline to read", () => {

--- a/ix-cli/src/cli/__tests__/stale-workspace.test.ts
+++ b/ix-cli/src/cli/__tests__/stale-workspace.test.ts
@@ -61,6 +61,7 @@ describe("workspace-scoped staleness", () => {
     moveMtimeForward(fileA);
     const beforeB = detectStaleFiles(rootA);
     expect(beforeB).toEqual({
+      mapCompleted: true,
       lastIngestAt: ingestedA.toISOString(),
       currentRev: 11,
       staleFiles: 1,
@@ -110,6 +111,7 @@ describe("workspace-scoped staleness", () => {
     writeSource(root, "new.js", "export const value = 1;\n");
 
     expect(detectStaleFiles(root)).toEqual({
+      mapCompleted: false,
       lastIngestAt: null,
       currentRev: 0,
       staleFiles: 0,
@@ -145,6 +147,7 @@ describe("workspace-scoped staleness", () => {
     fs.unlinkSync(filePath);
 
     expect(detectStaleFiles(root)).toEqual({
+      mapCompleted: true,
       lastIngestAt: ingestedAt.toISOString(),
       currentRev: 14,
       staleFiles: 1,

--- a/ix-cli/src/cli/commands/status.ts
+++ b/ix-cli/src/cli/commands/status.ts
@@ -7,6 +7,7 @@ import { detectStaleFiles } from "../stale.js";
 import { llmError, llmLine, printLlmLines } from "../llm.js";
 
 interface StatusStaleInfo {
+  mapCompleted: boolean;
   currentRev: number;
   lastIngestAt: string | null;
   staleFiles: number;
@@ -31,10 +32,11 @@ export function renderStatusLlm(
   const lines = [llmLine("status", [
     ["backend", backend],
     ["endpoint", endpoint],
+    ["map_complete", staleInfo ? String(staleInfo.mapCompleted) : null],
     ["rev", staleInfo ? String(staleInfo.currentRev) : null],
     ["last_ingest_at", staleInfo?.lastIngestAt ?? null],
     ["stale_files", staleInfo ? String(staleInfo.staleFiles) : null],
-    ["stale", staleInfo ? (staleInfo.staleFiles > 0 ? "true" : "false") : null],
+    ["stale", staleInfo ? (!staleInfo.mapCompleted || staleInfo.staleFiles > 0 ? "true" : "false") : null],
   ])];
   for (const f of staleInfo?.sampleChangedFiles ?? []) {
     lines.push(llmLine("changed", [["path", f]]));
@@ -67,6 +69,7 @@ export function registerStatusCommand(program: Command): void {
         } else if (opts.format === "json") {
           const result: any = {
             backend: health.status,
+            mapCompleted: staleInfo?.mapCompleted ?? null,
             currentRev: staleInfo?.currentRev ?? null,
             lastIngestAt: staleInfo?.lastIngestAt ?? null,
             staleFiles: staleInfo?.staleFiles ?? 0,
@@ -83,7 +86,10 @@ export function registerStatusCommand(program: Command): void {
               const ago = timeSince(staleInfo.lastIngestAt);
               renderKeyValue("Last ingest", ago);
             }
-            if (staleInfo.staleFiles > 0) {
+            if (!staleInfo.mapCompleted) {
+              renderWarning("No completed map is recorded for this workspace.");
+              renderNote("Run ix map to build a trustworthy graph.");
+            } else if (staleInfo.staleFiles > 0) {
               renderWarning(`${staleInfo.staleFiles} file(s) changed since last ingest:`);
               for (const f of staleInfo.sampleChangedFiles) {
                 console.log(`    ${f}`);

--- a/ix-cli/src/cli/stale.ts
+++ b/ix-cli/src/cli/stale.ts
@@ -5,6 +5,7 @@ import { loadIngestBaseline } from "./ingest-baseline.js";
 import { SUPPORTED_EXTENSIONS } from "./supported-extensions.js";
 
 export interface StaleInfo {
+  mapCompleted: boolean;
   lastIngestAt: string | null;
   currentRev: number;
   staleFiles: number;
@@ -89,7 +90,13 @@ export function detectStaleFiles(
   const workspaceRoot = path.resolve(root);
   const baseline = loadIngestBaseline(workspaceRoot);
   if (!baseline) {
-    return { lastIngestAt: null, currentRev: 0, staleFiles: 0, sampleChangedFiles: [] };
+    return {
+      mapCompleted: false,
+      lastIngestAt: null,
+      currentRev: 0,
+      staleFiles: 0,
+      sampleChangedFiles: [],
+    };
   }
 
   const files = collectFiles(workspaceRoot);
@@ -121,6 +128,7 @@ export function detectStaleFiles(
   }
 
   return {
+    mapCompleted: true,
     lastIngestAt: baseline.lastIngestAt,
     currentRev: baseline.currentRev,
     staleFiles: changedFiles.length,


### PR DESCRIPTION
Closes #485.

## Summary
Stop reporting a workspace as current when no map has completed successfully.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Carry explicit map-completion state from the workspace ingest baseline.
- Expose `mapCompleted` in JSON and `map_complete` in LLM output.
- Mark a workspace with no completed map as stale and show actionable text guidance.
- Add regression coverage for unmapped and completed workspaces.

## Validation
- Workspace staleness and LLM status tests
- `npm test`
- `npm run typecheck`
- ESLint on changed files
- `git diff --check`

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
