### PR TITLE
fix: record map completion for a workspace with no regions to build

### DIFF
--- a/ix-cli/src/cli/__tests__/map-baseline.test.ts
+++ b/ix-cli/src/cli/__tests__/map-baseline.test.ts
@@ -56,6 +56,41 @@ describe("architecture map baseline", () => {
     expect(hasCompletedMapBaseline(root)).toBe(true);
   });
 
+  it("records a one-file workspace that has no regions to build", () => {
+    // The E2E fixture: one Python file, mapped as `1 files · 0s/0ss/0m
+    // regions`. There is no hierarchy to build over a single file and no
+    // later run will produce one, so refusing to record completion here
+    // leaves `ix doctor` unhealthy for ever, telling the user to run the
+    // command that just ran. `describeRegionlessCompletedMap` is what
+    // rejects a regionless map over real source; it needs two discovered
+    // files, which this workspace does not have.
+    const root = path.join(home, "one-file");
+    const filePath = path.join(root, "billing.py");
+    fs.mkdirSync(root, { recursive: true });
+    fs.writeFileSync(filePath, "class Billing:\n    pass\n");
+    persistIngestBaselineIfClean(
+      root,
+      new Map([[filePath, fs.statSync(filePath).mtimeMs]]),
+      1,
+      0,
+      0,
+    );
+
+    expect(
+      persistCompletedMapBaseline(
+        {
+          file_count: 1,
+          region_count: 0,
+          regions: [],
+          outcome: "full_local_completed",
+        },
+        root,
+      ),
+    ).toBe(true);
+
+    expect(hasCompletedMapBaseline(root)).toBe(true);
+  });
+
   it.each(["local_map_too_large", "local_map_not_recommended"])(
     "does not record the guardrail outcome %s",
     (outcome) => {

--- a/ix-cli/src/cli/commands/map.ts
+++ b/ix-cli/src/cli/commands/map.ts
@@ -218,13 +218,26 @@ export function invalidateBaselineForIncompleteCompletedMap(
   return message;
 }
 
-/** Persist hierarchy completion only when a non-empty map was actually produced. */
+/**
+ * Persist hierarchy completion only when a non-empty map was actually produced.
+ *
+ * "Non-empty" is the whole result, deliberately not the region count alone. A
+ * single-file workspace maps `1 files · 0s/0ss/0m regions` and that is
+ * finished, not partial — there is no hierarchy to build over one file, and no
+ * later `ix map` will produce one. Refusing to record it leaves `ix status`
+ * reading map_complete=false and `ix doctor` unhealthy for ever, with the
+ * suggested fix being the command that just ran.
+ *
+ * The regionless-with-real-source case is already rejected upstream by
+ * `describeRegionlessCompletedMap`, which returns before this is reached, and
+ * which knows the discovered-file count this function does not.
+ */
 export function persistCompletedMapBaseline(
   result: Pick<MapResult, "file_count" | "region_count" | "regions" | "outcome">,
   projectRoot: string,
 ): boolean {
   if (result.outcome && !COMPLETED_MAP_OUTCOMES.has(result.outcome)) return false;
-  if (result.region_count === 0 && result.regions.length === 0) return false;
+  if (result.file_count === 0 && result.region_count === 0 && result.regions.length === 0) return false;
   const sourceBaseline = loadIngestBaseline(projectRoot);
   if (!sourceBaseline) return false;
   return saveMapBaseline(projectRoot, sourceBaseline.currentRev);


### PR DESCRIPTION
Follow-up to #530, found by #531's E2E.

## Summary

A single-file workspace maps as `1 files · 0s/0ss/0m regions`. That is a finished map, not a partial one — there is no hierarchy to build over one file, and no later `ix map` will produce one.

#530 tightened `persistCompletedMapBaseline` to refuse any result with no regions, which sweeps that case in. The workspace then records a source baseline and no map marker, so `ix status` reads `map_complete=false` and, once #531 lands, `ix doctor` reports it unhealthy permanently — with the suggested fix being the command that just ran.

The repository's own E2E fixture (`ix-cli/test/fixtures/sample_project`) is one Python file, which is how this surfaced:

```
map: 1 files · 0s/0ss/0m regions · 95ms
...
{
  "name": "Completed map for this workspace",
  "ok": false,
  "detail": "source graph at revision 1 has no completed architecture map — run `ix map`"
}
doctor not healthy
```

## Changes

- Restore the condition to refusing a *wholly* empty result (`file_count === 0 && region_count === 0 && regions.length === 0`).
- Document why it must not be tightened to the region count alone.
- Regression test pinning the one-file shape.

The tightening was aimed at a regionless map over real source, but `describeRegionlessCompletedMap` already rejects that and returns before `persistCompletedMapBaseline` is reached — and it knows the discovered-file count, which is the thing that tells the two cases apart and which this function does not have.

## Type
- [x] Bug fix

## Validation
- `npm test`, `npm run typecheck`, `npm run lint` (0 errors, 41 existing warnings)
- The blocked E2E in #531 is the acceptance test.

## Checklist
- [x] Tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format
