### PR TITLE
chore(release): 0.10.3

### DIFF
--- a/ix-cli/package-lock.json
+++ b/ix-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ix/cli",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ix/cli",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
         "chalk": "^6.0.0",

--- a/ix-cli/package.json
+++ b/ix-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ix/cli",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "type": "module",
   "description": "Ix Memory — Persistent Memory for LLM Systems",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump for 0.10.3. Three bug fixes, all CLI-side — no backend change, so no `ix-memory-layer` release is needed first.

**`ix doctor` counted the whole backend, not your workspace** (#511, closes #510)
Doctor's graph counts were unscoped, so a freshly reset workspace still reported thousands of nodes and doctor disagreed with `ix stats`. It now scopes the same way `ix stats` does, and says which scope the count came from.

**`ix map` could exit 0 with no hierarchy** (#509, closes #508)
A clean ingest that committed every file could be followed by a completed-but-empty map, and the CLI recorded that as a successful map — `ix status` then reported `mapCompleted: true` for a hierarchy that did not exist. That contradiction now fails with a language-support diagnostic and leaves the workspace unmapped.

**`ix context` called a half-built graph current** (#507, closes #506)
When an initial map committed graph patches and then failed, read commands served those partial results as current. The bundle is now classified `unverified` — a state the freshness field has always declared and nothing had ever produced.

Note for anything parsing `ix context`: `freshness.classification` can now return `unverified` in addition to `current` and `stale`. It is reported where the answer was previously, and wrongly, `current`.

This PR touches the packaging surface, so the full per-platform build matrix runs here as a dry-run before the tag is pushed.
