### PR TITLE
fix(ingest): bisect a bulk refused for exceeding Arango's transaction size

### DIFF
--- a/ix-cli/src/cli/__tests__/ingest-retry.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-retry.test.ts
@@ -6,6 +6,16 @@ import {
   isRetryableCommitConflict,
 } from '../commands/ingest.js';
 
+// Verbatim from a backend that refused a bulk save of a >1,000-file repo (Ix#516).
+// A bulk commit runs as one exclusive Arango transaction, and Arango caps that at
+// 512MB; the driver error is relayed by ErrorHandler's catch-all arm, so it reaches
+// the CLI as a 500 body rather than the 413 the proxy limits produce.
+const ARANGO_TRANSACTION_LIMIT_ERROR = new Error(
+  '500: {"error":"internal_error","message":"Response: 500, Error: 32 - AQL: ' +
+    'Maximal transaction size limit of 536870912 bytes is reached ' +
+    '[node #5: InsertNode] (while executing)"}',
+);
+
 describe('isAbortError', () => {
   it('detects AbortError and TimeoutError by name', () => {
     const abort = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
@@ -56,6 +66,10 @@ describe('isPayloadTooLargeError', () => {
     expect(isPayloadTooLargeError(error)).toBe(true);
   });
 
+  it("recognises Arango's transaction size ceiling, which arrives as a 500", () => {
+    expect(isPayloadTooLargeError(ARANGO_TRANSACTION_LIMIT_ERROR)).toBe(true);
+  });
+
   it('does not mistake an unrelated error for a payload limit', () => {
     expect(isPayloadTooLargeError(new Error('500: internal server error'))).toBe(false);
     expect(isPayloadTooLargeError(new Error('patch 413 failed validation'))).toBe(false);
@@ -101,6 +115,34 @@ describe('commitBulkWithPayloadSplit', () => {
 
     expect(commitIndividually).toHaveBeenCalledOnce();
     expect(commitIndividually).toHaveBeenCalledWith([1], error);
+  });
+
+  it('bisects an over-limit Arango transaction instead of degrading to per-file', async () => {
+    // The regression behind Ix#516: this error was unrecognised, so a whole chunk
+    // took the per-file path — 1,000 patches committed one at a time, serialized
+    // behind the fallback mutex, with the progress bar parked on the last chunk
+    // boundary. Splitting the group puts each half in its own transaction instead.
+    const bulkCalls: number[][] = [];
+    const committed: number[] = [];
+    const commitIndividually = vi.fn(async () => {});
+
+    await commitBulkWithPayloadSplit([1, 2, 3, 4], {
+      commitBulk: async batch => {
+        bulkCalls.push([...batch]);
+        if (batch.length > 2) throw ARANGO_TRANSACTION_LIMIT_ERROR;
+        return batch.length;
+      },
+      onBulkCommitted: batch => committed.push(...batch),
+      commitIndividually,
+    });
+
+    expect(bulkCalls).toEqual([
+      [1, 2, 3, 4],
+      [1, 2],
+      [3, 4],
+    ]);
+    expect(committed).toEqual([1, 2, 3, 4]);
+    expect(commitIndividually).not.toHaveBeenCalled();
   });
 
   it('keeps the existing per-file fallback for non-payload bulk failures', async () => {

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -552,11 +552,23 @@ async function retryOnConflict<T>(fn: () => Promise<T>, maxRetries: number): Pro
   }
 }
 
+// Every entry here means the same thing operationally: this batch was refused for
+// being too big to apply as one unit, so committing fewer patches per request can
+// still succeed. That is what makes bisecting the right recovery.
 const PAYLOAD_TOO_LARGE_PATTERNS = [
+  // A proxy / ingress refused the request body before the backend saw it.
   'payload too large',
   'request entity too large',
   'content too large',
   'request body too large',
+  // The backend accepted the body, then ArangoDB refused the write: a bulk commit
+  // runs as ONE exclusive transaction, and Arango caps a transaction at 512MB by
+  // default (error 32, surfaced as a 500 — not a 413):
+  //   "AQL: Maximal transaction size limit of 536870912 bytes is reached"
+  // Bisecting splits the group across two transactions, so each half fits.
+  // Without this, a big-repo save fell through to the per-file path and a single
+  // 1,000-file chunk became 1,000 serialized commits — Ix#516.
+  'maximal transaction size',
 ];
 
 export function isPayloadTooLargeError(err: unknown): boolean {


### PR DESCRIPTION
Closes #516.

## What happens

A bulk commit is applied inside one exclusive Arango transaction, and Arango caps a transaction at 512MB by default. Past that it fails the write with error 32:

```
AQL: Maximal transaction size limit of 536870912 bytes is reached [node #5: InsertNode]
```

`ErrorHandler` relays that through its catch-all arm, so it reaches the CLI as a **500 body** — not the 413 a proxy body limit produces. `isPayloadTooLargeError` only recognised the proxy shapes (`payload too large`, `request entity too large`, …, plus HTTP 413), so the group took the `!isPayloadTooLargeError(err)` branch and went to `commitIndividually`.

That path is serialized behind the fallback mutex to keep revisions from racing, so a 1,000-patch chunk becomes 1,000 sequential commits. And because `progressCurrent` only advances once a whole chunk resolves, the bar sits on the previous chunk boundary for the duration — which is exactly the reported "hangs at 1,000 files".

## Measured

Reproduced against a local backend ingesting a 2,147-file repo. Bulk latency climbs until the ceiling is hit, then the fallback takes over:

| bulk attempt | duration | status |
|---|---|---|
| 1 | 40.1s | 200 |
| 2 | 70.7s | 200 |
| 3 | 110.3s | **500** (error 32) |

The per-file path that followed averaged **3.2s** per patch (median 490ms, p90 3.8s, max 22.3s) across 243 commits — roughly an hour for the single chunk.

## The change

Bisecting is already the correct recovery and was already implemented — each half commits in its own transaction, so it converges on a size that fits. This only lets that path recognise the error.

Scoped deliberately:

- **Matches `"maximal transaction size"`, not error 32 or a bare 500.** Error 32 is Arango's generic resource-limit code and a bare 500 covers unrelated failures; neither is fixed by sending fewer patches, and treating them as splittable would bisect all the way toward per-file for errors that can never succeed.
- **A plain 500 stays unrecognised**, still covered by its existing test.

## Tests

Two cases, asserting the recovery rather than the predicate alone:

- the predicate recognises the verbatim backend error;
- `commitBulkWithPayloadSplit` driven with that same error asserts the **split sequence** and that `commitIndividually` is never called.

Both fail without the pattern (verified by reverting it):

```
× recognises Arango's transaction size ceiling, which arrives as a 500
    AssertionError: expected false to be true
× bisects an over-limit Arango transaction instead of degrading to per-file
    AssertionError: expected [ [ 1, 2, 3, 4 ] ] to deeply equal [ [ 1, 2, 3, 4 ], [ 1, 2 ], [ 3, 4 ] ]
```

Full `ix-cli` suite: 1405 passed / 2 skipped, 82 files. `typecheck`, `lint`, and `knip` all clean.

## Relationship to #495 / #515

Related but distinct, and they do not overlap in code. #515 recovers a **409** by replaying `committed_patch_ids`; this is a **500** that takes the `commitIndividually` branch before any of that logic is reached. The two fixes compose — #515 also makes `setCurrentWork` update per file, which would turn this symptom from "hangs" into "visibly slow" even where a batch still ends up on the per-file path.

## Worth considering separately

`COMMIT_HTTP_MAX_FILES` bounds a request by **file count**, but Arango's limit is on transaction **bytes** — so the ceiling is reachable at very different file counts depending on how dense the files are. Bounding a chunk by estimated payload size would stop most of these before a round trip is wasted. Left out of this PR to keep the fix to the recovery path.
