### PR TITLE
fix(mcp): flag semantic CLI errors

### DIFF
--- a/ix-cli/src/cli/__tests__/mcp.test.ts
+++ b/ix-cli/src/cli/__tests__/mcp.test.ts
@@ -108,7 +108,41 @@ describe("ix mcp", () => {
     });
 
     expect(calls).toEqual([["locate", "--format=llm", "--", "Widget"]]);
+    expect(result.isError).toBeFalsy();
     expect(result.content).toEqual([{ type: "text", text: "match name=Widget" }]);
+  });
+
+  it("marks a structured LLM error as an MCP error when the CLI exits successfully", async () => {
+    const error = 'error code=unknown_target message="No graph entity found for \\"Missing\\"."';
+    const client = await connect(async () => ({
+      ok: true,
+      stdout: error,
+      stderr: 'No entity found matching "Missing".',
+    }));
+
+    const result = await client.callTool({
+      name: "ix_locate",
+      arguments: { symbol: "Missing" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([{ type: "text", text: error }]);
+  });
+
+  it("keeps error-like source lines after a successful LLM record as data", async () => {
+    const output = [
+      "content target=fixture.ts lines=1",
+      'error code=source_text message="This is source, not a tool error."',
+    ].join("\n");
+    const client = await connect(async () => ({ ok: true, stdout: output, stderr: "" }));
+
+    const result = await client.callTool({
+      name: "ix_read",
+      arguments: { symbol: "fixture.ts" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual([{ type: "text", text: output }]);
   });
 
   it("forwards ix_context target and bounded budgets as the CLI contract", async () => {

--- a/ix-cli/src/mcp/server.ts
+++ b/ix-cli/src/mcp/server.ts
@@ -553,7 +553,14 @@ async function runFormatted(
   argv: IxArgv,
   timeoutMs = DEFAULT_TIMEOUT_MS,
 ): Promise<CallToolResult> {
-  return runCommand(runIx, tool, toArgv(argv, "llm"), timeoutMs);
+  const result = await runCommand(runIx, tool, toArgv(argv, "llm"), timeoutMs);
+  if (result.isError) return result;
+
+  const first = result.content[0];
+  // Only the leading record governs status. `ix_read` may contain error-like
+  // source lines after its successful `content` record.
+  const semanticError = first?.type === "text" && first.text.startsWith("error code=");
+  return semanticError ? { ...result, isError: true } : result;
 }
 
 async function runJson(


### PR DESCRIPTION
Closes #489.

## Summary
Mark leading structured CLI error records as MCP tool errors.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Inspect successful `runFormatted` output for a leading `error code=` record.
- Add `isError: true` without changing the CLI text payload.
- Keep error-like source lines after a successful leading record as ordinary data.
- Add MCP regression coverage for both cases.

## Validation
- MCP tool tests
- `npm test`
- `npm run typecheck`
- ESLint on changed files
- `git diff --check`

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
