### PR TITLE
chore(release): 0.10.5

### DIFF
--- a/ix-cli/package-lock.json
+++ b/ix-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ix/cli",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ix/cli",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
         "chalk": "^6.0.0",

--- a/ix-cli/package.json
+++ b/ix-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ix/cli",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "type": "module",
   "description": "Ix Memory — Persistent Memory for LLM Systems",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump only — `ix-cli/package.json` + `ix-cli/package-lock.json`, 3 lines.

Opening this rather than tagging straight off `main` so the **release.yml packaging dry-run** runs the real per-platform build matrix before the tag, not during it.

## What ships in 0.10.5

Nine merged PRs, closing six issues.

**Map completion is no longer conflated with source ingest** (#535, closes #534). A failed hierarchy build used to delete the clean source-ingest baseline with it, forcing a full reparse on every retry — about 198s down to about 1s on a ~7,400-file workspace. `ix status` now reports `graph_complete` and `map_complete` independently.

**A completed map with no regions is rejected** (#530, closes #524). A mixed-language repo could record a hierarchy covering nothing as complete, while `ix locate` reported `hasMapData: false` for the one class it counted. Detection is the absent region set, not a coverage ratio — see the PR for why a ratio over `filesDiscovered` rejects healthy maps.

**`ix doctor` checks map completion** (#531, closes #525). A partially committed graph still has nodes and edges, so every other check passed it. Reads the two marker files rather than walking the workspace; warns instead of failing when a cloud runner explains a missing local baseline.

**Generated dependency lockfiles are skipped** (#529, closes #523). A 646 KB `package-lock.json` is under the 1 MB source limit but expands into a patch a proxy rejects with HTTP 413. Covers npm, pnpm and NuGet lockfiles.

**Machine-readable commands fail properly on a missing target** (#532, closes #526). `ix context`, `explain` and `read` emitted nothing and exited 0; they now emit a JSON/llm error record and exit 1.

**Cross-workspace stitch failures are surfaced** (#533, closes #528), while a backend that has no `/v1/stitch` is still skipped silently rather than failing every map.

**Follow-ups:** #536 (a one-file workspace can record map completion — it has no regions to build), #537 (existing workspaces are not failed on upgrade to the new marker), #538 (one `unresolved_target` slug across every command; `docs/llm-format.md` documents the new `status` booleans).

## Upgrade impact

None expected. #537 grandfathers every workspace whose ingest baseline predates the map marker, so the first `ix status`/`ix doctor` after upgrading reads the same as before and the grandfathering expires at the next ingest. Verified against backend 1.0.28 by rewinding a mapped workspace to the exact 0.10.4 on-disk shape.

No backend version floor — every change is CLI-side and degrades cleanly against older backends.

## Validation

`npm test` (1447 passed, 2 skipped), `npm run typecheck`, `npm run build`, `npm run lint` (0 errors; 41 existing warnings) on the merge result.

## Type
- [x] CI

## Release checklist
- [x] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag v0.10.5 && git push origin v0.10.5`)
- [x] No backend changes — `ix-memory` release not required
- [x] `docker-compose.standalone.yml` unchanged
