### PR TITLE
fix(stale): mark unmapped graph results stale

### DIFF
--- a/ix-cli/src/cli/__tests__/context.test.ts
+++ b/ix-cli/src/cli/__tests__/context.test.ts
@@ -225,6 +225,30 @@ describe("ix context bundle", () => {
     ]);
   });
 
+  it("classifies a workspace with no completed map baseline as unverified", () => {
+    // Ix#506: the backend answers from graph patches an initial map committed
+    // before it failed. `ix status` already reported mapCompleted:false while
+    // the bundle said current, so an agent reading the bundle trusted a graph
+    // the CLI knew was half-built.
+    const bundle = buildBundle({ ...input(), mapCompleted: false });
+
+    expect(bundle.freshness.classification).toBe("unverified");
+  });
+
+  it("does not let an unverified workspace masquerade as stale", () => {
+    // `stale` is a claim that a file changed since ingest. Without a baseline
+    // nothing is known to have changed, so the two states stay distinguishable:
+    // an agent can re-map on unverified without being told its files are dirty.
+    const unverified = buildBundle({ ...input(), mapCompleted: false });
+    const stale = buildBundle({
+      ...input(), mapCompleted: true, facts: makeFacts({ stale: true }),
+    });
+
+    expect(unverified.freshness.classification).toBe("unverified");
+    expect(unverified.freshness.stale).toBe(false);
+    expect(stale.freshness.classification).toBe("stale");
+  });
+
   it("asks about each entity's own staleness instead of copying the target's", () => {
     // `freshness` is the target's, from the facts collector. Every other entity
     // has its own source file and its own answer — stamping the target's onto

--- a/ix-cli/src/cli/__tests__/stale-workspace.test.ts
+++ b/ix-cli/src/cli/__tests__/stale-workspace.test.ts
@@ -6,7 +6,7 @@ import * as path from "node:path";
 import { ingestMtimeCachePath, saveConfig } from "../config.js";
 import { loadIngestBaseline } from "../ingest-baseline.js";
 import { persistIngestBaselineIfClean } from "../commands/ingest.js";
-import { detectStaleFiles, isFileStale } from "../stale.js";
+import { createStaleProbe, detectStaleFiles, isFileStale } from "../stale.js";
 
 let home: string;
 let savedHome: string | undefined;
@@ -108,7 +108,19 @@ describe("workspace-scoped staleness", () => {
 
   it("returns the unmapped state when the workspace has no baseline", async () => {
     const root = path.join(home, "unmapped");
-    writeSource(root, "new.js", "export const value = 1;\n");
+    const filePath = writeSource(root, "new.js", "export const value = 1;\n");
+    saveConfig({
+      endpoint: "http://localhost:8090",
+      format: "text",
+      workspaces: [
+        {
+          workspace_id: "unmapped0001",
+          workspace_name: "unmapped",
+          root_path: root,
+          default: true,
+        },
+      ],
+    });
 
     expect(detectStaleFiles(root)).toEqual({
       mapCompleted: false,
@@ -117,6 +129,8 @@ describe("workspace-scoped staleness", () => {
       staleFiles: 0,
       sampleChangedFiles: [],
     });
+    expect(isFileStale(filePath)).toBe(true);
+    expect(createStaleProbe()(filePath)).toBe(true);
   });
 
   it("reports a mapped file that was deleted after ingest", async () => {

--- a/ix-cli/src/cli/__tests__/stale-workspace.test.ts
+++ b/ix-cli/src/cli/__tests__/stale-workspace.test.ts
@@ -6,7 +6,7 @@ import * as path from "node:path";
 import { ingestMtimeCachePath, saveConfig } from "../config.js";
 import { loadIngestBaseline } from "../ingest-baseline.js";
 import { persistIngestBaselineIfClean } from "../commands/ingest.js";
-import { createStaleProbe, detectStaleFiles, isFileStale } from "../stale.js";
+import { createStaleProbe, detectStaleFiles, hasCompletedMapBaseline, isFileStale } from "../stale.js";
 
 let home: string;
 let savedHome: string | undefined;
@@ -129,8 +129,28 @@ describe("workspace-scoped staleness", () => {
       staleFiles: 0,
       sampleChangedFiles: [],
     });
-    expect(isFileStale(filePath)).toBe(true);
-    expect(createStaleProbe()(filePath)).toBe(true);
+    // The workspace is unverified, but no individual file is known to have
+    // changed — the distinction this pair of assertions exists to pin down.
+    // Answering `true` here is what marked every file of a cloud-ingested or
+    // parse-error workspace as modified.
+    expect(hasCompletedMapBaseline(root)).toBe(false);
+    expect(isFileStale(filePath)).toBe(false);
+    expect(createStaleProbe()(filePath)).toBe(false);
+  });
+
+  it("reports a completed baseline as verified", async () => {
+    const root = path.join(home, "verified");
+    const filePath = writeSource(root, "verified.js", "export const value = 1;\n");
+    persistIngestBaselineIfClean(
+      root,
+      new Map([[filePath, fs.statSync(filePath).mtimeMs]]),
+      7,
+      0,
+      0,
+      new Date("2026-08-24T12:00:00.000Z"),
+    );
+
+    expect(hasCompletedMapBaseline(root)).toBe(true);
   });
 
   it("reports a mapped file that was deleted after ingest", async () => {

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -21,7 +21,7 @@ import { collectFacts, type EntityFacts } from "../explain/facts.js";
 import { llmLine, printLlmLines } from "../llm.js";
 import { parseBudgetOption, parsePickOption, parseRevisionOption } from "../options.js";
 import { resolveFileOrEntity } from "../resolve.js";
-import { createStaleProbe } from "../stale.js";
+import { createStaleProbe, hasCompletedMapBaseline } from "../stale.js";
 import { renderNote, renderSection, renderWarning, renderWarningErr, reportFailure } from "../ui.js";
 
 /** The four `--max-*` knobs that bound a bundle. */
@@ -334,6 +334,7 @@ export function registerContextCommand(program: Command): void {
         asOfRev,
         depth: opts.depth,
         budgets,
+        mapCompleted: hasCompletedMapBaseline(),
       });
 
       if (opts.save) {
@@ -416,7 +417,10 @@ async function buildFreshBundle(
     client.provenance(resolved.id),
   ]);
 
-  return buildBundle({ resolved, facts, context, provenance, asOfRev, depth: opts.depth, budgets });
+  return buildBundle({
+    resolved, facts, context, provenance, asOfRev, depth: opts.depth, budgets,
+    mapCompleted: hasCompletedMapBaseline(),
+  });
 }
 }
 
@@ -1326,13 +1330,28 @@ interface BuildInput {
    * under test; production passes nothing and gets the real baseline-backed one.
    */
   isStale?: (path: string) => boolean;
+  /**
+   * Whether the workspace has a completed map baseline. Injected for the same
+   * reason as `isStale`: it is a filesystem question, and buildBundle stays
+   * pure under test. Both production callers pass the real answer; the default
+   * is the optimistic one so a bundle built from injected facts alone is not
+   * silently reclassified.
+   */
+  mapCompleted?: boolean;
 }
 
 export function buildBundle(input: BuildInput): ContextBundle {
   const { resolved, facts, context, provenance, asOfRev, depth, budgets } = input;
 
   const stale = facts.stale;
-  const classification = stale ? "stale" : "current";
+  // Three states, not two. Without a completed map baseline the backend can
+  // still answer from graph patches an initial map committed before it failed,
+  // and calling that `current` is what let agents trust a half-built graph
+  // (#506). It is not `stale` either — nothing is known to have changed. The
+  // freshness union has carried `unverified` for exactly this case since it was
+  // written; this is the first thing to produce it.
+  const mapCompleted = input.mapCompleted ?? true;
+  const classification = !mapCompleted ? "unverified" : stale ? "stale" : "current";
   const prov = asRecord(provenance);
 
   // Entities: the target itself plus every referenced node, deduped by id and

--- a/ix-cli/src/cli/stale.ts
+++ b/ix-cli/src/cli/stale.ts
@@ -161,7 +161,10 @@ export function createStaleProbe(): (filePath: string) => boolean {
   const baseline = loadIngestBaseline(workspaceRoot);
 
   return (filePath: string): boolean => {
-    if (!baseline) return false;
+    // A baseline is written only after a map completes successfully. The
+    // backend can already contain partial commits when an initial map fails,
+    // so absence means its results are unverified rather than current.
+    if (!baseline) return true;
 
     const absolutePath = path.isAbsolute(filePath)
       ? path.resolve(filePath)

--- a/ix-cli/src/cli/stale.ts
+++ b/ix-cli/src/cli/stale.ts
@@ -137,6 +137,26 @@ export function detectStaleFiles(
 }
 
 /**
+ * Whether the active workspace has a completed map baseline.
+ *
+ * A baseline is written only by a local ingest that finished with no parse or
+ * commit errors, so its absence means one of three things: no map has been run,
+ * the initial map committed graph patches but never completed, or the workspace
+ * was ingested through the cloud runner, which writes no local baseline. In all
+ * three the backend may still answer reads from partially committed data (#506).
+ * None of them justify calling an individual file stale — that is a claim about
+ * a file having changed — so callers use this to report the *result set* as
+ * unverified rather than dressing up every file as modified.
+ */
+export function hasCompletedMapBaseline(root?: string): boolean {
+  try {
+    return loadIngestBaseline(path.resolve(root ?? resolveWorkspaceRoot())) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Check if a specific file path differs from the active workspace's ingest baseline.
  *
  * Synchronous now that it reads a local file instead of the patch log. It is
@@ -161,10 +181,14 @@ export function createStaleProbe(): (filePath: string) => boolean {
   const baseline = loadIngestBaseline(workspaceRoot);
 
   return (filePath: string): boolean => {
-    // A baseline is written only after a map completes successfully. The
-    // backend can already contain partial commits when an initial map fails,
-    // so absence means its results are unverified rather than current.
-    if (!baseline) return true;
+    // No baseline means the question this probe answers — "did this file change
+    // since it was ingested?" — has no answer, not that the answer is yes. The
+    // baseline is absent for a cloud-ingested workspace and for any workspace
+    // whose ingest never completed cleanly, so answering `true` reported every
+    // result of every command as modified in repos that were perfectly current.
+    // That unverified state is carried by `ix context`'s freshness
+    // classification instead, which can say so without claiming a file changed.
+    if (!baseline) return false;
 
     const absolutePath = path.isAbsolute(filePath)
       ? path.resolve(filePath)


### PR DESCRIPTION
Closes #506.

## Summary
Treat graph results as stale when their workspace has no completed ingest baseline.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Test
- [ ] CI

## Changes
- Make the shared stale probe treat a missing baseline as unverified instead of current.
- Cover both direct stale checks and the cached probe used by `ix context`.

## Validation
- `npm test`: 82 files passed, 1387 tests passed, 3 skipped.
- `npm run typecheck` passed.
- Parser smoke test and ESLint passed.
- Runtime comparison on 0.10.2/backend 1.0.26 changed an incomplete workspace result from `classification:current` to `classification:stale`.

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
