### PR TITLE
chore(release): 0.10.4

### DIFF
--- a/ix-cli/package-lock.json
+++ b/ix-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ix/cli",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ix/cli",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
         "chalk": "^6.0.0",

--- a/ix-cli/package.json
+++ b/ix-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ix/cli",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "type": "module",
   "description": "Ix Memory — Persistent Memory for LLM Systems",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Cuts **v0.10.4** from the three fixes merged today. Version bump only — `ix-cli/package.json` and the two `@ix/cli` entries in the lock.

## What ships

| | |
|---|---|
| #515 | Resume a partly-committed bulk instead of degrading to per-file — closes #495 |
| #517 | Recognise Arango's transaction-size ceiling so an oversized bulk bisects — closes #516 |
| #519 | `ix doctor` stops reporting *All checks passed* for a directory no workspace covers — closes #518 |

Both bulk-save bugs were reported from outside and are only reachable through a release; #516's reporter is on the `IX_COMMIT_HTTP_MAX_FILES=200` workaround until this lands.

#515 reads `committed_patch_ids`, which the backend gained in **memory-layer v1.0.27** (Ix-memory#171, already released). It degrades to the previous whole-batch fallback against anything older, so there is no backend floor to raise here.

## Type
- [x] CI

## Changes
- `ix-cli/package.json`: `0.10.3` → `0.10.4`
- `ix-cli/package-lock.json`: the same for both `@ix/cli` entries. Note `node_modules/@tybys/wasm-util` is coincidentally also `0.10.3` and is deliberately untouched.

## Validation
- Full unit suite green (1406 passed, 2 skipped) and main's CI green on `1211829`, including the E2E against a real backend.
- #519 verified end to end against the local memory-layer v1.0.27, reproducing #518's exact setup: a never-ingested directory now reports `healthy=false` with `no workspace registered for … — reads here answer from workspace 'system-compass' instead`, and the counts read `7717 nodes in workspace 'system-compass'` rather than the misleading *in this workspace*. Inside a registered workspace it still passes every check.
- Touching `ix-cli/package.json` triggers the release packaging dry-run — that matrix is the gate for this PR.

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [x] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag -a v0.10.4 <sha> && git push origin v0.10.4`)
- [x] If backend changes: none — v1.0.27 is already released
- [x] If `docker-compose.standalone.yml` changed: unchanged
