### PR TITLE
test(upgrade): stop the --check test writing to the real ~/.ix

### DIFF
--- a/ix-cli/src/cli/__tests__/upgrade-check-closing-line.test.ts
+++ b/ix-cli/src/cli/__tests__/upgrade-check-closing-line.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -46,6 +46,16 @@ describe("ix upgrade --check output", () => {
   let logs: string[];
 
   beforeEach(() => {
+    // upgrade.ts binds IX_HOME and VERSION_CACHE as module-level consts at load
+    // time, so `await import` below only picks up this temp home if the module
+    // is not already in the registry. Running this file alone it is not, and the
+    // test passed; in a full-suite run another file has already imported it and
+    // the writeCache at the end of the command lands in the developer's REAL
+    // ~/.ix, seeding latest: "99.0.0" for CLI, compass and backend. The test
+    // still passes, so nothing catches it, and CI never sees it because a runner
+    // has a throwaway home. What the developer sees afterwards is `ix` insisting
+    // on an upgrade to a version that does not exist.
+    vi.resetModules();
     home = mkdtempSync(join(tmpdir(), "ix-upgrade-check-"));
     process.env.IX_HOME = home;
     logs = [];
@@ -77,6 +87,15 @@ describe("ix upgrade --check output", () => {
     await program.parseAsync(["node", "ix", "upgrade", "--check"]);
     return logs.join("\n");
   }
+
+  it("writes its version cache under the temp IX_HOME, not the real one", async () => {
+    await runCheck("v99.0.0");
+    // The bug this file caused, stated as an assertion: the command must have
+    // written its cache into the throwaway home. Checking the temp side rather
+    // than the developer's real ~/.ix keeps the test hermetic on a machine that
+    // legitimately has one.
+    expect(existsSync(join(home, ".version-check.json"))).toBe(true);
+  });
 
   it("does not claim to be up to date when it just announced a new version", async () => {
     const out = await runCheck("v99.0.0");


### PR DESCRIPTION
Follow-up to #477, which I merged earlier today.

## The bug

`upgrade-check-closing-line.test.ts` sets `process.env.IX_HOME` to a temp dir and imports `upgrade.js` afterwards, on the stated reasoning that the module reads `IX_HOME` at load time.

That holds only while the module is not already in the registry. `upgrade.ts:52-53` binds both as module-level consts:

```ts
const IX_HOME = process.env.IX_HOME || join(homedir(), ".ix");
const VERSION_CACHE = join(IX_HOME, ".version-check.json");
```

In a full-suite run another file has already imported it, so the dynamic import returns the cached module still pointed at the developer's real home. The command's `writeCache` then lands in `~/.ix/.version-check.json`:

```json
{"latest":"99.0.0","checkedAt":...,"compassLatest":"99.0.0","backendLatest":"99.0.0"}
```

and `ix` spends the next hour insisting on an upgrade to a version that does not exist — on the CLI, Compass and the backend at once.

Run the file on its own and it is fine, which is why it looked correct. **Nothing catches it:** the test passes either way, and CI never sees it because a runner's home is thrown away. I hit it running the suite on a machine with a real Ix install.

## The fix

`vi.resetModules()` in `beforeEach`, matching `upgrade-pinned-compose.test.ts` (#480), which already does this. Plus an assertion that the cache lands under the temp home, so a regression fails the suite instead of the developer's machine.

## Verification

Mutation-tested rather than asserted:

| | new assertion | real `~/.ix` after full suite |
|---|---|---|
| with `vi.resetModules()` | passes | untouched |
| with it removed | **fails** | **written with `99.0.0`** |

Full suite on this branch: 81 files, 1383 tests passed, 2 skipped, 0 failed.