### PR TITLE
fix: reject severely incomplete architecture maps

### DIFF
--- a/ix-cli/src/cli/__tests__/map-auto-skip.test.ts
+++ b/ix-cli/src/cli/__tests__/map-auto-skip.test.ts
@@ -7,7 +7,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   applyRequestedMapCoalesceExitCode,
   describeEmptyCompletedMap,
+  describeSeverelyIncompleteCompletedMap,
   invalidateBaselineForEmptyCompletedMap,
+  invalidateBaselineForIncompleteCompletedMap,
   mapModeForIngest,
   registerMapCommand,
   requestedMapCoalesceExitCode,
@@ -206,5 +208,56 @@ describe('describeEmptyCompletedMap', () => {
       parseErrors: 0,
       commitErrors: 0,
     })).toBeDefined();
+  });
+});
+
+describe('describeSeverelyIncompleteCompletedMap', () => {
+  const cleanIngest = {
+    filesDiscovered: 200,
+    patchesApplied: 200,
+    parseErrors: 0,
+    commitErrors: 0,
+  };
+
+  it('rejects a completed hierarchy that covers no more than half of the source files', () => {
+    const message = describeSeverelyIncompleteCompletedMap({
+      file_count: 100,
+      outcome: 'full_local_completed',
+    }, cleanIngest);
+
+    expect(message).toContain('mapped only 100 of 200 supported source files');
+    expect(message).toContain('architecture hierarchy is severely incomplete');
+  });
+
+  it('allows ordinary small omissions', () => {
+    expect(describeSeverelyIncompleteCompletedMap({
+      file_count: 190,
+      outcome: 'full_local_completed',
+    }, cleanIngest)).toBeUndefined();
+  });
+
+  it('does not replace an ingest failure with a coverage diagnosis', () => {
+    expect(describeSeverelyIncompleteCompletedMap({
+      file_count: 1,
+      outcome: 'full_local_completed',
+    }, { ...cleanIngest, commitErrors: 1 })).toBeUndefined();
+  });
+
+  it('invalidates the completion baseline for a severely partial hierarchy', () => {
+    const invalidate = vi.fn();
+    const message = invalidateBaselineForIncompleteCompletedMap({
+      file_count: 1,
+      region_count: 0,
+      regions: [],
+      outcome: 'full_local_completed',
+    }, {
+      filesDiscovered: 2,
+      patchesApplied: 2,
+      parseErrors: 0,
+      commitErrors: 0,
+    }, '/workspace/mixed', invalidate);
+
+    expect(message).toContain('mapped only 1 of 2');
+    expect(invalidate).toHaveBeenCalledWith('/workspace/mixed');
   });
 });

--- a/ix-cli/src/cli/commands/map.ts
+++ b/ix-cli/src/cli/commands/map.ts
@@ -163,6 +163,27 @@ export function describeEmptyCompletedMap(
 }
 
 /**
+ * A non-empty hierarchy can still be unusably partial when the backend maps
+ * only a small subset of the source graph. Allow ordinary small omissions,
+ * but reject a completed result that covers no more than half of a clean
+ * local ingest.
+ */
+export function describeSeverelyIncompleteCompletedMap(
+  result: Pick<MapResult, "file_count" | "outcome">,
+  ingest: Pick<IngestFilesSummary, "filesDiscovered" | "patchesApplied" | "parseErrors" | "commitErrors"> | undefined,
+): string | undefined {
+  if (!ingest || ingest.filesDiscovered < 2 || ingest.parseErrors > 0 || ingest.commitErrors > 0) {
+    return undefined;
+  }
+  if (!result.outcome || !COMPLETED_MAP_OUTCOMES.has(result.outcome)) return undefined;
+  if (result.file_count <= 0 || result.file_count * 2 > ingest.filesDiscovered) return undefined;
+
+  const sourceFiles = ingest.filesDiscovered;
+  const patches = ingest.patchesApplied;
+  return `Backend reported ${result.outcome}, but mapped only ${result.file_count} of ${sourceFiles} supported source files after a clean local ingest (${patches} ${patches === 1 ? "patch" : "patches"} committed). The source graph was ingested, but the architecture hierarchy is severely incomplete. The ingest cache has been cleared, so the next 'ix map' re-parses every file.`;
+}
+
+/**
  * An empty completed map invalidates the local completion baseline. Keeping it
  * would make `ix status` report mapCompleted=true for a hierarchy that does not
  * exist. The next run may hash-skip unchanged files, so detection is based on
@@ -181,6 +202,18 @@ export function invalidateBaselineForEmptyCompletedMap(
   invalidate: (root: string) => void = clearIngestMtimeCache,
 ): string | undefined {
   const message = describeEmptyCompletedMap(result, ingest);
+  if (message) invalidate(projectRoot);
+  return message;
+}
+
+export function invalidateBaselineForIncompleteCompletedMap(
+  result: Pick<MapResult, "file_count" | "region_count" | "regions" | "outcome">,
+  ingest: Pick<IngestFilesSummary, "filesDiscovered" | "patchesApplied" | "parseErrors" | "commitErrors"> | undefined,
+  projectRoot: string,
+  invalidate: (root: string) => void = clearIngestMtimeCache,
+): string | undefined {
+  const message = describeEmptyCompletedMap(result, ingest)
+    ?? describeSeverelyIncompleteCompletedMap(result, ingest);
   if (message) invalidate(projectRoot);
   return message;
 }
@@ -403,7 +436,7 @@ Examples:
       if (mapInterval) { clearInterval(mapInterval); process.stderr.write('\r' + ' '.repeat(60) + '\r'); }
       const mapMs = Math.round(performance.now() - mapStart);
 
-      const emptyMapError = invalidateBaselineForEmptyCompletedMap(result, localIngest, cwd);
+      const emptyMapError = invalidateBaselineForIncompleteCompletedMap(result, localIngest, cwd);
       if (emptyMapError) {
         emitError(emptyMapError);
         process.exitCode = 1;


### PR DESCRIPTION
Fixes #524

## Summary
Prevent a non-empty but severely incomplete architecture hierarchy from being recorded as a completed local map.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Compare completed map coverage with the clean local ingest count.
- Reject coverage of half or fewer discovered source files while allowing ordinary small omissions.
- Clear the local completion baseline so status remains unverified and the next run reparses the workspace.
- Add regression coverage for severe, ordinary, and ingest-failure cases.

## Validation
- `npm test` (1,419 passed, 3 skipped)
- `npm run typecheck`
- `npm run lint` (0 errors; 41 existing warnings)
- Re-ran a generic mixed PHP and JSON repository. The map exited 1 with `mapped only 1 of 2`, and status kept `mapCompleted: false`.

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
