### PR TITLE
fix(text): enforce workspace-relative search paths

### DIFF
--- a/ix-cli/src/cli/__tests__/text-workspace-boundary.test.ts
+++ b/ix-cli/src/cli/__tests__/text-workspace-boundary.test.ts
@@ -3,7 +3,7 @@ import { Command } from "commander";
 import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { registerTextCommand } from "../commands/text.js";
+import { registerTextCommand, resolveTextSearchPath } from "../commands/text.js";
 
 describe("text workspace boundary", () => {
   let fixture: string;
@@ -44,13 +44,8 @@ describe("text workspace boundary", () => {
     await program.parseAsync(["node", "ix", ...args]);
   }
 
-  it("resolves --path relative to --root instead of the process cwd", async () => {
-    await run(["text", "boundaryNeedle", "--root", workspace, "--path", "src", "--format", "json"]);
-
-    const result = JSON.parse(logs.join("\n"));
-    expect(result).toHaveLength(1);
-    expect(result[0].path).toBe("src/inside.ts");
-    expect(process.exitCode).toBeUndefined();
+  it("resolves --path relative to --root instead of the process cwd", () => {
+    expect(resolveTextSearchPath(workspace, "src")).toBe(join(workspace, "src"));
   });
 
   it("rejects an absolute search path outside the explicit workspace", async () => {

--- a/ix-cli/src/cli/__tests__/text-workspace-boundary.test.ts
+++ b/ix-cli/src/cli/__tests__/text-workspace-boundary.test.ts
@@ -12,6 +12,7 @@ describe("text workspace boundary", () => {
   let originalCwd: string;
   let originalExitCode: number | string | undefined;
   let logs: string[];
+  let runRipgrep: ReturnType<typeof vi.fn<(args: string[]) => Promise<{ stdout: string }>>>;
 
   beforeEach(() => {
     fixture = mkdtempSync(join(tmpdir(), "ix-text-boundary-"));
@@ -29,6 +30,16 @@ describe("text workspace boundary", () => {
     vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
       logs.push(args.join(" "));
     });
+    runRipgrep = vi.fn(async () => ({
+      stdout: JSON.stringify({
+        type: "match",
+        data: {
+          path: { text: join(workspace, "src", "inside.ts") },
+          line_number: 1,
+          lines: { text: "export const boundaryNeedle = true;\n" },
+        },
+      }),
+    }));
   });
 
   afterEach(() => {
@@ -40,12 +51,18 @@ describe("text workspace boundary", () => {
 
   async function run(args: string[]): Promise<void> {
     const program = new Command();
-    registerTextCommand(program);
+    registerTextCommand(program, runRipgrep);
     await program.parseAsync(["node", "ix", ...args]);
   }
 
-  it("resolves --path relative to --root instead of the process cwd", () => {
+  it("resolves --path relative to --root instead of the process cwd", async () => {
     expect(resolveTextSearchPath(workspace, "src")).toBe(join(workspace, "src"));
+
+    await run(["text", "boundaryNeedle", "--root", workspace, "--path", "src", "--format", "json"]);
+
+    expect(runRipgrep).toHaveBeenCalledWith(expect.arrayContaining(["boundaryNeedle", join(workspace, "src")]));
+    expect(JSON.parse(logs.join("\n"))).toMatchObject([{ path: "src/inside.ts" }]);
+    expect(process.exitCode).toBeUndefined();
   });
 
   it("rejects an absolute search path outside the explicit workspace", async () => {

--- a/ix-cli/src/cli/__tests__/text-workspace-boundary.test.ts
+++ b/ix-cli/src/cli/__tests__/text-workspace-boundary.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Command } from "commander";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerTextCommand } from "../commands/text.js";
+
+describe("text workspace boundary", () => {
+  let fixture: string;
+  let workspace: string;
+  let outside: string;
+  let originalCwd: string;
+  let originalExitCode: number | string | undefined;
+  let logs: string[];
+
+  beforeEach(() => {
+    fixture = mkdtempSync(join(tmpdir(), "ix-text-boundary-"));
+    workspace = join(fixture, "workspace");
+    outside = join(fixture, "outside");
+    mkdirSync(join(workspace, "src"), { recursive: true });
+    mkdirSync(outside, { recursive: true });
+    writeFileSync(join(workspace, "src", "inside.ts"), "export const boundaryNeedle = true;\n");
+    writeFileSync(join(outside, "outside.ts"), "export const boundaryNeedle = false;\n");
+    originalCwd = process.cwd();
+    originalExitCode = process.exitCode;
+    process.chdir(outside);
+    process.exitCode = undefined;
+    logs = [];
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.join(" "));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.chdir(originalCwd);
+    process.exitCode = originalExitCode;
+    rmSync(fixture, { recursive: true, force: true });
+  });
+
+  async function run(args: string[]): Promise<void> {
+    const program = new Command();
+    registerTextCommand(program);
+    await program.parseAsync(["node", "ix", ...args]);
+  }
+
+  it("resolves --path relative to --root instead of the process cwd", async () => {
+    await run(["text", "boundaryNeedle", "--root", workspace, "--path", "src", "--format", "json"]);
+
+    const result = JSON.parse(logs.join("\n"));
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe("src/inside.ts");
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("rejects an absolute search path outside the explicit workspace", async () => {
+    await run(["text", "boundaryNeedle", "--root", workspace, "--path", outside, "--format", "json"]);
+
+    expect(JSON.parse(logs.join("\n"))).toMatchObject({ error: "path_outside_workspace" });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it.skipIf(process.platform === "win32")("rejects a symlink that leaves the workspace", async () => {
+    symlinkSync(outside, join(workspace, "linked"), "dir");
+
+    await run(["text", "boundaryNeedle", "--root", workspace, "--path", "linked", "--format", "json"]);
+
+    expect(JSON.parse(logs.join("\n"))).toMatchObject({ error: "path_outside_workspace" });
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/ix-cli/src/cli/commands/text.ts
+++ b/ix-cli/src/cli/commands/text.ts
@@ -74,7 +74,7 @@ export function registerTextCommand(program: Command, executeRipgrep: RunRipgrep
                 : path.resolve(process.cwd(), filePath);
               const lineNum = data.line_number ?? 0;
               results.push({
-                path: path.relative(root, absoluteFilePath),
+                path: path.relative(root, absoluteFilePath).split(path.sep).join("/"),
                 line_start: lineNum,
                 line_end: lineNum,
                 snippet: data.lines?.text ?? "",

--- a/ix-cli/src/cli/commands/text.ts
+++ b/ix-cli/src/cli/commands/text.ts
@@ -9,6 +9,10 @@ import { llmError } from "../llm.js";
 
 const execFileAsync = promisify(execFile);
 
+export function resolveTextSearchPath(root: string, searchPath: string): string {
+  return path.resolve(root, searchPath);
+}
+
 export function registerTextCommand(program: Command): void {
   program
     .command("text <term>")
@@ -22,7 +26,7 @@ export function registerTextCommand(program: Command): void {
     .action(async (term: string, opts: { limit: string; path: string; format: string; language?: string; root?: string }) => {
       const limit = parseInt(opts.limit, 10);
       const root = path.resolve(resolveWorkspaceRoot(opts.root));
-      const searchPath = path.resolve(root, opts.path);
+      const searchPath = resolveTextSearchPath(root, opts.path);
       if (!isPathInsideResolvedRoot(root, searchPath)) {
         const message = `Search path is outside the workspace: ${opts.path}`;
         if (opts.format === "json") {

--- a/ix-cli/src/cli/commands/text.ts
+++ b/ix-cli/src/cli/commands/text.ts
@@ -1,9 +1,11 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import path from "node:path";
 import type { Command } from "commander";
 import { formatTextResults, type TextResult } from "../format.js";
-import { resolveWorkspaceRoot } from "../config.js";
+import { isPathInsideResolvedRoot, resolveWorkspaceRoot } from "../config.js";
 import { stderr } from "../stderr.js";
+import { llmError } from "../llm.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -19,7 +21,20 @@ export function registerTextCommand(program: Command): void {
     .addHelpText("after", "\nExamples:\n  ix text verify_token --language python\n  ix text \"class.*Service\" --limit 10 --format json\n  ix text TODO --path src/")
     .action(async (term: string, opts: { limit: string; path: string; format: string; language?: string; root?: string }) => {
       const limit = parseInt(opts.limit, 10);
-      const searchPath = opts.path !== "." ? opts.path : resolveWorkspaceRoot(opts.root);
+      const root = path.resolve(resolveWorkspaceRoot(opts.root));
+      const searchPath = path.resolve(root, opts.path);
+      if (!isPathInsideResolvedRoot(root, searchPath)) {
+        const message = `Search path is outside the workspace: ${opts.path}`;
+        if (opts.format === "json") {
+          console.log(JSON.stringify({ error: "path_outside_workspace", message }, null, 2));
+        } else if (opts.format === "llm") {
+          console.log(llmError("path_outside_workspace", message));
+        } else {
+          stderr(`Error: ${message}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
       try {
         const rgArgs = [
           "--json",
@@ -44,9 +59,12 @@ export function registerTextCommand(program: Command): void {
             if (parsed.type === "match") {
               const data = parsed.data;
               const filePath = data.path?.text ?? "";
+              const absoluteFilePath = path.isAbsolute(filePath)
+                ? filePath
+                : path.resolve(process.cwd(), filePath);
               const lineNum = data.line_number ?? 0;
               results.push({
-                path: filePath,
+                path: path.relative(root, absoluteFilePath),
                 line_start: lineNum,
                 line_end: lineNum,
                 snippet: data.lines?.text ?? "",

--- a/ix-cli/src/cli/commands/text.ts
+++ b/ix-cli/src/cli/commands/text.ts
@@ -9,16 +9,22 @@ import { llmError } from "../llm.js";
 
 const execFileAsync = promisify(execFile);
 
+type RunRipgrep = (args: string[]) => Promise<{ stdout: string }>;
+
+async function runRipgrep(args: string[]): Promise<{ stdout: string }> {
+  return execFileAsync("rg", args, { maxBuffer: 10 * 1024 * 1024 });
+}
+
 export function resolveTextSearchPath(root: string, searchPath: string): string {
   return path.resolve(root, searchPath);
 }
 
-export function registerTextCommand(program: Command): void {
+export function registerTextCommand(program: Command, executeRipgrep: RunRipgrep = runRipgrep): void {
   program
     .command("text <term>")
     .description("Fast lexical/text search across the codebase (uses ripgrep)")
     .option("--limit <n>", "Max results", "20")
-    .option("--path <dir>", "Restrict search to a directory", ".")
+    .option("--path <dir>", "Restrict search to a workspace-relative directory", ".")
     .option("--language <lang>", "Filter by language (python, typescript, scala, etc.)")
     .option("--format <fmt>", "Output format (text|json|llm)", "text")
     .option("--root <dir>", "Workspace root directory")
@@ -53,7 +59,7 @@ export function registerTextCommand(program: Command): void {
 
         rgArgs.push(term, searchPath);
 
-        const { stdout } = await execFileAsync("rg", rgArgs, { maxBuffer: 10 * 1024 * 1024 });
+        const { stdout } = await executeRipgrep(rgArgs);
 
         const results: TextResult[] = [];
         for (const line of stdout.split("\n")) {

--- a/ix-cli/src/cli/config.ts
+++ b/ix-cli/src/cli/config.ts
@@ -224,6 +224,16 @@ export function isPathInside(root: string, candidate: string): boolean {
 }
 
 /**
+ * Is a path contained by one specific root after resolving symlinks on both
+ * sides? This is stricter than `isReadablePath`, which deliberately allows all
+ * registered workspace roots for cross-workspace reads.
+ */
+export function isPathInsideResolvedRoot(root: string, candidate: string): boolean {
+  const real = (p: string) => { try { return realpathSync(p); } catch { return resolvePath(p); } };
+  return isPathInside(root, candidate) && isPathInside(real(root), real(candidate));
+}
+
+/**
  * The roots a read command may open a file from: the workspace this invocation
  * resolves to, plus every workspace the user has registered with `ix init`.
  *
@@ -248,10 +258,8 @@ export function readableRoots(explicitRoot?: string): string[] {
  * path stands in, which is the same answer for everything that is not a link.
  */
 export function isReadablePath(candidate: string, explicitRoot?: string): boolean {
-  const real = (p: string) => { try { return realpathSync(p); } catch { return resolvePath(p); } };
-  const realCandidate = real(candidate);
   return readableRoots(explicitRoot).some(
-    root => isPathInside(root, candidate) && isPathInside(real(root), realCandidate),
+    root => isPathInsideResolvedRoot(root, candidate),
   );
 }
 


### PR DESCRIPTION
Fixes #542

## Summary
Resolve `ix text --path` from the selected workspace root and reject paths that escape it.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Resolve relative search paths against `--root` instead of the process working directory.
- Apply lexical and real-path containment checks before invoking ripgrep.
- Return structured JSON and LLM errors with exit status 1 for path escapes.
- Emit successful result paths relative to the selected workspace with POSIX separators on every platform. This changes the existing JSON path field from absolute to workspace-relative, including the default `--path .` case.
- Document that `--path` is workspace-root-relative, including when the command is launched from a subdirectory.
- Add command-level regression coverage for an accepted in-workspace path without depending on a system ripgrep binary.

## Plugin compatibility
Audited the current `ix-claude-plugin`, `ix-codex-plugin`, `ix-cursor-plugin`, `ix-gemini-plugin`, `ix-openclaw-plugin`, and `ix-opencode-plugin` consumers. Their text-search consumers display, forward, or reduce the path to a basename; none requires an absolute path. Several fixtures already use workspace-relative paths.

## Known limitation
A non-existent path below a symlinked workspace root can still be reported as `path_outside_workspace` because the existing containment helper falls back to a lexical candidate when `realpath` fails. This fails closed and is not a traversal bypass. It is intentionally left for the separate follow-up offered in review.

## Validation
- `npm test` (85 files, 1449 passed, 3 skipped; parser smoke passed)
- `npm run typecheck`
- `npm run build`
- `npm run knip`

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
