### PR TITLE
fix(doctor): scope graph counts to active workspace

### DIFF
--- a/ix-cli/src/cli/__tests__/doctor-stats-once.test.ts
+++ b/ix-cli/src/cli/__tests__/doctor-stats-once.test.ts
@@ -1,17 +1,32 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Command } from "commander";
 
-const statsCalls = { n: 0 };
+const statsCalls: Array<{ workspaceId?: string; systemId?: string } | undefined> = [];
+const scope = { workspaceId: "workspace-current", systemId: undefined as string | undefined };
 
 vi.mock("../../client/api.js", () => ({
   IxClient: class {
-    async stats() {
-      statsCalls.n += 1;
-      return { nodes: { total: 10 }, edges: { total: 20 } };
+    async stats(opts?: { workspaceId?: string; systemId?: string }) {
+      statsCalls.push(opts);
+      if (opts?.workspaceId === scope.workspaceId ||
+          (scope.systemId !== undefined && opts?.systemId === scope.systemId)) {
+        return { nodes: { total: 3457 }, edges: { total: 10365 } };
+      }
+      return { nodes: { total: 22969 }, edges: { total: 10365 } };
     }
     async conflicts() { return []; }
     async health() { return { status: "ok" }; }
   },
+}));
+
+vi.mock("../bootstrap.js", async (orig) => ({
+  ...(await orig<typeof import("../bootstrap.js")>()),
+  resolveWorkspaceId: () => scope.workspaceId,
+}));
+
+vi.mock("../resolve.js", async (orig) => ({
+  ...(await orig<typeof import("../resolve.js")>()),
+  resolveReadSystemId: async () => scope.systemId,
 }));
 
 // Doctor also inspects the live container and probes the schema. Both are
@@ -34,7 +49,9 @@ let savedEndpoint: string | undefined;
 
 beforeEach(() => {
   vi.resetModules();
-  statsCalls.n = 0;
+  statsCalls.length = 0;
+  scope.workspaceId = "workspace-current";
+  scope.systemId = undefined;
   // Belt and braces with the mocks above: nothing in this test may depend on a
   // backend being reachable, or on how quickly a given OS refuses a connection.
   savedEndpoint = process.env.IX_ENDPOINT;
@@ -46,12 +63,13 @@ afterEach(() => {
   else process.env.IX_ENDPOINT = savedEndpoint;
 });
 
-async function runDoctor(): Promise<void> {
+async function runDoctor(): Promise<string[]> {
   const { registerDoctorCommand } = await import("../commands/doctor.js");
   const program = new Command();
   program.name("ix").exitOverride();
   registerDoctorCommand(program);
-  const log = vi.spyOn(console, "log").mockImplementation(() => {});
+  const lines: string[] = [];
+  const log = vi.spyOn(console, "log").mockImplementation((...args) => lines.push(args.join(" ")));
   const err = vi.spyOn(console, "error").mockImplementation(() => {});
   try {
     await program.parseAsync(["doctor", "--format", "llm"], { from: "user" });
@@ -59,6 +77,7 @@ async function runDoctor(): Promise<void> {
     log.mockRestore();
     err.mockRestore();
   }
+  return lines;
 }
 
 describe("ix doctor", () => {
@@ -70,6 +89,21 @@ describe("ix doctor", () => {
    */
   it("asks the backend for stats once, not once per check that reads it", async () => {
     await runDoctor();
-    expect(statsCalls.n).toBe(1);
+    expect(statsCalls).toHaveLength(1);
+  });
+
+  it("reports active workspace counts rather than unscoped tombstones", async () => {
+    const lines = await runDoctor();
+
+    expect(statsCalls).toEqual([{ workspaceId: "workspace-current", systemId: undefined }]);
+    expect(lines).toContain('check name="Graph has nodes" status=ok detail="3457 nodes"');
+  });
+
+  it("uses the active system scope for a co-ingested workspace", async () => {
+    scope.systemId = "system-current";
+
+    await runDoctor();
+
+    expect(statsCalls).toEqual([{ workspaceId: undefined, systemId: "system-current" }]);
   });
 });

--- a/ix-cli/src/cli/__tests__/doctor-stats-once.test.ts
+++ b/ix-cli/src/cli/__tests__/doctor-stats-once.test.ts
@@ -2,16 +2,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Command } from "commander";
 
 const statsCalls: Array<{ workspaceId?: string; systemId?: string } | undefined> = [];
-const scope = { workspaceId: "workspace-current", systemId: undefined as string | undefined };
+const scope = {
+  workspaceId: "workspace-current" as string | undefined,
+  systemId: undefined as string | undefined,
+};
 
 vi.mock("../../client/api.js", () => ({
   IxClient: class {
     async stats(opts?: { workspaceId?: string; systemId?: string }) {
       statsCalls.push(opts);
-      if (opts?.workspaceId === scope.workspaceId ||
-          (scope.systemId !== undefined && opts?.systemId === scope.systemId)) {
-        return { nodes: { total: 3457 }, edges: { total: 10365 } };
-      }
+      // Both ids undefined is the unscoped call, not a match on a scope that
+      // happens to be unset — compare only ids that are actually present, or
+      // `undefined === undefined` silently answers with the workspace figure.
+      const scoped =
+        (opts?.workspaceId !== undefined && opts.workspaceId === scope.workspaceId) ||
+        (opts?.systemId !== undefined && opts.systemId === scope.systemId);
+      if (scoped) return { nodes: { total: 3457 }, edges: { total: 10365 } };
       return { nodes: { total: 22969 }, edges: { total: 10365 } };
     }
     async conflicts() { return []; }
@@ -96,14 +102,25 @@ describe("ix doctor", () => {
     const lines = await runDoctor();
 
     expect(statsCalls).toEqual([{ workspaceId: "workspace-current", systemId: undefined }]);
-    expect(lines).toContain('check name="Graph has nodes" status=ok detail="3457 nodes"');
+    expect(lines).toContain('check name="Graph has nodes" status=ok detail="3457 nodes in this workspace"');
   });
 
   it("uses the active system scope for a co-ingested workspace", async () => {
     scope.systemId = "system-current";
 
-    await runDoctor();
+    const lines = await runDoctor();
 
     expect(statsCalls).toEqual([{ workspaceId: undefined, systemId: "system-current" }]);
+    expect(lines).toContain('check name="Graph has nodes" status=ok detail="3457 nodes in this system"');
+  });
+
+  it("says the count is unscoped when no workspace is registered", async () => {
+    // A count of everything is not wrong here, but it is the one case where
+    // naming a scope would be — there is no active workspace to name.
+    scope.workspaceId = undefined;
+
+    const lines = await runDoctor();
+
+    expect(lines).toContain('check name="Graph has nodes" status=ok detail="22969 nodes in all workspaces"');
   });
 });

--- a/ix-cli/src/cli/commands/doctor.ts
+++ b/ix-cli/src/cli/commands/doctor.ts
@@ -3,6 +3,8 @@ import chalk from "chalk";
 import { renderSection, renderSuccess, renderError } from "../ui.js";
 import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
+import { resolveWorkspaceId } from "../bootstrap.js";
+import { resolveReadSystemId } from "../resolve.js";
 import { llmLine, printLlmLines } from "../llm.js";
 import { existsSync, readFileSync } from "node:fs";
 import { join as pathJoin, win32 as winPath } from "node:path";
@@ -127,7 +129,12 @@ export function registerDoctorCommand(program: Command): void {
       // hoisted so a run that never reaches those checks still never asks, and
       // so a failure is still reported per check rather than aborting both.
       let statsOnce: Promise<any> | undefined;
-      const sharedStats = (): Promise<any> => (statsOnce ??= client.stats());
+      const sharedStats = (): Promise<any> => (statsOnce ??= (async () => {
+        // The unscoped endpoint includes tombstoned nodes. Use the same active
+        // workspace/system scope as `ix stats` so a reset graph stays empty.
+        const systemId = await resolveReadSystemId(client);
+        return client.stats({ workspaceId: systemId ? undefined : resolveWorkspaceId(), systemId });
+      })());
 
       const checks: Check[] = [
         {

--- a/ix-cli/src/cli/commands/doctor.ts
+++ b/ix-cli/src/cli/commands/doctor.ts
@@ -128,12 +128,26 @@ export function registerDoctorCommand(program: Command): void {
       // the second one was most of what `ix doctor` spent. Memoized rather than
       // hoisted so a run that never reaches those checks still never asks, and
       // so a failure is still reported per check rather than aborting both.
-      let statsOnce: Promise<any> | undefined;
-      const sharedStats = (): Promise<any> => (statsOnce ??= (async () => {
-        // The unscoped endpoint includes tombstoned nodes. Use the same active
-        // workspace/system scope as `ix stats` so a reset graph stays empty.
+      // Counting only the active scope makes the number correct and, on its own,
+      // less self-evident: "0 nodes" against a backend holding thousands reads
+      // as a broken install until it says whose nodes it counted. The scope
+      // travels with the count so the check explains itself.
+      let statsOnce: Promise<{ stats: any; scope: string }> | undefined;
+      const sharedStats = (): Promise<{ stats: any; scope: string }> => (statsOnce ??= (async () => {
+        // Scoped the same way `ix stats` scopes, because doctor disagreeing with
+        // stats about the size of the graph is the whole of #510. Not a
+        // tombstone fix: /v1/stats filters `deleted_rev == null` in every one of
+        // its queries, scoped or not, so deleted nodes were never in either
+        // count. What the unscoped call added was every *live* node belonging to
+        // some other workspace on the same backend, which is how a freshly
+        // reset workspace still looked like a 17k-node graph.
         const systemId = await resolveReadSystemId(client);
-        return client.stats({ workspaceId: systemId ? undefined : resolveWorkspaceId(), systemId });
+        const workspaceId = systemId ? undefined : resolveWorkspaceId();
+        const stats = await client.stats({ workspaceId, systemId });
+        // Undefined on both means no workspace is registered yet, and the
+        // request really was unscoped — say that rather than name a scope.
+        const scope = systemId ? "this system" : workspaceId ? "this workspace" : "all workspaces";
+        return { stats, scope };
       })());
 
       const checks: Check[] = [
@@ -154,9 +168,9 @@ export function registerDoctorCommand(program: Command): void {
           name: "Graph has nodes",
           run: async () => {
             try {
-              const s = await sharedStats();
-              const total = s.nodes?.total ?? 0;
-              return { ok: total > 0, detail: `${total} nodes` };
+              const { stats, scope } = await sharedStats();
+              const total = stats.nodes?.total ?? 0;
+              return { ok: total > 0, detail: `${total} nodes in ${scope}` };
             } catch (e: any) {
               return { ok: false, detail: e.message ?? "stats failed" };
             }
@@ -166,9 +180,9 @@ export function registerDoctorCommand(program: Command): void {
           name: "Graph has edges",
           run: async () => {
             try {
-              const s = await sharedStats();
-              const total = s.edges?.total ?? 0;
-              return { ok: total > 0, detail: `${total} edges` };
+              const { stats, scope } = await sharedStats();
+              const total = stats.edges?.total ?? 0;
+              return { ok: total > 0, detail: `${total} edges in ${scope}` };
             } catch (e: any) {
               return { ok: false, detail: e.message ?? "stats failed" };
             }


### PR DESCRIPTION
Closes #510.

## Summary
Scope `ix doctor` graph counts to the active workspace or stitched system.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Test
- [ ] CI

## Changes
- Resolve the active read system before fetching doctor stats.
- Fall back to the active workspace when no stitched system is present.
- Keep the existing single stats request shared by the node and edge checks.

## Validation
- `npm test`: 82 files passed, 1389 tests passed, 3 skipped.
- `npm run typecheck`, parser smoke test, ESLint, and `git diff --check` passed.
- Runtime comparison on 0.10.2/backend 1.0.26 changed doctor from unscoped 17,213 nodes/2,528 edges to the active workspace's 5 nodes/6 edges.

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
