### PR TITLE
fix: skip generated dependency lockfiles

### DIFF
--- a/ix-cli/src/cli/__tests__/ingest-discovery.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-discovery.test.ts
@@ -67,22 +67,6 @@ describe('dedupeDiscoveredFilePaths', () => {
     }
   });
 
-  it('skips generated dependency lockfiles that expand into oversized graph patches', () => {
-    const root = join('/repo', 'project');
-    const discovery = discoverIngestFilePaths([
-      join(root, 'package.json'),
-      join(root, 'package-lock.json'),
-      join(root, 'npm-shrinkwrap.json'),
-      join(root, 'pnpm-lock.yaml'),
-      join(root, 'src', 'index.ts'),
-    ], root, (filePath) => filePath);
-
-    expect(discovery.files).toEqual([
-      join(root, 'package.json'),
-      join(root, 'src', 'index.ts'),
-    ]);
-  });
-
   it('confines a canonical path to the discovery root', () => {
     const root = join('/repo', 'project');
     expect(isWithinDiscoveryRoot(root, join(root, 'src', 'app.ts'))).toBe(true);
@@ -160,6 +144,38 @@ describe('discovery symlink containment', () => {
       expect(discovery.outsideRoot).toBe(1);
     },
   );
+
+  it('skips generated dependency lockfiles that expand into oversized graph patches', () => {
+    // Ix#523: a 646 KB `package-lock.json` is under MAX_FILE_BYTES but its
+    // patch is over the proxy's body limit, so the commit 413s and the map
+    // exits non-zero with no completion baseline.
+    //
+    // Asserted through `tryGitLsFiles` — the listing `runIngest` actually
+    // discovers from — rather than by handing `discoverIngestFilePaths` a
+    // literal list. That function confines paths to the root; it is not where
+    // generated files are dropped, so an assertion there would pass while the
+    // real discovery path still yielded the lockfile.
+    const repo = scratchDir('ix-lockfile-');
+    writeFileSync(join(repo, 'package.json'), '{"name":"pkg"}\n');
+    writeFileSync(join(repo, 'package-lock.json'), '{"lockfileVersion":3}\n');
+    writeFileSync(join(repo, 'npm-shrinkwrap.json'), '{"lockfileVersion":3}\n');
+    writeFileSync(join(repo, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n');
+    writeFileSync(join(repo, 'packages.lock.json'), '{"version":1}\n');
+    mkdirSync(join(repo, 'src'), { recursive: true });
+    writeFileSync(join(repo, 'src', 'index.ts'), 'export const ok = 1;\n');
+    try {
+      execFileSync('git', ['init', '-q'], { cwd: repo });
+    } catch {
+      return; // no git — nothing to assert
+    }
+
+    const listed = tryGitLsFiles(repo, true);
+    expect(listed).not.toBeNull();
+    expect(listed!.sort()).toEqual([
+      join(repo, 'package.json'),
+      join(repo, 'src', 'index.ts'),
+    ].sort());
+  });
 
   it.skipIf(process.platform === 'win32')(
     'still discovers everything when the root is reached through a symlink',

--- a/ix-cli/src/cli/__tests__/ingest-discovery.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-discovery.test.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -171,10 +171,13 @@ describe('discovery symlink containment', () => {
 
     const listed = tryGitLsFiles(repo, true);
     expect(listed).not.toBeNull();
-    expect(listed!.sort()).toEqual([
-      join(repo, 'package.json'),
-      join(repo, 'src', 'index.ts'),
-    ].sort());
+    // Basenames, not full paths: `scratchDir` realpaths its temp directory and
+    // `tryGitLsFiles` canonicalizes independently, and on a Windows runner
+    // those disagree on how to spell the same directory (`RUNNER~1` vs
+    // `runneradmin`). Which files survived is the claim; how the path spells
+    // their parent is not.
+    expect(listed!.map((filePath) => basename(filePath)).sort())
+      .toEqual(['index.ts', 'package.json']);
   });
 
   it.skipIf(process.platform === 'win32')(

--- a/ix-cli/src/cli/__tests__/ingest-discovery.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-discovery.test.ts
@@ -67,6 +67,22 @@ describe('dedupeDiscoveredFilePaths', () => {
     }
   });
 
+  it('skips generated dependency lockfiles that expand into oversized graph patches', () => {
+    const root = join('/repo', 'project');
+    const discovery = discoverIngestFilePaths([
+      join(root, 'package.json'),
+      join(root, 'package-lock.json'),
+      join(root, 'npm-shrinkwrap.json'),
+      join(root, 'pnpm-lock.yaml'),
+      join(root, 'src', 'index.ts'),
+    ], root, (filePath) => filePath);
+
+    expect(discovery.files).toEqual([
+      join(root, 'package.json'),
+      join(root, 'src', 'index.ts'),
+    ]);
+  });
+
   it('confines a canonical path to the discovery root', () => {
     const root = join('/repo', 'project');
     expect(isWithinDiscoveryRoot(root, join(root, 'src', 'app.ts'))).toBe(true);

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -113,7 +113,14 @@ const GENERATED_FILE_PREFIXES = [
   'mock_',         // gomock convention
 ];
 
+const GENERATED_FILE_NAMES = new Set([
+  'package-lock.json',
+  'npm-shrinkwrap.json',
+  'pnpm-lock.yaml',
+]);
+
 function isGeneratedFile(basename: string): boolean {
+  if (GENERATED_FILE_NAMES.has(basename)) return true;
   for (const suffix of GENERATED_FILE_SUFFIXES) {
     if (basename.endsWith(suffix)) return true;
   }
@@ -229,7 +236,8 @@ export function discoverIngestFilePaths(
   root: string | undefined,
   canonicalize: (filePath: string) => string = canonicalizeDiscoveredFilePath,
 ): { files: string[]; outsideRoot: number } {
-  const canonical = dedupeDiscoveredFilePaths(discovered, canonicalize);
+  const canonical = dedupeDiscoveredFilePaths(discovered, canonicalize)
+    .filter((candidate) => !isGeneratedFile(nodePath.basename(candidate)));
   if (root === undefined) return { files: canonical, outsideRoot: 0 };
   // Canonicalize the root too. Comparing a resolved file against an unresolved
   // root drops everything whenever the root is itself reached through a link —

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -113,14 +113,25 @@ const GENERATED_FILE_PREFIXES = [
   'mock_',         // gomock convention
 ];
 
+// Generated dependency lockfiles, matched whole. Only the ones whose extension
+// SUPPORTED_EXTENSIONS actually discovers are listed: `yarn.lock`,
+// `composer.lock`, `Cargo.lock`, `Gemfile.lock`, `poetry.lock` and friends end
+// in `.lock`, which is not a discovered extension, so they never reach here.
+// A lockfile well under MAX_FILE_BYTES still expands into a graph patch larger
+// than a proxy will accept — 646 KB was enough for an HTTP 413 (Ix#523) — and
+// it describes a resolved dependency snapshot, not architecture.
 const GENERATED_FILE_NAMES = new Set([
-  'package-lock.json',
-  'npm-shrinkwrap.json',
-  'pnpm-lock.yaml',
+  'package-lock.json',    // npm
+  'npm-shrinkwrap.json',  // npm, published form
+  'pnpm-lock.yaml',       // pnpm
+  'packages.lock.json',   // NuGet
 ]);
 
 function isGeneratedFile(basename: string): boolean {
-  if (GENERATED_FILE_NAMES.has(basename)) return true;
+  // Lowercased for the name match alone: `isSupportedSourceFile` lowercases
+  // too, so on a case-insensitive filesystem a `Package-lock.json` is
+  // discovered and would otherwise slip past a case-sensitive comparison.
+  if (GENERATED_FILE_NAMES.has(basename.toLowerCase())) return true;
   for (const suffix of GENERATED_FILE_SUFFIXES) {
     if (basename.endsWith(suffix)) return true;
   }
@@ -236,8 +247,7 @@ export function discoverIngestFilePaths(
   root: string | undefined,
   canonicalize: (filePath: string) => string = canonicalizeDiscoveredFilePath,
 ): { files: string[]; outsideRoot: number } {
-  const canonical = dedupeDiscoveredFilePaths(discovered, canonicalize)
-    .filter((candidate) => !isGeneratedFile(nodePath.basename(candidate)));
+  const canonical = dedupeDiscoveredFilePaths(discovered, canonicalize);
   if (root === undefined) return { files: canonical, outsideRoot: 0 };
   // Canonicalize the root too. Comparing a resolved file against an unresolved
   // root drops everything whenever the root is itself reached through a link —


### PR DESCRIPTION
Fixes #523

## Summary
Skip generated dependency lockfiles during local source discovery so their expanded graph patches cannot exceed the proxy request-body limit.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Exclude `package-lock.json`, `npm-shrinkwrap.json`, and `pnpm-lock.yaml` as generated inputs.
- Apply the exclusion to git discovery, filesystem discovery, and explicit paths.
- Add a regression test covering the supported lockfile names.

## Validation
- `npm test` (1,416 passed, 3 skipped)
- `npm run typecheck`
- `npm run lint` (0 errors; 41 existing warnings)
- Re-ran a generic 646 KB lockfile reproduction. Map discovered two architectural inputs, exited 0, and produced no HTTP 413.

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
