### PR TITLE
fix: check map completion in doctor

### DIFF
--- a/ix-cli/src/cli/__tests__/doctor-stats-once.test.ts
+++ b/ix-cli/src/cli/__tests__/doctor-stats-once.test.ts
@@ -16,7 +16,9 @@ const scope = {
   matched: undefined as FakeWorkspace | undefined,
   fallback: undefined as FakeWorkspace | undefined,
   systemId: undefined as string | undefined,
+  sourceBaseline: true,
   mapCompleted: true,
+  cloudReady: false,
 };
 
 vi.mock("../../client/api.js", () => ({
@@ -53,14 +55,29 @@ vi.mock("../resolve.js", async (orig) => ({
   resolveReadSystemId: async () => scope.systemId,
 }));
 
-vi.mock("../stale.js", () => ({
-  detectStaleFiles: () => ({
-    mapCompleted: scope.mapCompleted,
-    currentRev: scope.mapCompleted ? 42 : 0,
-    lastIngestAt: scope.mapCompleted ? "2026-01-01T00:00:00.000Z" : null,
-    staleFiles: 0,
-    sampleChangedFiles: [],
-  }),
+// The two completion markers, mocked separately because the check has to tell
+// them apart: a missing source baseline and a missing map marker are different
+// states with different verdicts.
+vi.mock("../stale.js", async (orig) => ({
+  ...(await orig<typeof import("../stale.js")>()),
+  hasCompletedMapBaseline: () => scope.mapCompleted,
+}));
+
+vi.mock("../ingest-baseline.js", async (orig) => ({
+  ...(await orig<typeof import("../ingest-baseline.js")>()),
+  loadIngestBaseline: () => scope.sourceBaseline
+    ? {
+      files: new Map<string, number>(),
+      deletedFiles: new Map<string, string[]>(),
+      currentRev: 42,
+      lastIngestAt: "2026-01-01T00:00:00.000Z",
+    }
+    : null,
+}));
+
+vi.mock("../remote.js", async (orig) => ({
+  ...(await orig<typeof import("../remote.js")>()),
+  isCloudReady: async () => scope.cloudReady,
 }));
 
 // Doctor also inspects the live container and probes the schema. Both are
@@ -87,7 +104,9 @@ beforeEach(() => {
   scope.matched = CURRENT;
   scope.fallback = undefined;
   scope.systemId = undefined;
+  scope.sourceBaseline = true;
   scope.mapCompleted = true;
+  scope.cloudReady = false;
   // Belt and braces with the mocks above: nothing in this test may depend on a
   // backend being reachable, or on how quickly a given OS refuses a connection.
   savedEndpoint = process.env.IX_ENDPOINT;
@@ -141,7 +160,17 @@ describe("ix doctor", () => {
     expect(lines).toContain(`check name="Workspace for this directory" status=ok detail="workspace 'current-repo'"`);
   });
 
-  it("does not report a partial graph as healthy when no completed map baseline exists", async () => {
+  it("reports the recorded revision when both completion markers are current", async () => {
+    const lines = await runDoctor();
+
+    expect(lines[0]).toContain("healthy=true");
+    expect(lines).toContain(
+      'check name="Completed map for this workspace" status=ok detail="recorded at revision 42"',
+    );
+  });
+
+  it("does not report a partial graph as healthy when no completed baseline exists", async () => {
+    scope.sourceBaseline = false;
     scope.mapCompleted = false;
 
     const lines = await runDoctor();
@@ -149,6 +178,35 @@ describe("ix doctor", () => {
     expect(lines[0]).toContain("healthy=false");
     expect(lines).toContain(
       'check name="Completed map for this workspace" status=fail detail="no completed map baseline — the graph may be partial. Run `ix map`."',
+    );
+  });
+
+  it("fails a clean source graph that has no architecture map for its revision", async () => {
+    scope.mapCompleted = false;
+
+    const lines = await runDoctor();
+
+    expect(lines[0]).toContain("healthy=false");
+    expect(lines).toContain(
+      'check name="Completed map for this workspace" status=fail ' +
+      'detail="source graph at revision 42 has no completed architecture map — run `ix map`"',
+    );
+  });
+
+  it("warns rather than fails when a cloud runner explains the missing local baseline", async () => {
+    // The cloud runner writes no local baseline by design, so absence is not
+    // evidence of a partial graph there — and calling it a failure would make
+    // `ix doctor` permanently unhealthy on a perfectly good cloud workspace.
+    scope.sourceBaseline = false;
+    scope.mapCompleted = false;
+    scope.cloudReady = true;
+
+    const lines = await runDoctor();
+
+    expect(lines[0]).toContain("healthy=true");
+    expect(lines).toContain(
+      'check name="Completed map for this workspace" status=warn ' +
+      'detail="no local baseline — expected for a cloud-ingested workspace"',
     );
   });
 

--- a/ix-cli/src/cli/__tests__/doctor-stats-once.test.ts
+++ b/ix-cli/src/cli/__tests__/doctor-stats-once.test.ts
@@ -16,6 +16,7 @@ const scope = {
   matched: undefined as FakeWorkspace | undefined,
   fallback: undefined as FakeWorkspace | undefined,
   systemId: undefined as string | undefined,
+  mapCompleted: true,
 };
 
 vi.mock("../../client/api.js", () => ({
@@ -52,6 +53,16 @@ vi.mock("../resolve.js", async (orig) => ({
   resolveReadSystemId: async () => scope.systemId,
 }));
 
+vi.mock("../stale.js", () => ({
+  detectStaleFiles: () => ({
+    mapCompleted: scope.mapCompleted,
+    currentRev: scope.mapCompleted ? 42 : 0,
+    lastIngestAt: scope.mapCompleted ? "2026-01-01T00:00:00.000Z" : null,
+    staleFiles: 0,
+    sampleChangedFiles: [],
+  }),
+}));
+
 // Doctor also inspects the live container and probes the schema. Both are
 // mocked, not merely pointed somewhere harmless: an unmocked `docker inspect`
 // or socket connect is slow-and-variable rather than fast-and-failing, which is
@@ -76,6 +87,7 @@ beforeEach(() => {
   scope.matched = CURRENT;
   scope.fallback = undefined;
   scope.systemId = undefined;
+  scope.mapCompleted = true;
   // Belt and braces with the mocks above: nothing in this test may depend on a
   // backend being reachable, or on how quickly a given OS refuses a connection.
   savedEndpoint = process.env.IX_ENDPOINT;
@@ -127,6 +139,17 @@ describe("ix doctor", () => {
     const lines = await runDoctor();
 
     expect(lines).toContain(`check name="Workspace for this directory" status=ok detail="workspace 'current-repo'"`);
+  });
+
+  it("does not report a partial graph as healthy when no completed map baseline exists", async () => {
+    scope.mapCompleted = false;
+
+    const lines = await runDoctor();
+
+    expect(lines[0]).toContain("healthy=false");
+    expect(lines).toContain(
+      'check name="Completed map for this workspace" status=fail detail="no completed map baseline — the graph may be partial. Run `ix map`."',
+    );
   });
 
   it("uses the active system scope for a co-ingested workspace", async () => {

--- a/ix-cli/src/cli/commands/doctor.ts
+++ b/ix-cli/src/cli/commands/doctor.ts
@@ -15,6 +15,7 @@ import {
   isNonStandardBackend,
 } from "../backend-status.js";
 import { backendCeiling, isNewer, readBackendHealth } from "./upgrade.js";
+import { detectStaleFiles } from "../stale.js";
 
 interface CheckResult {
   ok: boolean;
@@ -211,6 +212,26 @@ export function registerDoctorCommand(program: Command): void {
             // is read on the not-ok branch, so `ok: true` here would render as a
             // clean pass and say nothing.
             return { ok: false, warn: true, detail: "none registered yet — run `ix map`" };
+          },
+        },
+        {
+          name: "Completed map for this workspace",
+          run: async () => {
+            if (!matchedWorkspace) {
+              return { ok: false, warn: true, detail: "no local workspace to check" };
+            }
+            try {
+              const stale = detectStaleFiles(matchedWorkspace.root_path);
+              if (stale.mapCompleted) {
+                return { ok: true, detail: `recorded at revision ${stale.currentRev}` };
+              }
+              return {
+                ok: false,
+                detail: "no completed map baseline — the graph may be partial. Run `ix map`.",
+              };
+            } catch (e: any) {
+              return { ok: false, detail: e.message ?? "map completion check failed" };
+            }
           },
         },
         {

--- a/ix-cli/src/cli/commands/doctor.ts
+++ b/ix-cli/src/cli/commands/doctor.ts
@@ -6,7 +6,7 @@ import { findWorkspaceForCwd, getDefaultWorkspace, getEndpoint } from "../config
 import { resolveReadSystemId } from "../resolve.js";
 import { llmLine, printLlmLines } from "../llm.js";
 import { existsSync, readFileSync } from "node:fs";
-import { join as pathJoin, win32 as winPath } from "node:path";
+import { join as pathJoin, resolve as resolvePath, win32 as winPath } from "node:path";
 import { homedir } from "node:os";
 import {
   BACKEND_IMAGE,
@@ -15,7 +15,9 @@ import {
   isNonStandardBackend,
 } from "../backend-status.js";
 import { backendCeiling, isNewer, readBackendHealth } from "./upgrade.js";
-import { detectStaleFiles } from "../stale.js";
+import { loadIngestBaseline } from "../ingest-baseline.js";
+import { isCloudReady } from "../remote.js";
+import { hasCompletedMapBaseline } from "../stale.js";
 
 interface CheckResult {
   ok: boolean;
@@ -215,20 +217,43 @@ export function registerDoctorCommand(program: Command): void {
           },
         },
         {
+          // Ix#525: a partially committed graph still has nodes and edges, so
+          // every check below it passes and doctor calls a half-built graph
+          // healthy. The completion markers are the only thing that knows.
+          //
+          // Reads the two marker files rather than calling `detectStaleFiles`:
+          // that walks the workspace and stats every file to answer a question
+          // about *changed* files, and this check needs neither the walk nor
+          // the answer. On a large workspace it is the whole tree per `ix
+          // doctor`.
           name: "Completed map for this workspace",
           run: async () => {
             if (!matchedWorkspace) {
               return { ok: false, warn: true, detail: "no local workspace to check" };
             }
             try {
-              const stale = detectStaleFiles(matchedWorkspace.root_path);
-              if (stale.mapCompleted) {
-                return { ok: true, detail: `recorded at revision ${stale.currentRev}` };
+              // Resolve once: both marker files are keyed by the exact root
+              // string, and `hasCompletedMapBaseline` resolves internally.
+              const root = resolvePath(matchedWorkspace.root_path);
+              const source = loadIngestBaseline(root);
+              if (!source) {
+                // No local baseline means one of: never mapped, an initial map
+                // that committed patches but never finished, or a workspace fed
+                // by the cloud runner — which writes none by design. Only the
+                // last is healthy, and only a registered runner makes it
+                // possible, so that is the one case this warns instead of fails.
+                const cloud = await isCloudReady();
+                return cloud
+                  ? { ok: false, warn: true, detail: "no local baseline — expected for a cloud-ingested workspace" }
+                  : { ok: false, detail: "no completed map baseline — the graph may be partial. Run `ix map`." };
               }
-              return {
-                ok: false,
-                detail: "no completed map baseline — the graph may be partial. Run `ix map`.",
-              };
+              if (!hasCompletedMapBaseline(root)) {
+                return {
+                  ok: false,
+                  detail: `source graph at revision ${source.currentRev} has no completed architecture map — run \`ix map\``,
+                };
+              }
+              return { ok: true, detail: `recorded at revision ${source.currentRev}` };
             } catch (e: any) {
               return { ok: false, detail: e.message ?? "map completion check failed" };
             }


### PR DESCRIPTION
Fixes #525

## Summary
Make `ix doctor` include the active workspace's completed-map baseline in its health decision.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Add a `Completed map for this workspace` doctor check.
- Fail health when a registered workspace has no completed local baseline.
- Report the recorded revision when the baseline exists.
- Add regression coverage for a partial graph that still has nodes and edges.

## Validation
- `npm test` (1,416 passed, 3 skipped)
- `npm run typecheck`
- `npm run lint` (0 errors; 41 existing warnings)
- Ran doctor against a generic partial workspace. The result changed from `healthy: true` to `healthy: false` with the new failed check.

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
