### PR TITLE
chore(release): 0.10.2

### DIFF
--- a/ix-cli/package-lock.json
+++ b/ix-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ix/cli",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ix/cli",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
         "chalk": "^6.0.0",

--- a/ix-cli/package.json
+++ b/ix-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ix/cli",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "type": "module",
   "description": "Ix Memory — Persistent Memory for LLM Systems",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump for 0.10.2. `ix context`, twice over.

**#499 — seed by resolved id, not by name.** The backend stopped re-running the search the resolver had just done: **16.7–21.5 s → 2.3–3.0 s** on a live 1.16M-node graph. It is also a correctness fix — by name, `README.md` came back seeded on a *different* README, with the resolved id in neither the seeds nor the returned nodes.

**Requires backend >= 1.0.26.** That change exposed three backend defects, all found by measuring rather than reading: outbound-only slice expansion (1.0.24), a trim that could drop the requested node itself (1.0.25), and a trim that dropped the expansion's claim-less neighbours, collapsing the bundle to 2 entities (1.0.26).

**#503 — budget relationships against the entities that survived.** The two budgets were independent, so an edge could outlive its own endpoints: at `--max-entities 10`, 59 of 74 relationships pointed at an entity no longer in the bundle, and `relationshipsTruncated` still reported 0.

Also in this release: #497 (brew formula → v0.10.1) and #498 (the `--check` test no longer writes `99.0.0` into the developer's real `~/.ix`).