### PR TITLE
fix(context): consume summarized graph results, and warn rather than fail on unknown --depth

### DIFF
--- a/ix-cli/src/cli/__tests__/context-pick-validation.test.ts
+++ b/ix-cli/src/cli/__tests__/context-pick-validation.test.ts
@@ -148,6 +148,27 @@ describe("ix context --as-of-rev validation", () => {
   });
 });
 
+describe("ix context --depth validation", () => {
+  beforeEach(() => {
+    resolveFileOrEntity.mockReset().mockResolvedValue(undefined);
+  });
+
+  it.each(["2", "wide", "standard-ish"])("rejects unsupported depth %j before resolving", async (depth) => {
+    const result = await runContext(["--depth", depth]);
+
+    expect(result.error?.exitCode).toBe(1);
+    expect(result.stderr).toContain("must be one of: compact, standard, full, shallow, deep");
+    expect(resolveFileOrEntity).not.toHaveBeenCalled();
+  });
+
+  it.each(["compact", "standard", "full", "shallow", "deep", "FULL"])("accepts depth %j", async (depth) => {
+    const result = await runContext(["--depth", depth]);
+
+    expect(result.error).toBeUndefined();
+    expect(resolveFileOrEntity).toHaveBeenCalledOnce();
+  });
+});
+
 describe("ix context refusals reach the caller that asked for records", () => {
   beforeEach(() => {
     resolveFileOrEntity.mockReset().mockResolvedValue(undefined);

--- a/ix-cli/src/cli/__tests__/context-pick-validation.test.ts
+++ b/ix-cli/src/cli/__tests__/context-pick-validation.test.ts
@@ -8,7 +8,7 @@ vi.mock("../resolve.js", async (importOriginal) => ({
   resolveFileOrEntity,
 }));
 
-import { registerContextCommand } from "../commands/context.js";
+import { parseContextDepthOption, registerContextCommand } from "../commands/context.js";
 
 async function runContext(args: string[]): Promise<{ error?: CommanderError; stderr: string }> {
   const stderr: string[] = [];
@@ -153,19 +153,65 @@ describe("ix context --depth validation", () => {
     resolveFileOrEntity.mockReset().mockResolvedValue(undefined);
   });
 
-  it.each(["2", "wide", "standard-ish"])("rejects unsupported depth %j before resolving", async (depth) => {
-    const result = await runContext(["--depth", depth]);
-
-    expect(result.error?.exitCode).toBe(1);
-    expect(result.stderr).toContain("must be one of: compact, standard, full, shallow, deep");
-    expect(resolveFileOrEntity).not.toHaveBeenCalled();
-  });
-
   it.each(["compact", "standard", "full", "shallow", "deep", "FULL"])("accepts depth %j", async (depth) => {
     const result = await runContext(["--depth", depth]);
 
     expect(result.error).toBeUndefined();
     expect(resolveFileOrEntity).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["compact", "compact"],
+    ["FULL", "full"],
+    ["  Deep  ", "deep"],
+  ])("normalizes a known depth %j to %j", (input, expected) => {
+    expect(parseContextDepthOption(input)).toBe(expected);
+  });
+
+  /**
+   * An unrecognized depth must NOT exit 1.
+   *
+   * The backend's limit selection ends in a `case _` that lands every
+   * unrecognized value on the standard tier, so `--depth 2` has always run a
+   * standard-depth query rather than failing. Anything already passing one is
+   * a working pipeline, and turning it into a non-zero exit inside a patch
+   * release breaks it on upgrade for no gain.
+   */
+  it.each(["2", "wide", "standard-ish"])("falls back to standard for %j instead of exiting", (depth) => {
+    const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(parseContextDepthOption(depth)).toBe("standard");
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn.mock.calls[0].join(" ")).toContain(`--depth ${depth}`);
+      expect(warn.mock.calls[0].join(" ")).toContain("using standard");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it.each(["2", "wide"])("still resolves the target after an unknown depth %j", async (depth) => {
+    const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const result = await runContext(["--depth", depth]);
+
+      expect(result.error).toBeUndefined();
+      expect(resolveFileOrEntity).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("warns on stderr, never stdout, so --format json stays parseable", () => {
+    const out = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      parseContextDepthOption("nonsense");
+      expect(warn).toHaveBeenCalledOnce();
+      expect(out).not.toHaveBeenCalled();
+    } finally {
+      out.mockRestore();
+      warn.mockRestore();
+    }
   });
 });
 

--- a/ix-cli/src/cli/__tests__/context.test.ts
+++ b/ix-cli/src/cli/__tests__/context.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from "vitest";
 import type {
   ConflictReport,
   DecisionReport,
+  EdgeSummary,
   GraphEdge,
   GraphNode,
   IntentReport,
+  NodeSummary,
   ScoredClaim,
 } from "../../client/types.js";
 import type { EntityFacts } from "../explain/facts.js";
@@ -58,6 +60,8 @@ function makeContext(overrides: Partial<{
   intents: IntentReport[];
   nodes: GraphNode[];
   edges: GraphEdge[];
+  nodeSummaries: NodeSummary[];
+  edgeSummaries: EdgeSummary[];
 }> = {}) {
   return {
     claims: overrides.claims ?? [makeClaim("renders to DOM", 0.9)],
@@ -83,6 +87,8 @@ function makeContext(overrides: Partial<{
       ([
         { id: "edge-1", src: "entity-1", dst: "entity-2", predicate: "calls", attrs: {}, createdRev: 3 },
       ] as GraphEdge[]),
+    nodeSummaries: overrides.nodeSummaries,
+    edgeSummaries: overrides.edgeSummaries,
     metadata: { query: "Widget", seedEntities: ["entity-1"], hopsExpanded: 1, asOfRev: 3 },
   };
 }
@@ -136,6 +142,35 @@ describe("ix context bundle", () => {
     expect(bundle.truncation.relationshipsTruncated).toBe(1);
     expect(bundle.evidence.length).toBeLessThanOrEqual(2);
     expect(bundle.truncation.evidenceTruncated).toBeGreaterThanOrEqual(0);
+  });
+
+  it("builds entities and relationships from compact graph summaries", () => {
+    const bundle = buildBundle({
+      ...input(),
+      context: makeContext({
+        nodes: [],
+        edges: [],
+        nodeSummaries: [
+          { id: "entity-1", kind: "class", name: "Widget", rev: 3, sourceUri: "src/widget.ts" },
+          { id: "entity-2", kind: "method", name: "render", rev: 3, sourceUri: "src/widget.ts" },
+          { id: "entity-3", kind: "method", name: "mount", rev: 3, sourceUri: "src/widget.ts" },
+        ],
+        edgeSummaries: [
+          { id: "edge-1", src: "entity-1", dst: "entity-2", predicate: "calls", rev: 3 },
+          { id: "edge-2", src: "entity-1", dst: "entity-3", predicate: "calls", rev: 3 },
+        ],
+      }),
+    });
+
+    expect(bundle.entities).toEqual([
+      { id: "entity-1", name: "Widget", kind: "class", stale: false },
+      { id: "entity-3", name: "mount", kind: "method", path: "src/widget.ts", stale: false },
+      { id: "entity-2", name: "render", kind: "method", path: "src/widget.ts", stale: false },
+    ]);
+    expect(bundle.relationships).toEqual([
+      { src: "entity-1", dst: "entity-2", predicate: "calls" },
+      { src: "entity-1", dst: "entity-3", predicate: "calls" },
+    ]);
   });
 
   it("asks about each entity's own staleness instead of copying the target's", () => {

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -1,4 +1,4 @@
-import { InvalidArgumentError, type Command } from "commander";
+import type { Command } from "commander";
 import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -121,12 +121,33 @@ interface ContextOptions extends Partial<BudgetSnapshot> {
 
 const CONTEXT_DEPTHS = ["compact", "standard", "full", "shallow", "deep"] as const;
 
-function parseContextDepthOption(value: string): string {
+/**
+ * The depth vocabulary the backend understands, and what to do about anything
+ * else.
+ *
+ * `ContextService` normalizes `shallow`->`compact` and `deep`->`full`, then
+ * picks its limits with a `case _` that lands every unrecognized value on the
+ * `standard` tier. So `--depth 2` was never an error: it silently ran a
+ * standard-depth query, and scripts have been passing values like it.
+ *
+ * Rejecting those outright would be a breaking change in a patch release, for
+ * a flag whose wrong values were previously harmless. So this warns and does
+ * exactly what the backend already did with them — the typo still gets
+ * surfaced, on stderr so `--format json` and `--format llm` stay parseable,
+ * but nobody's pipeline starts exiting 1 on upgrade.
+ *
+ * Deliberately not an `InvalidArgumentError`, unlike `--pick` and `--as-of-rev`
+ * next to it: those reject values that have no defined meaning, whereas this
+ * one has a defined meaning and it is `standard`.
+ */
+export function parseContextDepthOption(value: string): string {
   const normalized = value.trim().toLowerCase();
-  if (!(CONTEXT_DEPTHS as readonly string[]).includes(normalized)) {
-    throw new InvalidArgumentError(`must be one of: ${CONTEXT_DEPTHS.join(", ")}`);
-  }
-  return normalized;
+  if ((CONTEXT_DEPTHS as readonly string[]).includes(normalized)) return normalized;
+
+  renderWarningErr(
+    `--depth ${value} is not one of ${CONTEXT_DEPTHS.join(", ")}; using standard.`
+  );
+  return "standard";
 }
 
 /** Stable evidence kinds, ordered by relevance tier (lower is more relevant). */

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -1,4 +1,4 @@
-import type { Command } from "commander";
+import { InvalidArgumentError, type Command } from "commander";
 import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -13,7 +13,6 @@ import { IxClient } from "../../client/api.js";
 import type {
   ConflictReport,
   DecisionReport,
-  GraphNode,
   IntentReport,
   StructuredContext,
 } from "../../client/types.js";
@@ -120,6 +119,16 @@ interface ContextOptions extends Partial<BudgetSnapshot> {
   format: string;
 }
 
+const CONTEXT_DEPTHS = ["compact", "standard", "full", "shallow", "deep"] as const;
+
+function parseContextDepthOption(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (!(CONTEXT_DEPTHS as readonly string[]).includes(normalized)) {
+    throw new InvalidArgumentError(`must be one of: ${CONTEXT_DEPTHS.join(", ")}`);
+  }
+  return normalized;
+}
+
 /** Stable evidence kinds, ordered by relevance tier (lower is more relevant). */
 type EvidenceKind =
   | "target"
@@ -197,7 +206,11 @@ export function registerContextCommand(program: Command): void {
     .option("--kind <kind>", "Filter target entity by kind")
     .option("--path <path>", "Prefer symbols from files matching this path substring")
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
-    .option("--depth <depth>", "Context-graph expansion depth")
+    .option(
+      "--depth <depth>",
+      `Context-graph expansion depth (${CONTEXT_DEPTHS.join("|")})`,
+      parseContextDepthOption,
+    )
     .option("--as-of-rev <n>", "Historical context as of a graph revision", parseRevisionOption)
     // No Commander default on the --max-* flags, so `parseRequestedBudgets`
     // can tell an absent flag from one set to the default value. The defaults
@@ -1289,20 +1302,37 @@ export function buildBundle(input: BuildInput): ContextBundle {
       stale,
     },
   ];
-  for (const node of orderedNodes(context.nodes)) {
+  // Compact and standard backend responses omit the full graph arrays and
+  // carry the same graph as summaries. Falling back here keeps the default
+  // context mode from collapsing to a target-only bundle.
+  const contextNodes = context.nodes.length > 0
+    ? context.nodes.map((node) => ({
+        id: node.id,
+        name: node.name,
+        kind: node.kind,
+        path: node.provenance?.sourceUri,
+      }))
+    : (context.nodeSummaries ?? []).map((node) => ({
+        id: node.id,
+        name: node.name,
+        kind: node.kind,
+        path: node.sourceUri ?? undefined,
+      }));
+  for (const node of orderedNodes(contextNodes)) {
     if (seen.has(node.id)) continue;
     seen.add(node.id);
     entities.push({
       id: node.id,
       name: node.name,
       kind: node.kind,
-      path: node.provenance?.sourceUri,
+      path: node.path,
       stale: false, // replaced below, for the entities that survive the budget
     });
   }
 
   // Relationships: graph edges, ordered deterministically.
-  const relationships = [...context.edges]
+  const contextEdges = context.edges.length > 0 ? context.edges : (context.edgeSummaries ?? []);
+  const relationships = [...contextEdges]
     .sort((a, b) => cmp(a.src, b.src) || cmp(a.dst, b.dst) || cmp(a.predicate, b.predicate))
     .map((edge) => ({ src: edge.src, dst: edge.dst, predicate: edge.predicate }));
 
@@ -1590,7 +1620,7 @@ export function renderBundle(bundle: ContextBundle, format: string): void {
   console.log();
 }
 
-function orderedNodes(nodes: GraphNode[]): GraphNode[] {
+function orderedNodes<T extends { id: string; kind: string; name: string }>(nodes: T[]): T[] {
   return [...nodes].sort((a, b) => cmp(a.kind, b.kind) || cmp(a.name, b.name) || cmp(a.id, b.id));
 }
 

--- a/ix-cli/src/client/types.ts
+++ b/ix-cli/src/client/types.ts
@@ -100,6 +100,22 @@ export interface GraphEdge {
   deletedRev?: number;
 }
 
+export interface NodeSummary {
+  id: string;
+  kind: string;
+  name: string;
+  rev: number;
+  sourceUri?: string | null;
+}
+
+export interface EdgeSummary {
+  id: string;
+  src: string;
+  dst: string;
+  predicate: string;
+  rev: number;
+}
+
 export interface ContextMetadata {
   query: string;
   seedEntities: string[];
@@ -116,6 +132,8 @@ export interface StructuredContext {
   intents: IntentReport[];
   nodes: GraphNode[];
   edges: GraphEdge[];
+  nodeSummaries?: NodeSummary[];
+  edgeSummaries?: EdgeSummary[];
   metadata: ContextMetadata;
 }
 


### PR DESCRIPTION
Supersedes #488. Carries @Hiro-Chiba's commit `13ae4f4` unchanged, plus one fix
commit. Opened here only because pushing to the fork is not possible from this
environment — please credit @Hiro-Chiba, and close #488 in favour of this once
it lands.

## Why #488 matters (verified against a live 1.0.17 backend, not the mocks)

The CLI sends no `depth` unless `--depth` is passed, and `ContextService`
defaults to `standard` — which is one of the depths that deliberately empties
the full arrays:

```scala
nodesOut = if (effectiveDepth == "full") allNodes else Vector.empty
edgesOut = if (effectiveDepth == "full") edgesTrimmed else Vector.empty
```

So **every default `ix context` was reading two arrays the backend empties on
purpose.** `POST /v1/context` against this box:

| depth | nodes | edges | nodeSummaries | edgeSummaries |
|---|---|---|---|---|
| compact | 0 | 0 | 8 | 10 |
| **standard (default)** | **0** | **0** | **40** | **106** |
| full | 84 | 106 | 84 | 106 |

End-to-end through the built CLI, same target, same backend:

| | entities | relationships |
|---|---|---|
| `main` | 1 | 0 |
| this PR | **41** | **100** |

`NodeSummary(id, kind, name, rev, sourceUri: Option[String])` and
`EdgeSummary(id, src, dst, predicate, rev)` in `StructuredContext.scala` match
the added TS types exactly, including `sourceUri` arriving as literal `null`.

## What this PR adds: the `--depth` allowlist no longer exits 1

This is the only breaking change in an otherwise pure-bugfix batch, and it broke
a case that had always worked.

The backend picks its limits with a match ending in `case _ => standard`, so a
value outside the vocabulary was never an error — `ix context X --depth 2` ran a
standard-depth query and exited 0. #488 turned that into:

```
error: option '--depth <depth>' argument '2' is invalid. must be one of: compact, standard, full, shallow, deep
```

Anyone with a numeric or stale depth in a script would start failing on upgrade,
inside a **patch** release, for a flag whose wrong values had been harmless.

Now it warns and does what the backend already did:

```
$ ix context README.md --depth 2 --format json
  Warning  --depth 2 is not one of compact, standard, full, shallow, deep; using standard.
$ echo $?
0
```

stdout stays valid JSON with the full 41/100 standard-depth result. The warning
goes to **stderr** via `renderWarningErr`, so `--format json` and `--format llm`
stay parseable by whatever is reading stdout — the entire audience for those two
formats.

Deliberately unlike `--pick` and `--as-of-rev` beside it, which do throw
`InvalidArgumentError`: those reject values with no defined meaning, whereas this
one has a defined meaning and it is `standard`. The typo still gets surfaced;
nobody's pipeline starts exiting 1.

## Verification

- Full suite **1201 passed**, 2 skipped; `typecheck` clean; `lint` **0 errors**
  (42 pre-existing warnings, same as `main`); `knip` exit 0
- **Mutation-checked both directions**: restoring the `throw` fails 6 tests;
  falling back to `full` instead of `standard` fails 3
- The `--depth` validation is still real — `parseContextDepthOption` is exported
  and tested directly, since the command-level harness returns before a depth
  would reach the client

One caveat worth recording: across 6 full-suite runs, one run had a single
unidentified test failure that did not reproduce in the other 5, including a
deliberate rebuild-then-run to test the obvious hypothesis. Nothing in this PR
touches processes, ports, or timing — it is a pure function plus its tests — so
I do not believe it is from this change, but I would rather flag it than report
6/6 green.
