### PR TITLE
fix(doctor): exit non-zero when checks fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,13 @@ jobs:
           # The converse, and the regression guard for #518: in a directory no
           # workspace covers, doctor must say so instead of passing every check
           # against whichever workspace happens to be the default.
-          echo "::group::doctor (unmapped cwd)"; (cd "$RUNNER_TEMP" && $IX doctor --format json) | tee doctor-unmapped.json; echo "::endgroup::"
+          echo "::group::doctor (unmapped cwd)"
+          set +e
+          (cd "$RUNNER_TEMP" && $IX doctor --format json) | tee doctor-unmapped.json
+          doctor_exit=${PIPESTATUS[0]}
+          set -e
+          if [ "$doctor_exit" -ne 1 ]; then echo "expected doctor to exit 1 for an unmapped cwd, got $doctor_exit"; exit 1; fi
+          echo "::endgroup::"
           node -e "const d=require('./doctor-unmapped.json');const c=(d.checks||[]).find(c=>c.name==='Workspace for this directory');if(!c){console.error('no workspace check in doctor output');process.exit(1)}if(c.ok||d.healthy){console.error('doctor reported healthy in a directory with no workspace');process.exit(1)}console.log('unmapped cwd reported:',c.detail)"
 
       - name: Backend logs on failure

--- a/ix-cli/src/cli/__tests__/doctor-stats-once.test.ts
+++ b/ix-cli/src/cli/__tests__/doctor-stats-once.test.ts
@@ -97,6 +97,7 @@ vi.mock("../commands/upgrade.js", async (orig) => ({
 }));
 
 let savedEndpoint: string | undefined;
+let savedExitCode: number | string | undefined;
 
 beforeEach(() => {
   vi.resetModules();
@@ -111,11 +112,14 @@ beforeEach(() => {
   // backend being reachable, or on how quickly a given OS refuses a connection.
   savedEndpoint = process.env.IX_ENDPOINT;
   process.env.IX_ENDPOINT = "http://127.0.0.1:9";
+  savedExitCode = process.exitCode;
+  process.exitCode = undefined;
 });
 
 afterEach(() => {
   if (savedEndpoint === undefined) delete process.env.IX_ENDPOINT;
   else process.env.IX_ENDPOINT = savedEndpoint;
+  process.exitCode = savedExitCode;
 });
 
 async function runDoctor(): Promise<string[]> {
@@ -176,6 +180,7 @@ describe("ix doctor", () => {
     const lines = await runDoctor();
 
     expect(lines[0]).toContain("healthy=false");
+    expect(process.exitCode).toBe(1);
     expect(lines).toContain(
       'check name="Completed map for this workspace" status=fail detail="no completed map baseline — the graph may be partial. Run `ix map`."',
     );
@@ -204,6 +209,7 @@ describe("ix doctor", () => {
     const lines = await runDoctor();
 
     expect(lines[0]).toContain("healthy=true");
+    expect(process.exitCode).toBeUndefined();
     expect(lines).toContain(
       'check name="Completed map for this workspace" status=warn ' +
       'detail="no local baseline — expected for a cloud-ingested workspace"',
@@ -246,6 +252,7 @@ describe("ix doctor", () => {
       // The whole of #518: this said healthy=true, so "All checks passed" is
       // what a reader acted on.
       expect(lines[0]).toContain("healthy=false");
+      expect(process.exitCode).toBe(1);
       // cwd reaches the assertion through the llm format's quoting, which
       // escapes `\`. A Windows path therefore renders as `D:\\a\\Ix`, not as the
       // raw `process.cwd()` — escape it here rather than compare against the

--- a/ix-cli/src/cli/commands/doctor.ts
+++ b/ix-cli/src/cli/commands/doctor.ts
@@ -369,6 +369,7 @@ export function registerDoctorCommand(program: Command): void {
 
       const hasFailure = results.some((r) => !r.ok && !r.warn);
       const hasWarning = results.some((r) => r.warn);
+      if (hasFailure) process.exitCode = 1;
 
       if (opts.format === "llm") {
         printLlmLines(renderDoctorLlm(results, hasFailure, hasWarning));


### PR DESCRIPTION
Fixes #548

## Summary
Set a non-zero process status whenever `ix doctor` has a failing health check.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Set exit status 1 when any non-warning doctor check fails.
- Keep warning-only doctor runs successful.
- Verify the exit status for incomplete maps, unmatched workspaces, and warning-only cloud workspaces.

## Validation
- `npm test` (84 files, 1446 passed, 3 skipped)
- `npm run typecheck`

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works
