### PR TITLE
fix: do not fail every existing workspace on upgrade to the map marker

### DIFF
--- a/ix-cli/src/cli/__tests__/map-baseline.test.ts
+++ b/ix-cli/src/cli/__tests__/map-baseline.test.ts
@@ -5,7 +5,8 @@ import * as path from "node:path";
 
 import { persistIngestBaselineIfClean } from "../commands/ingest.js";
 import { persistCompletedMapBaseline } from "../commands/map.js";
-import { loadMapBaseline } from "../map-baseline.js";
+import { loadMapBaseline, saveMapBaseline } from "../map-baseline.js";
+import { ingestMtimeCachePath } from "../config.js";
 import { hasCompletedMapBaseline } from "../stale.js";
 
 let home: string;
@@ -119,4 +120,62 @@ describe("architecture map baseline", () => {
       expect(loadMapBaseline(root)).toBeNull();
     },
   );
+});
+
+/**
+ * Every workspace that existed before the marker did has a clean ingest
+ * baseline and no marker, and the CLI that wrote it reported that state as
+ * map-complete. Reversing the answer on upgrade would fail `ix doctor` on all
+ * of them at once, so a baseline with no `tracksMapBaseline` is grandfathered
+ * until the next ingest rewrites it.
+ */
+describe("upgrade from a baseline written before the map marker", () => {
+  function writeLegacyBaseline(root: string, filePath: string, currentRev: number): void {
+    fs.mkdirSync(root, { recursive: true });
+    fs.writeFileSync(filePath, "export const value = 1;\n");
+    fs.mkdirSync(path.dirname(ingestMtimeCachePath(root)), { recursive: true });
+    // The exact shape 0.10.4 wrote: no `tracksMapBaseline`.
+    fs.writeFileSync(ingestMtimeCachePath(root), JSON.stringify({
+      root,
+      files: { [filePath]: fs.statSync(filePath).mtimeMs },
+      deletedFiles: {},
+      currentRev,
+      lastIngestAt: "2026-01-01T00:00:00.000Z",
+    }));
+  }
+
+  it("reports an existing workspace as mapped rather than failing it on upgrade", () => {
+    const root = path.join(home, "legacy");
+    writeLegacyBaseline(root, path.join(root, "index.ts"), 7);
+
+    expect(loadMapBaseline(root)).toBeNull();
+    expect(hasCompletedMapBaseline(root)).toBe(true);
+  });
+
+  it("stops grandfathering once an ingest rewrites the baseline", () => {
+    const root = path.join(home, "upgraded");
+    const filePath = path.join(root, "index.ts");
+    writeLegacyBaseline(root, filePath, 7);
+    expect(hasCompletedMapBaseline(root)).toBe(true);
+
+    // A 0.10.5 ingest — the map that follows it is the one that must record
+    // completion, and until it does the workspace is honestly incomplete.
+    persistIngestBaselineIfClean(
+      root,
+      new Map([[filePath, fs.statSync(filePath).mtimeMs]]),
+      8,
+      0,
+      0,
+    );
+
+    expect(hasCompletedMapBaseline(root)).toBe(false);
+  });
+
+  it("does not grandfather past a marker that is behind the source revision", () => {
+    const root = path.join(home, "stale-marker");
+    writeLegacyBaseline(root, path.join(root, "index.ts"), 9);
+    saveMapBaseline(root, 4);
+
+    expect(hasCompletedMapBaseline(root)).toBe(false);
+  });
 });

--- a/ix-cli/src/cli/__tests__/stale-workspace.test.ts
+++ b/ix-cli/src/cli/__tests__/stale-workspace.test.ts
@@ -298,6 +298,7 @@ describe("workspace-scoped staleness", () => {
       deletedFiles,
       currentRev: 15,
       lastIngestAt: completedAt.toISOString(),
+      tracksMapBaseline: true,
     });
   });
 

--- a/ix-cli/src/cli/ingest-baseline.ts
+++ b/ix-cli/src/cli/ingest-baseline.ts
@@ -8,6 +8,7 @@ interface SerializedIngestBaseline {
   deletedFiles?: Record<string, string[]>;
   currentRev?: number;
   lastIngestAt?: string;
+  tracksMapBaseline?: boolean;
 }
 
 export interface IngestBaseline {
@@ -15,6 +16,18 @@ export interface IngestBaseline {
   deletedFiles: Map<string, string[]>;
   currentRev: number;
   lastIngestAt: string;
+  /**
+   * Whether this baseline was written by a CLI that also maintains the
+   * architecture-map marker.
+   *
+   * Absent on every baseline written before that marker existed, which is what
+   * makes it usable as an upgrade signal: such a workspace has a clean source
+   * ingest and no marker, and the CLI that produced it *reported that state as
+   * map-complete*. Treating it as incomplete on the first run after an upgrade
+   * would fail `ix doctor` on every existing workspace at once, for a claim
+   * nothing has actually re-evaluated. See `hasCompletedMapFor`.
+   */
+  tracksMapBaseline: boolean;
 }
 
 /**
@@ -55,7 +68,13 @@ export function loadIngestBaseline(projectRoot: string): IngestBaseline | null {
       : fs.statSync(cachePath).mtime.toISOString();
     const currentRev = isRev(data.currentRev) ? data.currentRev : 0;
 
-    return { files, deletedFiles, currentRev, lastIngestAt };
+    return {
+      files,
+      deletedFiles,
+      currentRev,
+      lastIngestAt,
+      tracksMapBaseline: data.tracksMapBaseline === true,
+    };
   } catch {
     return null;
   }
@@ -85,6 +104,10 @@ export function saveIngestBaseline(
       deletedFiles: Object.fromEntries(deletedFiles),
       currentRev: rev,
       lastIngestAt: now.toISOString(),
+      // Written unconditionally from here on, so its absence dates a baseline
+      // to before the map marker existed. The first ingest after an upgrade
+      // sets it, which is what ends the grandfathering for this workspace.
+      tracksMapBaseline: true,
     };
     fs.mkdirSync(path.dirname(ingestMtimeCachePath(projectRoot)), { recursive: true });
     fs.writeFileSync(ingestMtimeCachePath(projectRoot), JSON.stringify(data));

--- a/ix-cli/src/cli/map-baseline.ts
+++ b/ix-cli/src/cli/map-baseline.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { mapBaselinePath } from "./config.js";
-import { isRev } from "./ingest-baseline.js";
+import { isRev, type IngestBaseline } from "./ingest-baseline.js";
 
 interface SerializedMapBaseline {
   root: string;
@@ -43,4 +43,26 @@ export function saveMapBaseline(projectRoot: string, sourceRev: number): boolean
 
 export function hasCurrentMapBaseline(projectRoot: string, sourceRev: number): boolean {
   return loadMapBaseline(projectRoot)?.sourceRev === sourceRev;
+}
+
+/**
+ * Whether `baseline`'s source revision has a completed architecture map.
+ *
+ * A baseline written before the marker existed carries no `tracksMapBaseline`,
+ * and for those the answer is yes without a marker to show for it. That is not
+ * a guess: the CLI that wrote the baseline answered this question with "does an
+ * ingest baseline exist", and answered it *yes*. Reversing that on upgrade
+ * would turn `ix doctor` red on every existing workspace simultaneously, for a
+ * hierarchy nobody has re-examined — and the remedy on offer, `ix map`, is what
+ * they already ran.
+ *
+ * It expires on its own. The next ingest rewrites the baseline with the flag
+ * set, from which point only a real marker answers yes, so a workspace whose
+ * map genuinely never completed is caught the first time it is re-mapped. A
+ * baseline written by this version is never grandfathered, so the state #525
+ * is about — a fresh workspace whose patches half-committed — is unaffected.
+ */
+export function hasCompletedMapFor(projectRoot: string, baseline: IngestBaseline): boolean {
+  if (hasCurrentMapBaseline(projectRoot, baseline.currentRev)) return true;
+  return !baseline.tracksMapBaseline && loadMapBaseline(projectRoot) === null;
 }

--- a/ix-cli/src/cli/stale.ts
+++ b/ix-cli/src/cli/stale.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { resolveWorkspaceRoot } from "./config.js";
 import { loadIngestBaseline } from "./ingest-baseline.js";
-import { hasCurrentMapBaseline } from "./map-baseline.js";
+import { hasCompletedMapFor } from "./map-baseline.js";
 import { SUPPORTED_EXTENSIONS } from "./supported-extensions.js";
 
 export interface StaleInfo {
@@ -132,7 +132,7 @@ export function detectStaleFiles(
 
   return {
     graphCompleted: true,
-    mapCompleted: hasCurrentMapBaseline(workspaceRoot, baseline.currentRev),
+    mapCompleted: hasCompletedMapFor(workspaceRoot, baseline),
     lastIngestAt: baseline.lastIngestAt,
     currentRev: baseline.currentRev,
     staleFiles: changedFiles.length,
@@ -152,7 +152,7 @@ export function hasCompletedMapBaseline(root?: string): boolean {
   try {
     const workspaceRoot = path.resolve(root ?? resolveWorkspaceRoot());
     const baseline = loadIngestBaseline(workspaceRoot);
-    return baseline !== null && hasCurrentMapBaseline(workspaceRoot, baseline.currentRev);
+    return baseline !== null && hasCompletedMapFor(workspaceRoot, baseline);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

#535 tied map completion to a marker file that no earlier release wrote. So on upgrade, the first `ix status` reports `map_complete=false` for **every workspace that already existed**, and #531's doctor check reports each one unhealthy. Nothing about those workspaces changed — only the question did — and the remedy on offer, `ix map`, is the command they already ran.

The CLI that wrote those baselines answered this question with "does an ingest baseline exist", and answered it **yes**. A baseline carrying no `tracksMapBaseline` is therefore grandfathered: it predates the marker, so its own recorded answer stands until something re-evaluates it. This cannot be more wrong than what already shipped.

## Why this needs no migration step and cannot get stuck

`saveIngestBaseline` now writes `tracksMapBaseline: true` unconditionally, so the next ingest — the one whose map is about to record a real marker — ends the grandfathering for that workspace. From then on only a marker answers yes. There is no migration to run, nothing to clean up later, and no way for a workspace to stay grandfathered while still being used.

## What it must not swallow (both tested)

- **A baseline written by this version with no marker stays incomplete**, so the state #525 is about — a fresh workspace whose patches half-committed — is unaffected.
- **A marker that exists but is behind the source revision is not grandfathered either**, legacy baseline or not. A stale hierarchy is a different claim from an unexamined one.

## Validation

`npm test` (1447 passed, 2 skipped), `npm run typecheck`, `npm run lint` (0 errors; 41 existing warnings).

Verified against backend 1.0.28 by mapping a workspace normally and then rewinding it to the exact shape 0.10.4 left behind — marker deleted, flag stripped from the baseline:

```
# upgraded CLI, 0.10.4-shaped workspace
status ... graph_complete=true map_complete=true
doctor healthy=true
check name="Completed map for this workspace" status=ok detail="recorded at revision 2470"

# after an ingest sets the flag, with the marker then removed
status ... graph_complete=true map_complete=false
doctor healthy=false
check name="Completed map for this workspace" status=fail
  detail="source graph at revision 2470 has no completed architecture map — run `ix map`"
```

## Type
- [x] Bug fix
- [x] Test

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format
