### PR TITLE
fix: surface cross-workspace stitch failures

### DIFF
--- a/ix-cli/src/cli/__tests__/ingest-commit-outcome.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-commit-outcome.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { describeCommitOutcome, describeStitchFailure, ingestCompletedCleanly } from "../commands/ingest.js";
+import { describeCommitOutcome, describeStitchFailure, ingestCompletedCleanly, isStitchUnsupported } from "../commands/ingest.js";
 
 describe("describeCommitOutcome", () => {
   it("says nothing when every patch committed", () => {
@@ -112,7 +112,27 @@ describe("describeStitchFailure", () => {
     const message = describeStitchFailure(new Error("504: <html>\nlarge proxy response"));
 
     expect(message).toContain("Cross-workspace stitch failed");
+    expect(message).toContain("HTTP 504");
     expect(message).toContain("cross-repository relationships may be incomplete");
     expect(message).not.toContain("large proxy response");
+  });
+
+  it("does not read a three-digit run elsewhere in the message as a status", () => {
+    expect(describeStitchFailure(new Error("connect ECONNREFUSED 127.0.0.1:8090")))
+      .toContain("backend request failed");
+  });
+});
+
+describe("isStitchUnsupported", () => {
+  it.each([404, 501])("treats %d as a backend that does not implement stitch", (status) => {
+    expect(isStitchUnsupported(new Error(`${status}: Not Found`))).toBe(true);
+  });
+
+  it.each([500, 502, 504])("treats %d as a real failure worth surfacing", (status) => {
+    expect(isStitchUnsupported(new Error(`${status}: upstream timeout`))).toBe(false);
+  });
+
+  it("treats a transport error with no status as a real failure", () => {
+    expect(isStitchUnsupported(new Error("connect ECONNREFUSED 127.0.0.1:8090"))).toBe(false);
   });
 });

--- a/ix-cli/src/cli/__tests__/ingest-commit-outcome.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-commit-outcome.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { describeCommitOutcome, ingestCompletedCleanly } from "../commands/ingest.js";
+import { describeCommitOutcome, describeStitchFailure, ingestCompletedCleanly } from "../commands/ingest.js";
 
 describe("describeCommitOutcome", () => {
   it("says nothing when every patch committed", () => {
@@ -104,5 +104,15 @@ describe("ingestCompletedCleanly", () => {
 
   it("is true only when neither happened", () => {
     expect(ingestCompletedCleanly(0, 0)).toBe(true);
+  });
+});
+
+describe("describeStitchFailure", () => {
+  it("reports incomplete cross-repository relationships without dumping an HTML response", () => {
+    const message = describeStitchFailure(new Error("504: <html>\nlarge proxy response"));
+
+    expect(message).toContain("Cross-workspace stitch failed");
+    expect(message).toContain("cross-repository relationships may be incomplete");
+    expect(message).not.toContain("large proxy response");
   });
 });

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -796,9 +796,37 @@ export interface IngestFilesSummary {
   stitchErrors: number;
 }
 
+/**
+ * The HTTP status `IxClient` put at the front of its `${status}: ${body}`
+ * error, when there is one. Anchored, so a three-digit run anywhere else in the
+ * message — a port, a byte count, a timestamp — cannot be read as a status.
+ */
+function stitchFailureStatus(error: unknown): number | null {
+  const match = /^(?:Error:\s*)?(\d{3}):/.exec(String(error));
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * A backend that does not implement `/v1/stitch` is not a failed stitch.
+ *
+ * The stitch call has always been best-effort precisely so an older backend
+ * keeps working, and it is issued on every full local map. Reporting 404/501
+ * as a degraded graph would make `ix map` warn and exit 1 on every run against
+ * such a backend, for a step it was never going to perform.
+ */
+export function isStitchUnsupported(error: unknown): boolean {
+  const status = stitchFailureStatus(error);
+  return status === 404 || status === 501;
+}
+
+/**
+ * Ix#528: describe the failure without echoing the response body. The observed
+ * case is a proxy 504 whose body is a full HTML error page, and pasting that
+ * into a map summary buries the one line that matters.
+ */
 export function describeStitchFailure(error: unknown): string {
-  const status = String(error).match(/(?:^Error:\s*)?(\d{3}):/);
-  const detail = status ? `HTTP ${status[1]}` : "backend request failed";
+  const status = stitchFailureStatus(error);
+  const detail = status === null ? "backend request failed" : `HTTP ${status}`;
   return `Warning: Cross-workspace stitch failed (${detail}). Source patches were committed, but cross-repository relationships may be incomplete.`;
 }
 
@@ -2131,8 +2159,12 @@ export async function ingestFiles(
           clearStitchScopeCache(workspaceId);
         }
       } catch (err) {
-        stitchErrors++;
-        stitchError = err;
+        // Unsupported is not failed: an older backend answers 404 here, and
+        // that is the case this call has always been allowed to shrug off.
+        if (!isStitchUnsupported(err)) {
+          stitchErrors++;
+          stitchError = err;
+        }
         if (debug) process.stderr.write(`  [stitch skipped] ${err}\n`);
       }
     }

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -793,6 +793,13 @@ export interface IngestFilesSummary {
   patchesApplied: number;
   parseErrors: number;
   commitErrors: number;
+  stitchErrors: number;
+}
+
+export function describeStitchFailure(error: unknown): string {
+  const status = String(error).match(/(?:^Error:\s*)?(\d{3}):/);
+  const detail = status ? `HTTP ${status[1]}` : "backend request failed";
+  return `Warning: Cross-workspace stitch failed (${detail}). Source patches were committed, but cross-repository relationships may be incomplete.`;
 }
 
 /**
@@ -1175,6 +1182,8 @@ export async function ingestFiles(
   let filesSkipped = 0;
   let parseErrors = 0;
   let commitErrors = 0;
+  let stitchErrors = 0;
+  let stitchError: unknown;
   let tooLarge = 0;
   let minifiedLikely = 0;
   let outsideRoot = 0;
@@ -2122,6 +2131,8 @@ export async function ingestFiles(
           clearStitchScopeCache(workspaceId);
         }
       } catch (err) {
+        stitchErrors++;
+        stitchError = err;
         if (debug) process.stderr.write(`  [stitch skipped] ${err}\n`);
       }
     }
@@ -2170,7 +2181,12 @@ export async function ingestFiles(
     patchesApplied,
     parseErrors,
     commitErrors,
+    stitchErrors,
   };
+  if (stitchErrors > 0) {
+    process.stderr.write(`  ${describeStitchFailure(stitchError)}\n`);
+    process.exitCode = 1;
+  }
   if (commitReport.kind === "warn") {
     process.stderr.write(`  ${commitReport.message}\n`);
     // Non-zero even though we do not throw. A partial failure still means the
@@ -2197,6 +2213,7 @@ export async function ingestFiles(
       latestRev,
       skipReasons: { unchanged: filesSkipped, emptyFile: 0, parseError: parseErrors, tooLarge, minifiedLikely, outsideRoot },
       commitErrors,
+      stitchErrors,
       elapsedSeconds: parseFloat(elapsed),
       timings: {
         ...timings,


### PR DESCRIPTION
Fixes #528

## Summary
Surface cross-workspace stitch failures even when ingest output is suppressed by normal or silent map mode.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Track stitch failures separately from source parse and commit failures.
- Print a bounded warning that distinguishes committed source patches from incomplete cross-repository relationships.
- Exit non-zero so machine callers can detect the degraded graph.
- Include `stitchErrors` in JSON ingest output and add regression coverage for bounded error rendering.

## Validation
- `npm test` (1,416 passed, 3 skipped)
- `npm run typecheck`
- `npm run lint` (0 errors; 41 existing warnings)
- Routed a generic map through a proxy that returns HTTP 504 only from `/v1/stitch`. The command printed the bounded warning and exited 1.

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
