### PR TITLE
fix(map): report files dropped by patch build errors

### DIFF
--- a/ix-cli/src/cli/__tests__/llm-renderers.test.ts
+++ b/ix-cli/src/cli/__tests__/llm-renderers.test.ts
@@ -64,6 +64,22 @@ describe("renderMapLlm", () => {
     const noCross = captureLog(() => renderMapLlm(result, [region({ id: "y", label: "Y", crosscut_score: 0.005 })]));
     expect(noCross[1]).not.toContain("crosscut=");
   });
+
+  it("carries dropped-file counts, and only when non-zero (#554)", () => {
+    const result: MapResult = { file_count: 1, region_count: 1, levels: 1, map_rev: 1, outcome: "ok", regions: [], hierarchy: [] };
+
+    const dropped = captureLog(() => renderMapLlm(result, [], { parseErrors: 48, commitErrors: 3 }));
+    expect(dropped[0]).toBe("map files=1 regions=0 levels=1 rev=1 outcome=ok parse_errors=48 commit_errors=3");
+
+    // A clean ingest carries no signal, so the fields are dropped -- as is
+    // every other zero in this format.
+    const clean = captureLog(() => renderMapLlm(result, [], { parseErrors: 0, commitErrors: 0 }));
+    expect(clean[0]).toBe("map files=1 regions=0 levels=1 rev=1 outcome=ok");
+
+    // `ix subsystems` renders the same record with no local ingest to report.
+    const noIngest = captureLog(() => renderMapLlm(result, []));
+    expect(noIngest[0]).toBe("map files=1 regions=0 levels=1 rev=1 outcome=ok");
+  });
 });
 
 describe("renderSubsystemScoreLlm", () => {

--- a/ix-cli/src/cli/__tests__/map-auto-skip.test.ts
+++ b/ix-cli/src/cli/__tests__/map-auto-skip.test.ts
@@ -6,6 +6,7 @@ import { Command } from 'commander';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   applyRequestedMapCoalesceExitCode,
+  describeDroppedFiles,
   describeEmptyCompletedMap,
   describeRegionlessCompletedMap,
   invalidateBaselineForIncompleteCompletedMap,
@@ -277,5 +278,45 @@ describe('describeRegionlessCompletedMap', () => {
 
     expect(message).toContain('produced 0 regions while mapping 1 of 2');
     expect(invalidate).toHaveBeenCalledWith('/workspace/mixed');
+  });
+});
+
+describe('describeDroppedFiles', () => {
+  it('stays silent on a clean ingest', () => {
+    expect(describeDroppedFiles({ parseErrors: 0, commitErrors: 0 })).toBeUndefined();
+  });
+
+  it('stays silent when there was no local ingest', () => {
+    expect(describeDroppedFiles(undefined)).toBeUndefined();
+  });
+
+  it('reports files that failed to build a patch', () => {
+    const message = describeDroppedFiles({ parseErrors: 48, commitErrors: 0 });
+
+    expect(message).toContain('Map is incomplete');
+    expect(message).toContain('48 files failed to build a patch');
+    expect(message).toContain('absent from the graph');
+    expect(message).not.toContain('failed to commit');
+  });
+
+  it('reports commit failures', () => {
+    const message = describeDroppedFiles({ parseErrors: 0, commitErrors: 3 });
+
+    expect(message).toContain('3 patches failed to commit');
+    expect(message).not.toContain('failed to build a patch');
+  });
+
+  it('reports both causes together', () => {
+    const message = describeDroppedFiles({ parseErrors: 2, commitErrors: 5 });
+
+    expect(message).toContain('2 files failed to build a patch');
+    expect(message).toContain('5 patches failed to commit');
+  });
+
+  it('singularises a lone failure of each kind', () => {
+    expect(describeDroppedFiles({ parseErrors: 1, commitErrors: 0 }))
+      .toContain('1 file failed to build a patch');
+    expect(describeDroppedFiles({ parseErrors: 0, commitErrors: 1 }))
+      .toContain('1 patch failed to commit');
   });
 });

--- a/ix-cli/src/cli/__tests__/map-auto-skip.test.ts
+++ b/ix-cli/src/cli/__tests__/map-auto-skip.test.ts
@@ -293,7 +293,9 @@ describe('describeDroppedFiles', () => {
   it('reports files that failed to build a patch', () => {
     const message = describeDroppedFiles({ parseErrors: 48, commitErrors: 0 });
 
-    expect(message).toContain('Map is incomplete');
+    // Not "the map is incomplete": persistCompletedMapBaseline runs either way,
+    // so doctor answers "Completed map for this workspace" beside this line.
+    expect(message).not.toContain('incomplete');
     expect(message).toContain('48 files failed to build a patch');
     expect(message).toContain('absent from the graph');
     expect(message).not.toContain('failed to commit');

--- a/ix-cli/src/cli/commands/map.ts
+++ b/ix-cli/src/cli/commands/map.ts
@@ -205,6 +205,13 @@ export function describeRegionlessCompletedMap(
  * deliberately bail out when `parseErrors > 0`, which left a partial map as
  * the one failure mode `ix map` never mentioned.
  *
+ * Deliberately not phrased as "the map is incomplete": the same run goes on to
+ * persist a completed map baseline, so `ix doctor` answers "Completed map for
+ * this workspace" right after this line prints. That is correct — a file the
+ * parser cannot handle is normal and must not turn doctor red for ever (#530,
+ * #536) — so the warning states what is missing rather than contradicting the
+ * health signal beside it.
+ *
  * Exported for tests; returns the message rather than writing it so the
  * formatting is assertable without capturing stderr.
  */
@@ -219,7 +226,7 @@ export function describeDroppedFiles(
   const parts: string[] = [];
   if (parse > 0) parts.push(`${parse} ${parse === 1 ? "file" : "files"} failed to build a patch`);
   if (commit > 0) parts.push(`${commit} ${commit === 1 ? "patch" : "patches"} failed to commit`);
-  return `Map is incomplete: ${parts.join(" and ")}. Those files are absent from the graph; re-run with 'ix ingest' to see the per-file errors.`;
+  return `${parts.join(" and ")} — those files are absent from the graph. Re-run with 'ix ingest' to see the per-file errors.`;
 }
 
 function emitDroppedFileWarning(
@@ -561,7 +568,7 @@ Examples:
         return;
       }
       if (opts.format === "llm") {
-        renderMapLlm(result, regions);
+        renderMapLlm(result, regions, localIngest);
         return;
       }
       renderMapText(result, cwd, opts);
@@ -569,13 +576,24 @@ Examples:
 }
 
 /** Flat one-record-per-line region listing with explicit parent= for the llm format. */
-export function renderMapLlm(result: MapResult, regions: MapRegion[]): void {
+export function renderMapLlm(
+  result: MapResult,
+  regions: MapRegion[],
+  ingest?: Pick<IngestFilesSummary, "parseErrors" | "commitErrors">,
+): void {
   console.log(llmLine("map", [
     ["files", result.file_count],
     ["regions", regions.length],
     ["levels", result.levels],
     ["rev", result.map_rev],
     ["outcome", result.outcome],
+    // The same signal the json payload carries as parse_errors/commit_errors.
+    // Agents are told to pass --format llm unconditionally, so leaving it out
+    // of this record hid the dropped files from the one consumer #554 is about.
+    // Emitted only when non-zero, per the format's rule that zeros carrying no
+    // signal are dropped (docs/llm-format.md); a clean ingest says nothing.
+    ["parse_errors", ingest?.parseErrors ? ingest.parseErrors : undefined],
+    ["commit_errors", ingest?.commitErrors ? ingest.commitErrors : undefined],
   ]));
   for (const r of regions) {
     console.log(llmLine("region", [

--- a/ix-cli/src/cli/commands/map.ts
+++ b/ix-cli/src/cli/commands/map.ts
@@ -196,6 +196,40 @@ export function describeRegionlessCompletedMap(
 }
 
 /**
+ * Report files the local ingest could not turn into a patch.
+ *
+ * `ingestFiles` counts these into `parseErrors` and writes a `[patch build
+ * error]` line per file, but `ix map` runs it in a silent/machine format on
+ * every path that matters, so the count is the only surviving signal — and
+ * until #554 nothing read it. Both completed-map sanity checks above
+ * deliberately bail out when `parseErrors > 0`, which left a partial map as
+ * the one failure mode `ix map` never mentioned.
+ *
+ * Exported for tests; returns the message rather than writing it so the
+ * formatting is assertable without capturing stderr.
+ */
+export function describeDroppedFiles(
+  ingest: Pick<IngestFilesSummary, "parseErrors" | "commitErrors"> | undefined,
+): string | undefined {
+  if (!ingest) return undefined;
+  const parse = ingest.parseErrors;
+  const commit = ingest.commitErrors;
+  if (parse <= 0 && commit <= 0) return undefined;
+
+  const parts: string[] = [];
+  if (parse > 0) parts.push(`${parse} ${parse === 1 ? "file" : "files"} failed to build a patch`);
+  if (commit > 0) parts.push(`${commit} ${commit === 1 ? "patch" : "patches"} failed to commit`);
+  return `Map is incomplete: ${parts.join(" and ")}. Those files are absent from the graph; re-run with 'ix ingest' to see the per-file errors.`;
+}
+
+function emitDroppedFileWarning(
+  ingest: Pick<IngestFilesSummary, "parseErrors" | "commitErrors"> | undefined,
+): void {
+  const message = describeDroppedFiles(ingest);
+  if (message) process.stderr.write(chalk.yellow(`  ${message}\n`));
+}
+
+/**
  * A completed map with no usable hierarchy invalidates the architecture
  * completion baseline. Keeping it would make `ix status` report
  * mapCompleted=true for a hierarchy that does not exist. The next run may
@@ -469,6 +503,13 @@ Examples:
       }
       persistCompletedMapBaseline(result, cwd);
 
+      // stderr, so it reaches a human on the text path and never contaminates
+      // the JSON/llm payload on stdout. The exit code deliberately stays 0:
+      // plugins read this command's JSON through runners that discard stdout on
+      // a non-zero exit, so failing here would hide the very diagnostics the
+      // caller needs (the #539 lesson).
+      emitDroppedFileWarning(localIngest);
+
       if (silent) {
         const systems    = result.regions.filter(r => r.label_kind === "system").length;
         const subsystems = result.regions.filter(r => r.label_kind === "subsystem").length;
@@ -501,6 +542,12 @@ Examples:
           levels: result.levels,
           map_rev: result.map_rev,
           outcome: result.outcome,
+          // Always present so a consumer can branch on them without a key check.
+          // A dropped file is silent otherwise: the backend still answers with a
+          // completed outcome, so `outcome` alone cannot distinguish a whole map
+          // from one missing every file that failed to build a patch (#554).
+          parse_errors: localIngest?.parseErrors ?? 0,
+          commit_errors: localIngest?.commitErrors ?? 0,
           regions: regions.map((r: any) => ({
             label: r.label,
             level: r.level,


### PR DESCRIPTION
Closes half of #554 (the reporting half; the id collision itself is a separate change).

## Problem

`ix map` can finish with `outcome: "full_local_completed"` and **exit 0** while silently omitting every file whose patch failed to build. Reproduced on a plain `npm ci`'d TypeScript project — 48 files dropped, nothing in the machine-readable output said so:

```json
{"file_count": 96, "region_count": 15, "levels": 2, "map_rev": 2483, "outcome": "full_local_completed"}
```

The count was already tracked — `ingestFiles` returns it as `parseErrors`, which gates `ingestCompletedCleanly` and feeds `skipReasons.parseError` — but nothing read it here. Both `describeEmptyCompletedMap` and `describeRegionlessCompletedMap` deliberately bail out when `parseErrors > 0`, so a partial map was the one failure mode `ix map` never mentioned in *any* format.

## Change

- `parse_errors` and `commit_errors` in the JSON payload, always present so a consumer can branch on them without a key check.
- A yellow stderr warning in every format, so the text path surfaces it too. stderr keeps the JSON/llm payload on stdout uncontaminated.
- `describeDroppedFiles` is exported and unit-tested rather than asserted through captured stderr.

## The exit code deliberately stays 0

Tempting to fail here, but the opencode and openclaw plugins read this command's JSON through a Bun `$` runner whose `.text()` throws on a non-zero exit — they would lose the very diagnostics this PR adds. That is the trap recorded on #539: fix the consumers first, then the exit code. Happy to follow up in that order if you want the stronger signal.

## Verification

Against the real reproducer (`ix-gemini-plugin/mcp` after `npm ci`), local backend 1.0.27:

```
{'file_count': 95, 'region_count': 14, 'levels': 2, 'map_rev': 2493,
 'outcome': 'full_local_completed', 'parse_errors': 48, 'commit_errors': 0}

  Map is incomplete: 48 files failed to build a patch. Those files are absent
  from the graph; re-run with 'ix ingest' to see the per-file errors.
```

Full gate: **1453 tests passed** (1447 + 6 new), 2 skipped; lint 0 errors; typecheck clean; knip clean.