### PR TITLE
perf(context): seed the context request by resolved id, not by name

### DIFF
--- a/ix-cli/src/cli/__tests__/context-seeds-by-id.test.ts
+++ b/ix-cli/src/cli/__tests__/context-seeds-by-id.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { IxClient } from "../../client/api.js";
+
+/**
+ * `ix context` resolves its target and then has to ask the backend for the
+ * graph around it. It used to ask by NAME, which made the backend re-run the
+ * search the resolver had just done — the single most expensive call the CLI
+ * makes, measured at 10.6 s against 0.06 s for the id form on the same graph.
+ *
+ * Worse than slow: the re-derived seeds can land on a different node of the
+ * same name. `README.md` resolved to one id and came back seeded on
+ * `mcp/node_modules/serve-static/README.md`, with the resolved id in neither
+ * the seed list nor the returned nodes.
+ */
+describe("contextForNode", () => {
+  function capture() {
+    const calls: Array<{ url: string; body: any }> = [];
+    vi.stubGlobal("fetch", async (url: any, init: any) => {
+      calls.push({ url: String(url), body: JSON.parse(init.body) });
+      return new Response(JSON.stringify({ nodes: [], edges: [], claims: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    return calls;
+  }
+
+  it("sends the node id as a slice, never a name", async () => {
+    const calls = capture();
+    await new IxClient("http://x").contextForNode("11111111-2222-3333-4444-555555555555");
+    const body = calls[0].body;
+
+    expect(body.slices).toEqual([
+      {
+        type: "nodes",
+        nodeIds: ["11111111-2222-3333-4444-555555555555"],
+        expand: true,
+        hops: 1,
+      },
+    ]);
+    // The whole point: no free-text query for the backend to re-search.
+    expect(body.query).toBeUndefined();
+    vi.unstubAllGlobals();
+  });
+
+  it("passes depth through rather than pinning it to full", async () => {
+    const calls = capture();
+    await new IxClient("http://x").contextForNode("11111111-2222-3333-4444-555555555555", {
+      depth: "compact",
+      asOfRev: 2000,
+    });
+    // `--depth` has to keep meaning what it says: compact and standard return
+    // the summarized graph, full returns whole nodes plus claims. Hardcoding
+    // full would silently ignore the flag and change every bundle's size.
+    expect(calls[0].body.depth).toBe("compact");
+    expect(calls[0].body.asOfRev).toBe(2000);
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("context.ts call sites", () => {
+  it("has no by-name context call left in the command", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { fileURLToPath } = await import("node:url");
+    const { dirname, join } = await import("node:path");
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "..", "commands", "context.ts"),
+      "utf8",
+    );
+    // Two call sites, and both must convert. Leaving one behind makes `--diff`
+    // compare a by-id bundle against a by-name one and report the entire graph
+    // as changed on the first run after upgrade.
+    expect(src).not.toContain("client.query(resolved.name");
+    expect(src.match(/client\.contextForNode\(resolved\.id/g) ?? []).toHaveLength(2);
+  });
+});

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -314,7 +314,12 @@ export function registerContextCommand(program: Command): void {
 
       const [facts, context, provenance] = await Promise.all([
         collectFacts(client, resolved.id, resolved.name, resolved.kind),
-        client.query(resolved.name, {
+        // By id, not by name. Seeding by name makes the backend re-run the
+        // search the resolver just did, and it can land on a different node of
+        // the same name. Both call sites in this file must use it: converting
+        // only one makes `--diff` compare a by-id bundle against a by-name one
+        // and report the whole graph as changed.
+        client.contextForNode(resolved.id, {
           asOfRev,
           depth: opts.depth,
         }),
@@ -407,7 +412,7 @@ async function buildFreshBundle(
   const asOfRev = opts.asOfRev;
   const [facts, context, provenance] = await Promise.all([
     collectFacts(client, resolved.id, resolved.name, resolved.kind),
-    client.query(resolved.name, { asOfRev, depth: opts.depth }),
+    client.contextForNode(resolved.id, { asOfRev, depth: opts.depth }),
     client.provenance(resolved.id),
   ]);
 

--- a/ix-cli/src/client/api.ts
+++ b/ix-cli/src/client/api.ts
@@ -47,6 +47,32 @@ export class IxClient {
     return this.post("/v1/context", { query: question, ...opts });
   }
 
+  /**
+   * Context centred on a node we have already resolved.
+   *
+   * `query()` sends a NAME and makes the backend re-derive seeds by string
+   * search. That is the single most expensive call the CLI makes — measured at
+   * 10.6 s against 0.06 s for this form on the same graph — and it is not just
+   * slow, it can centre the bundle on a different node: `README.md` resolved to
+   * one id and came back seeded on `mcp/node_modules/serve-static/README.md`,
+   * with the resolved id in neither the seeds nor the returned nodes.
+   *
+   * The id is already in hand by the time this is called, so send it. `depth` is
+   * passed through rather than pinned to `full`, so `--depth` still means what it
+   * says: compact and standard return the summarized graph (which `buildBundle`
+   * reads), full returns whole nodes plus claims.
+   */
+  async contextForNode(
+    nodeId: string,
+    opts?: { asOfRev?: number; depth?: string; hops?: number }
+  ): Promise<StructuredContext> {
+    const { hops = 1, ...rest } = opts ?? {};
+    return this.post("/v1/context", {
+      slices: [{ type: "nodes", nodeIds: [nodeId], expand: true, hops }],
+      ...rest,
+    });
+  }
+
   async ingest(path: string, recursive?: boolean, force?: boolean): Promise<IngestResult> {
     const resp = await fetch(`${this.endpoint}/v1/ingest`, {
       method: "POST",


### PR DESCRIPTION
`ix context` resolved its target and then asked the backend for context **by name**, making the backend re-run the search the resolver had just done. It was the single most expensive call the CLI makes.

## Measured end-to-end, live 1.16M-node graph

| target | before | after | bundle |
|---|---|---|---|
| `constellation-layout.ts` | 16.7–21.5 s | **2.3–3.0 s** | 40 ents / 69 rels → 27 / 74 |
| `README.md` | ~13–17 s | **1.4–2.3 s** | 40 ents → 1 |

## It was not only slow — it could miss the node

`README.md` resolves to `808f04c5…`. The by-name request seeds 25 entities starting `00579c85…`, and the resolved id is in **neither the seeds nor the returned nodes**. The bundle described a different README.

By id it is centred correctly, and the single entity is the right answer — that file is a genuine orphan (`has_smell.orphan_file`), so there is nothing around it. 40 entities about the wrong file is not a richer bundle.

## Both call sites

`context.ts:322` and `:415` (the `--diff`/`--resume` path). Converting only one would make `--diff` compare a by-id bundle against a by-name one and report the entire graph as changed on the first run after upgrade. A test asserts no by-name call survives and that exactly two by-id call sites exist.

`depth` is passed through rather than pinned to `full`, so `--depth` keeps meaning what it says — compact/standard return the summarized graph `buildBundle` reads (since #493), full returns whole nodes plus claims. `asOfRev` verified honoured on the slices path.

## Requires backend >= 1.0.26

Three backend defects had to be fixed first, and **all three were found by measuring this change rather than by reading the code**:

| | defect |
|---|---|
| 1.0.24 | the slice expanded outbound-only, returning 16% of the neighbourhood |
| 1.0.25 | `trimSlice` could drop the very node the slice asked for — a 0-claim target came back as a *different* file that had one |
| 1.0.26 | it also dropped the expansion's claim-less neighbours, collapsing the bundle to 2 entities |

Landing this against an older backend would have shipped something fast, correctly centred, and nearly empty.

82 test files, **1386 tests**, 0 failures.