### PR TITLE
fix: fail unresolved machine-readable commands

### DIFF
--- a/ix-cli/src/cli/__tests__/unresolved-machine-output.test.ts
+++ b/ix-cli/src/cli/__tests__/unresolved-machine-output.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Command } from "commander";
+
+vi.mock("../../client/api.js", () => ({
+  IxClient: class {
+    async workspaceSystem() { return { systemId: null }; }
+    async search() { return []; }
+  },
+}));
+
+type Register = (program: Command) => void;
+
+async function run(register: Register, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  const program = new Command();
+  program.name("ix").exitOverride();
+  register(program);
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const log = vi.spyOn(console, "log").mockImplementation((...parts) => stdout.push(parts.join(" ")));
+  const error = vi.spyOn(console, "error").mockImplementation((...parts) => stderr.push(parts.join(" ")));
+  try {
+    await program.parseAsync(args, { from: "user" });
+  } finally {
+    log.mockRestore();
+    error.mockRestore();
+  }
+  return { stdout: stdout.join("\n"), stderr: stderr.join("\n") };
+}
+
+describe("unresolved targets in machine formats", () => {
+  let savedExitCode: number | string | undefined;
+
+  beforeEach(() => {
+    savedExitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = savedExitCode;
+  });
+
+  it.each([
+    ["context", async () => (await import("../commands/context.js")).registerContextCommand],
+    ["explain", async () => (await import("../commands/explain.js")).registerExplainCommand],
+    ["read", async () => (await import("../commands/read.js")).registerReadCommand],
+  ] as const)("returns JSON and a non-zero status from ix %s", async (command, loadRegister) => {
+    const result = await run(await loadRegister(), [command, "DefinitelyMissing", "--format", "json"]);
+
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(result.stdout)).toEqual({
+      error: "unresolved_target",
+      message: 'No entity found matching "DefinitelyMissing".',
+    });
+  });
+});

--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -22,7 +22,7 @@ import { llmLine, printLlmLines } from "../llm.js";
 import { parseBudgetOption, parsePickOption, parseRevisionOption } from "../options.js";
 import { resolveFileOrEntity } from "../resolve.js";
 import { createStaleProbe, hasCompletedMapBaseline } from "../stale.js";
-import { renderNote, renderSection, renderWarning, renderWarningErr, reportFailure } from "../ui.js";
+import { renderNote, renderSection, renderWarning, renderWarningErr, reportFailure, reportUnresolvedTarget } from "../ui.js";
 
 /** The four `--max-*` knobs that bound a bundle. */
 interface BudgetSnapshot {
@@ -307,7 +307,10 @@ export function registerContextCommand(program: Command): void {
         path: opts.path,
         pick: opts.pick,
       });
-      if (!resolved) return;
+      if (!resolved) {
+        reportUnresolvedTarget(target, opts.format);
+        return;
+      }
 
       const budgets = clampBudgets(opts);
       const asOfRev = opts.asOfRev;

--- a/ix-cli/src/cli/commands/explain.ts
+++ b/ix-cli/src/cli/commands/explain.ts
@@ -11,7 +11,7 @@ import { renderExplanation } from "../explain/render.js";
 import { renderExplainLlm, renderExplainRawLlm } from "../explain/llm.js";
 import { printLlmLines } from "../llm.js";
 import { parsePickOption } from "../options.js";
-import { renderSection, renderWarning, renderNote } from "../ui.js";
+import { renderSection, renderWarning, renderNote, reportUnresolvedTarget } from "../ui.js";
 
 export function registerExplainCommand(program: Command): void {
   program
@@ -27,7 +27,10 @@ export function registerExplainCommand(program: Command): void {
       const client = new IxClient(getEndpoint());
       const resolveOpts = { kind: opts.kind, path: opts.path, pick: opts.pick };
       const target = await resolveFileOrEntity(client, symbol, resolveOpts);
-      if (!target) return;
+      if (!target) {
+        reportUnresolvedTarget(symbol, opts.format);
+        return;
+      }
 
       if (opts.raw) {
         await rawExplain(client, target, opts.format);

--- a/ix-cli/src/cli/commands/read.ts
+++ b/ix-cli/src/cli/commands/read.ts
@@ -10,6 +10,7 @@ import { isFileStale } from "../stale.js";
 import { relativePath } from "../format.js";
 import { llmLine, printLlmLines } from "../llm.js";
 import { parsePickOption } from "../options.js";
+import { reportUnresolvedTarget } from "../ui.js";
 
 export interface ReadResult {
   targetType: "file" | "file-range" | "filename-match" | "symbol";
@@ -323,7 +324,7 @@ Examples:
         return;
       }
 
-      stderr(`Could not resolve "${target}" as a file or symbol.`);
+      reportUnresolvedTarget(target, opts.format);
     });
 }
 

--- a/ix-cli/src/cli/ui.ts
+++ b/ix-cli/src/cli/ui.ts
@@ -131,3 +131,14 @@ export function reportFailure(code: string, message: string, format?: string): v
   else console.error(chalk.red("Error:"), message);
   process.exitCode = 1;
 }
+
+/** Report a resolver miss without corrupting machine-readable stdout. */
+export function reportUnresolvedTarget(target: string, format?: string): void {
+  const message = `No entity found matching "${target}".`;
+  if (format === "json") {
+    console.log(JSON.stringify({ error: "unresolved_target", message }, null, 2));
+  } else if (format === "llm") {
+    console.log(llmError("unresolved_target", message));
+  }
+  process.exitCode = 1;
+}


### PR DESCRIPTION
Fixes #526

## Summary
Return a structured machine-readable failure when `context`, `explain`, or `read` cannot resolve the requested target.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Add a shared unresolved-target reporter for JSON and LLM formats.
- Emit a JSON error object from the three affected commands.
- Set the process status to 1 instead of returning a false success.
- Add command-level regression tests for all three commands.

## Validation
- `npm test` (1,418 passed, 3 skipped)
- `npm run typecheck`
- `npm run lint` (0 errors; 41 existing warnings)
- Re-ran all three generic missing-target commands. Each emitted valid JSON and exited 1.

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
