### PR TITLE
fix(context): budget relationships against the entities that survived

### DIFF
--- a/ix-cli/src/cli/__tests__/context.test.ts
+++ b/ix-cli/src/cli/__tests__/context.test.ts
@@ -144,6 +144,58 @@ describe("ix context bundle", () => {
     expect(bundle.truncation.evidenceTruncated).toBeGreaterThanOrEqual(0);
   });
 
+  it("never keeps a relationship whose endpoint the entity budget cut", () => {
+    // The two budgets used to be applied independently, so an edge could be kept
+    // while one or both of its endpoints were cut. Measured on a real target at
+    // --max-entities 10: 59 of 74 relationships referenced an entity no longer
+    // in the bundle, 13 of them at both ends -- and relationshipsTruncated said
+    // 0, because nothing had exceeded the RELATIONSHIP budget. The renderer
+    // prints those as bare UUIDs, so it looked fine.
+    const nodes = ["n1", "n2", "n3", "n4"].map((id) => ({
+      id,
+      kind: "method",
+      name: id,
+      attrs: {},
+      provenance: { sourceUri: `src/${id}.ts`, extractor: "tree-sitter", sourceType: "source", observedAt: "2026-01-01T00:00:00Z" },
+      createdRev: 3,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    })) as GraphNode[];
+    const edges = [
+      { id: "e1", src: "entity-1", dst: "n1", predicate: "calls", attrs: {}, createdRev: 3 },
+      { id: "e2", src: "n3", dst: "n4", predicate: "calls", attrs: {}, createdRev: 3 },
+    ] as GraphEdge[];
+
+    const bundle = buildBundle({
+      ...input(),
+      context: makeContext({ nodes, edges }),
+      // Room for the target plus a couple of entities, not all four.
+      budgets: { maxEntities: 3, maxRelationships: 100, maxEvidence: 25, maxChars: 12000 },
+    });
+
+    const kept = new Set(bundle.entities.map((e) => e.id));
+    for (const rel of bundle.relationships) {
+      expect(kept.has(rel.src)).toBe(true);
+      expect(kept.has(rel.dst)).toBe(true);
+    }
+    // And the count has to be honest: a relationship dropped because its
+    // endpoint lost the ENTITY budget is still a relationship the caller did
+    // not get, so it belongs in relationshipsTruncated.
+    expect(bundle.truncation.relationshipsTruncated).toBe(
+      edges.length - bundle.relationships.length,
+    );
+  });
+
+  it("keeps every relationship when nothing was truncated", () => {
+    // The fix must not cost edges in the common case -- it only removes ones
+    // that referenced an entity the bundle no longer contains.
+    const bundle = buildBundle(input());
+    expect(bundle.relationships).toHaveLength(1);
+    expect(bundle.truncation.relationshipsTruncated).toBe(0);
+    const kept = new Set(bundle.entities.map((e) => e.id));
+    expect(kept.has("entity-1") && kept.has("entity-2")).toBe(true);
+  });
+
   it("builds entities and relationships from compact graph summaries", () => {
     const bundle = buildBundle({
       ...input(),

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -1457,8 +1457,28 @@ export function buildBundle(input: BuildInput): ContextBundle {
   );
   bundle.truncation.entitiesTruncated = entities.length - entityLimit;
 
-  const relLimit = Math.min(relationships.length, budgets.maxRelationships);
-  bundle.relationships = relationships.slice(0, relLimit);
+  // Relationships are budgeted against the entities that SURVIVED, not against
+  // the full list. The two budgets used to be applied independently, so an edge
+  // could be kept while one or both of its endpoints were cut: measured on a
+  // real target at `--max-entities 10`, 59 of 74 relationships referenced an
+  // entity no longer in the bundle, 13 of them at both ends -- and
+  // `relationshipsTruncated` reported 0, because nothing had exceeded the
+  // relationship budget. The renderer prints those as bare UUIDs, so the damage
+  // was invisible.
+  //
+  // The backend already guarantees this on its side (`trimSlice` keeps an edge
+  // only when both endpoints survive); this stops the CLI from undoing it.
+  // Dropping the dangling edge rather than pulling its endpoint back in keeps
+  // `--max-entities` meaning exactly what it says.
+  const keptEntityIds = new Set(bundle.entities.map((e) => e.id));
+  const connected = relationships.filter(
+    (r) => keptEntityIds.has(r.src) && keptEntityIds.has(r.dst),
+  );
+  const relLimit = Math.min(connected.length, budgets.maxRelationships);
+  bundle.relationships = connected.slice(0, relLimit);
+  // Count everything the caller does not get back, whichever budget cost it --
+  // the entity cut and the relationship cut both drop relationships, and
+  // reporting only the second is what made an 80%-dangling bundle look clean.
   bundle.truncation.relationshipsTruncated = relationships.length - relLimit;
 
   // Evidence is ordered by relevance, so keep the highest-priority prefix and


### PR DESCRIPTION
Closes #496.

The entity and relationship budgets were applied independently, so an edge could be kept while one or both of its endpoints were cut. The renderer prints those endpoints as bare UUIDs, so a bundle that was 80% unusable looked clean.

Measured on a real target:

| `--max-entities` | before | after |
|---|---|---|
| 10 | 74 rels, **59 dangling**, truncated reported **0** | 15 rels, **0 dangling**, truncated **59** |
| 20 | 74 rels, **31 dangling**, truncated reported **0** | 43 rels, **0 dangling**, truncated **31** |
| 30 | 74 rels, 0 dangling | unchanged |

Two defects in one: the incoherent bundle, and `relationshipsTruncated` reporting **0** while 59 relationships were unusable — because nothing had exceeded the *relationship* budget. The count now reflects everything the caller does not get back, whichever budget cost it.

The backend already guarantees this on its side (`trimSlice` keeps an edge only when both endpoints survive), so this is the CLI no longer undoing it.

**Why drop rather than pull endpoints back in:** it keeps `--max-entities` meaning exactly what it says. Pulling endpoints back would silently exceed the budget the caller set.

Severity is lower than when I filed it — #499's id-seeding made typical bundles 27–49 entities, so the default 50/100 budgets rarely truncate now. It still bites whenever a caller sets a lower budget, which is exactly when they are trying to keep a bundle small enough to read.

Verified by mutation: with the coherence filter removed the new test fails. A second test pins that the no-truncation case keeps every relationship, so the fix costs nothing in the common path.

82 test files, **1388 tests**, 0 failures.