### PR TITLE
fix(context): consume summarized graph results

### DIFF
--- a/ix-cli/src/cli/__tests__/context-pick-validation.test.ts
+++ b/ix-cli/src/cli/__tests__/context-pick-validation.test.ts
@@ -148,6 +148,27 @@ describe("ix context --as-of-rev validation", () => {
   });
 });
 
+describe("ix context --depth validation", () => {
+  beforeEach(() => {
+    resolveFileOrEntity.mockReset().mockResolvedValue(undefined);
+  });
+
+  it.each(["2", "wide", "standard-ish"])("rejects unsupported depth %j before resolving", async (depth) => {
+    const result = await runContext(["--depth", depth]);
+
+    expect(result.error?.exitCode).toBe(1);
+    expect(result.stderr).toContain("must be one of: compact, standard, full, shallow, deep");
+    expect(resolveFileOrEntity).not.toHaveBeenCalled();
+  });
+
+  it.each(["compact", "standard", "full", "shallow", "deep", "FULL"])("accepts depth %j", async (depth) => {
+    const result = await runContext(["--depth", depth]);
+
+    expect(result.error).toBeUndefined();
+    expect(resolveFileOrEntity).toHaveBeenCalledOnce();
+  });
+});
+
 describe("ix context refusals reach the caller that asked for records", () => {
   beforeEach(() => {
     resolveFileOrEntity.mockReset().mockResolvedValue(undefined);

--- a/ix-cli/src/cli/__tests__/context.test.ts
+++ b/ix-cli/src/cli/__tests__/context.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from "vitest";
 import type {
   ConflictReport,
   DecisionReport,
+  EdgeSummary,
   GraphEdge,
   GraphNode,
   IntentReport,
+  NodeSummary,
   ScoredClaim,
 } from "../../client/types.js";
 import type { EntityFacts } from "../explain/facts.js";
@@ -58,6 +60,8 @@ function makeContext(overrides: Partial<{
   intents: IntentReport[];
   nodes: GraphNode[];
   edges: GraphEdge[];
+  nodeSummaries: NodeSummary[];
+  edgeSummaries: EdgeSummary[];
 }> = {}) {
   return {
     claims: overrides.claims ?? [makeClaim("renders to DOM", 0.9)],
@@ -83,6 +87,8 @@ function makeContext(overrides: Partial<{
       ([
         { id: "edge-1", src: "entity-1", dst: "entity-2", predicate: "calls", attrs: {}, createdRev: 3 },
       ] as GraphEdge[]),
+    nodeSummaries: overrides.nodeSummaries,
+    edgeSummaries: overrides.edgeSummaries,
     metadata: { query: "Widget", seedEntities: ["entity-1"], hopsExpanded: 1, asOfRev: 3 },
   };
 }
@@ -136,6 +142,35 @@ describe("ix context bundle", () => {
     expect(bundle.truncation.relationshipsTruncated).toBe(1);
     expect(bundle.evidence.length).toBeLessThanOrEqual(2);
     expect(bundle.truncation.evidenceTruncated).toBeGreaterThanOrEqual(0);
+  });
+
+  it("builds entities and relationships from compact graph summaries", () => {
+    const bundle = buildBundle({
+      ...input(),
+      context: makeContext({
+        nodes: [],
+        edges: [],
+        nodeSummaries: [
+          { id: "entity-1", kind: "class", name: "Widget", rev: 3, sourceUri: "src/widget.ts" },
+          { id: "entity-2", kind: "method", name: "render", rev: 3, sourceUri: "src/widget.ts" },
+          { id: "entity-3", kind: "method", name: "mount", rev: 3, sourceUri: "src/widget.ts" },
+        ],
+        edgeSummaries: [
+          { id: "edge-1", src: "entity-1", dst: "entity-2", predicate: "calls", rev: 3 },
+          { id: "edge-2", src: "entity-1", dst: "entity-3", predicate: "calls", rev: 3 },
+        ],
+      }),
+    });
+
+    expect(bundle.entities).toEqual([
+      { id: "entity-1", name: "Widget", kind: "class", stale: false },
+      { id: "entity-3", name: "mount", kind: "method", path: "src/widget.ts", stale: false },
+      { id: "entity-2", name: "render", kind: "method", path: "src/widget.ts", stale: false },
+    ]);
+    expect(bundle.relationships).toEqual([
+      { src: "entity-1", dst: "entity-2", predicate: "calls" },
+      { src: "entity-1", dst: "entity-3", predicate: "calls" },
+    ]);
   });
 
   it("asks about each entity's own staleness instead of copying the target's", () => {

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -1,4 +1,4 @@
-import type { Command } from "commander";
+import { InvalidArgumentError, type Command } from "commander";
 import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -13,7 +13,6 @@ import { IxClient } from "../../client/api.js";
 import type {
   ConflictReport,
   DecisionReport,
-  GraphNode,
   IntentReport,
   StructuredContext,
 } from "../../client/types.js";
@@ -120,6 +119,16 @@ interface ContextOptions extends Partial<BudgetSnapshot> {
   format: string;
 }
 
+const CONTEXT_DEPTHS = ["compact", "standard", "full", "shallow", "deep"] as const;
+
+function parseContextDepthOption(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (!(CONTEXT_DEPTHS as readonly string[]).includes(normalized)) {
+    throw new InvalidArgumentError(`must be one of: ${CONTEXT_DEPTHS.join(", ")}`);
+  }
+  return normalized;
+}
+
 /** Stable evidence kinds, ordered by relevance tier (lower is more relevant). */
 type EvidenceKind =
   | "target"
@@ -197,7 +206,11 @@ export function registerContextCommand(program: Command): void {
     .option("--kind <kind>", "Filter target entity by kind")
     .option("--path <path>", "Prefer symbols from files matching this path substring")
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
-    .option("--depth <depth>", "Context-graph expansion depth")
+    .option(
+      "--depth <depth>",
+      `Context-graph expansion depth (${CONTEXT_DEPTHS.join("|")})`,
+      parseContextDepthOption,
+    )
     .option("--as-of-rev <n>", "Historical context as of a graph revision", parseRevisionOption)
     // No Commander default on the --max-* flags, so `parseRequestedBudgets`
     // can tell an absent flag from one set to the default value. The defaults
@@ -1289,20 +1302,37 @@ export function buildBundle(input: BuildInput): ContextBundle {
       stale,
     },
   ];
-  for (const node of orderedNodes(context.nodes)) {
+  // Compact and standard backend responses omit the full graph arrays and
+  // carry the same graph as summaries. Falling back here keeps the default
+  // context mode from collapsing to a target-only bundle.
+  const contextNodes = context.nodes.length > 0
+    ? context.nodes.map((node) => ({
+        id: node.id,
+        name: node.name,
+        kind: node.kind,
+        path: node.provenance?.sourceUri,
+      }))
+    : (context.nodeSummaries ?? []).map((node) => ({
+        id: node.id,
+        name: node.name,
+        kind: node.kind,
+        path: node.sourceUri ?? undefined,
+      }));
+  for (const node of orderedNodes(contextNodes)) {
     if (seen.has(node.id)) continue;
     seen.add(node.id);
     entities.push({
       id: node.id,
       name: node.name,
       kind: node.kind,
-      path: node.provenance?.sourceUri,
+      path: node.path,
       stale: false, // replaced below, for the entities that survive the budget
     });
   }
 
   // Relationships: graph edges, ordered deterministically.
-  const relationships = [...context.edges]
+  const contextEdges = context.edges.length > 0 ? context.edges : (context.edgeSummaries ?? []);
+  const relationships = [...contextEdges]
     .sort((a, b) => cmp(a.src, b.src) || cmp(a.dst, b.dst) || cmp(a.predicate, b.predicate))
     .map((edge) => ({ src: edge.src, dst: edge.dst, predicate: edge.predicate }));
 
@@ -1590,7 +1620,7 @@ export function renderBundle(bundle: ContextBundle, format: string): void {
   console.log();
 }
 
-function orderedNodes(nodes: GraphNode[]): GraphNode[] {
+function orderedNodes<T extends { id: string; kind: string; name: string }>(nodes: T[]): T[] {
   return [...nodes].sort((a, b) => cmp(a.kind, b.kind) || cmp(a.name, b.name) || cmp(a.id, b.id));
 }
 

--- a/ix-cli/src/client/types.ts
+++ b/ix-cli/src/client/types.ts
@@ -100,6 +100,22 @@ export interface GraphEdge {
   deletedRev?: number;
 }
 
+export interface NodeSummary {
+  id: string;
+  kind: string;
+  name: string;
+  rev: number;
+  sourceUri?: string | null;
+}
+
+export interface EdgeSummary {
+  id: string;
+  src: string;
+  dst: string;
+  predicate: string;
+  rev: number;
+}
+
 export interface ContextMetadata {
   query: string;
   seedEntities: string[];
@@ -116,6 +132,8 @@ export interface StructuredContext {
   intents: IntentReport[];
   nodes: GraphNode[];
   edges: GraphEdge[];
+  nodeSummaries?: NodeSummary[];
+  edgeSummaries?: EdgeSummary[];
   metadata: ContextMetadata;
 }
 


### PR DESCRIPTION
Closes #487.

## Summary
Consume summarized context graph results and validate the backend depth vocabulary.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Add the backend `nodeSummaries` and `edgeSummaries` response shapes to the client types.
- Use summaries when full `nodes` or `edges` arrays are empty.
- Validate `--depth` against compact, standard, full, shallow, and deep.
- Add bundle and CLI argument regression tests.

## Validation
- Context bundle and option validation tests
- `npm test`
- `npm run typecheck`
- ESLint on changed files
- `git diff --check`

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
