### PR TITLE
fix(ingest): keep both edges when one source key resolves two ways

### DIFF
--- a/core-ingestion/src/__tests__/patchBuilder.resolution.test.ts
+++ b/core-ingestion/src/__tests__/patchBuilder.resolution.test.ts
@@ -473,3 +473,80 @@ function handler($obj): void { handle(); $obj->handle(); }
     expect(claims).toHaveLength(1);
   });
 });
+
+describe('colliding edge ids (#554)', () => {
+  // `resolveKey` collapses an ambiguous or unknown name to the bare name, so two
+  // distinct caller names can share one `srcKey` — while `edgeResolution` is
+  // keyed on the RAW name, so each caller still resolves its callee separately.
+  // The edge id folds the unresolved `dstKey`, so both edges mint the same id
+  // while carrying different `dst`. Before the fix `deduplicateUpsertEdges`
+  // threw on that and the caller dropped the whole file.
+  const sourceFile = '/repo/app.ts';
+
+  function buildCollidingPatch() {
+    const result = fileResult(
+      sourceFile,
+      SupportedLanguages.TypeScript,
+      [entity('run', SupportedLanguages.TypeScript, 'function', 'A')],
+      [
+        { srcName: 'run', dstName: 'helper', predicate: 'CALLS' },
+        { srcName: 'A.run', dstName: 'helper', predicate: 'CALLS' },
+      ],
+    );
+
+    // Only the 'run' spelling resolves cross-file; 'A.run' falls through to the
+    // local node. Same src, same predicate, two different destinations.
+    const resolvedEdges: ResolvedEdge[] = [
+      {
+        srcFilePath: sourceFile,
+        srcName: 'run',
+        dstFilePath: '/repo/helpers.ts',
+        dstName: 'helper',
+        dstQualifiedKey: 'helper',
+        predicate: 'CALLS',
+        confidence: 0.9,
+      },
+    ];
+
+    return buildPatchWithResolution(result, 'test-hash', '', resolvedEdges);
+  }
+
+  it('does not throw when one source key carries two resolved destinations', () => {
+    expect(() => buildCollidingPatch()).not.toThrow();
+  });
+
+  it('commits both edges under distinct ids', () => {
+    const callEdges = buildCollidingPatch().ops
+      .filter(op => op.type === 'UpsertEdge' && op.predicate === 'CALLS');
+
+    expect(callEdges).toHaveLength(2);
+
+    // Same source, genuinely different destinations.
+    expect(new Set(callEdges.map((e: any) => e.src)).size).toBe(1);
+    expect(new Set(callEdges.map((e: any) => e.dst)).size).toBe(2);
+    expect(callEdges).toContainEqual(expect.objectContaining({
+      dst: nodeId('/repo/helpers.ts', 'helper'),
+    }));
+    expect(callEdges).toContainEqual(expect.objectContaining({
+      dst: nodeId(sourceFile, 'helper'),
+    }));
+
+    // The point of the fix: one id each, so neither is dropped.
+    expect(new Set(callEdges.map((e: any) => e.id)).size).toBe(2);
+  });
+
+  it('leaves ids of non-colliding edges unsalted', () => {
+    // A file with no collision must keep byte-identical ids, so the fix needs no
+    // graph migration.
+    const result = fileResult(
+      '/repo/plain.ts',
+      SupportedLanguages.TypeScript,
+      [entity('alpha', SupportedLanguages.TypeScript)],
+      [{ srcName: 'alpha', dstName: 'beta', predicate: 'CALLS' }],
+    );
+    const edge: any = buildPatchWithResolution(result, 'test-hash', '', []).ops
+      .find((op: any) => op.type === 'UpsertEdge' && op.predicate === 'CALLS');
+
+    expect(edge.id).toBe(deterministicId('/repo/plain.ts:alpha:beta:CALLS'));
+  });
+});

--- a/core-ingestion/src/patch-builder.ts
+++ b/core-ingestion/src/patch-builder.ts
@@ -632,44 +632,96 @@ export function buildPatchWithResolution(
     const key = `${relationship.srcName}:${relationship.predicate}:${relationship.dstName}`;
     relationshipShapeCounts.set(key, (relationshipShapeCounts.get(key) ?? 0) + 1);
   }
+  /**
+   * Where a relationship's destination lands, without emitting anything.
+   *
+   * Pure so the collision pre-pass below can ask the same question the emission
+   * loop does. `externalPkg` is non-null exactly when the answer is an external
+   * node the loop still has to mint, which keeps op order identical to before.
+   */
+  const resolveDst = (r: (typeof relationships)[number], dstKey: string): {
+    dstNodeId: string;
+    externalPkg: { pkgName: string; funcName: string } | null;
+  } => {
+    const baseKey = `${r.srcName}:${r.predicate}:${r.dstName}`;
+    const salted = r.phpCallKind ? `${baseKey}:${r.phpCallKind}` : baseKey;
+    const matched = edgeResolution.has(salted) ? salted : baseKey;
+
+    if (edgeResolution.has(matched)) {
+      // Cross-file resolved — use the defining file's nodeId, in the dst repo's
+      // workspace namespace (matters only for cross-repo edges in a co-ingest).
+      const { dstFilePath, dstQualifiedKey } = edgeResolution.get(matched)!;
+      return { dstNodeId: dstNodeIdInRepo(dstFilePath, dstQualifiedKey), externalPkg: null };
+    }
+    if (r.predicate === 'CALLS' && dstKey.includes('::') && !allQKeys2.has(dstKey)) {
+      const sep = dstKey.indexOf('::');
+      const pkgName = dstKey.slice(0, sep);
+      const funcName = dstKey.slice(sep + 2);
+      return {
+        dstNodeId: nodeId(`external://${pkgName}`, dstKey),
+        externalPkg: { pkgName, funcName },
+      };
+    }
+    return { dstNodeId: nodeId(idPath, dstKey), externalPkg: null };
+  };
+
+  const relationshipDstKey = (r: (typeof relationships)[number]): string =>
+    r.predicate === 'CONTAINS' ? resolveKey(r.dstName, r.srcName) : resolveKey(r.dstName);
+
+  const edgeIdTuple = (srcKey: string, edgeDstKey: string, predicate: string): string =>
+    `${srcKey}\x00${edgeDstKey}\x00${predicate}`;
+
+  /**
+   * Edge ids fold the *unresolved* destination key, but an edge's identity is
+   * its resolved `(src, dst, predicate)`. So when one destination key resolves
+   * two ways inside a single file — one call site matched by `edgeResolution`,
+   * another falling through to the local node — both edges are real and
+   * distinct, yet they mint the same id. `deduplicateUpsertEdges` then sees one
+   * id carrying two endpoints and throws, and the caller drops the whole file
+   * (#554: 48 files on an ordinary npm dependency tree).
+   *
+   * Rather than fold the resolved id into every edge — which would rewrite the
+   * id of every edge in every graph — salt only the tuples that genuinely
+   * collide. Ids outside a collision group stay byte-identical to previous
+   * versions, so no re-ingest is needed.
+   */
+  const collidingIdTuples = new Set<string>();
+  {
+    const dstsByTuple = new Map<string, Set<string>>();
+    for (const r of relationships) {
+      const srcKey = resolveKey(r.srcName);
+      const dstKey = relationshipDstKey(r);
+      const baseKey = `${r.srcName}:${r.predicate}:${r.dstName}`;
+      const edgeDstKey = r.phpCallKind && (relationshipShapeCounts.get(baseKey) ?? 0) > 1
+        ? `${dstKey}:${r.phpCallKind}`
+        : dstKey;
+      const tuple = edgeIdTuple(srcKey, edgeDstKey, r.predicate);
+      let seen = dstsByTuple.get(tuple);
+      if (!seen) { seen = new Set<string>(); dstsByTuple.set(tuple, seen); }
+      seen.add(resolveDst(r, dstKey).dstNodeId);
+    }
+    for (const [tuple, dsts] of dstsByTuple) {
+      if (dsts.size > 1) collidingIdTuples.add(tuple);
+    }
+  }
+
   for (const r of relationships) {
     const srcKey = resolveKey(r.srcName);
     const dstKey = r.predicate === 'CONTAINS'
       ? resolveKey(r.dstName, r.srcName)
       : resolveKey(r.dstName);
 
-    let dstNodeId: string;
     const baseResolutionKey = `${r.srcName}:${r.predicate}:${r.dstName}`;
-    const resolutionKey = r.phpCallKind
-      ? `${baseResolutionKey}:${r.phpCallKind}`
-      : baseResolutionKey;
-    const matchedResolutionKey = edgeResolution.has(resolutionKey)
-      ? resolutionKey
-      : baseResolutionKey;
-
-    if (edgeResolution.has(matchedResolutionKey)) {
-      // Cross-file resolved — use the defining file's nodeId, in the dst repo's
-      // workspace namespace (matters only for cross-repo edges in a co-ingest).
-      const { dstFilePath, dstQualifiedKey } = edgeResolution.get(matchedResolutionKey)!;
-      dstNodeId = dstNodeIdInRepo(dstFilePath, dstQualifiedKey);
-    } else if (r.predicate === 'CALLS' && dstKey.includes('::') && !allQKeys2.has(dstKey)) {
-      const sep = dstKey.indexOf('::');
-      const pkgName = dstKey.slice(0, sep);
-      const funcName = dstKey.slice(sep + 2);
-      const extPath = `external://${pkgName}`;
-      dstNodeId = nodeId(extPath, dstKey);
-      if (!seenExternalNodes2.has(dstNodeId)) {
-        seenExternalNodes2.add(dstNodeId);
-        ops.push({
-          type: 'UpsertNode',
-          id: dstNodeId,
-          kind: 'function',
-          name: funcName,
-          attrs: { package: pkgName, external: true, language: result.language },
-        });
-      }
-    } else {
-      dstNodeId = nodeId(idPath, dstKey);
+    const { dstNodeId, externalPkg } = resolveDst(r, dstKey);
+    if (externalPkg && !seenExternalNodes2.has(dstNodeId)) {
+      seenExternalNodes2.add(dstNodeId);
+      ops.push({
+        type: 'UpsertNode',
+        id: dstNodeId,
+        kind: 'function',
+        name: externalPkg.funcName,
+        attrs: { package: externalPkg.pkgName, external: true, language: result.language },
+      });
     }
 
     const edgeDstKey = r.phpCallKind && (relationshipShapeCounts.get(baseResolutionKey) ?? 0) > 1
@@ -683,9 +735,14 @@ export function buildPatchWithResolution(
     const edgeIdentity = `${nodeId(idPath, srcKey)}\x00${dstNodeId}\x00${r.predicate}`;
     if (emittedEdgeIdentities.has(edgeIdentity)) continue;
     emittedEdgeIdentities.add(edgeIdentity);
+    // Only a colliding tuple is salted, so every other edge keeps the id it
+    // had before this change.
+    const idDstKey = collidingIdTuples.has(edgeIdTuple(srcKey, edgeDstKey, r.predicate))
+      ? `${edgeDstKey}\x00${dstNodeId}`
+      : edgeDstKey;
     ops.push({
       type: 'UpsertEdge',
-      id: edgeId(idPath, srcKey, edgeDstKey, r.predicate),
+      id: edgeId(idPath, srcKey, idDstKey, r.predicate),
       src: nodeId(idPath, srcKey),
       dst: dstNodeId,
       predicate: r.predicate,


### PR DESCRIPTION
Closes the other half of #554 — the `Conflicting UpsertEdge identity` error itself. (#555 is the reporting half; the two are independent and can land in either order.)

## Root cause

An edge id folds the **unresolved** destination key:

```ts
id: edgeId(idPath, srcKey, edgeDstKey, r.predicate)
```

but an edge's identity is its **resolved** `(src, dst, predicate)`, which is what the dedup guard keys on:

```ts
const edgeIdentity = `${nodeId(idPath, srcKey)}\x00${dstNodeId}\x00${r.predicate}`;
```

`resolveKey` returns the bare name whenever a name is unknown or maps to several qualified keys. So two distinct caller spellings (`run` and `A.run`) can collapse to one `srcKey` — while `edgeResolution` is keyed on the *raw* name, so each caller still resolves its callee independently.

Both edges are real and distinct, but they mint the same id. `deduplicateUpsertEdges` sees one id with two endpoints and throws — correctly, by its own comment — and `ingest.ts` catches it, counts a `parseError`, and drops the whole file.

Instrumenting the throw on the real reproducer shows exactly that shape — same `src`, same predicate, different `dst`:

```
Conflicting UpsertEdge identity for deterministic id 6519c6cc-…
  | A src=89116ede-… dst=33f845bc-… pred=CALLS
  | B src=89116ede-… dst=dbfb22ad-… pred=CALLS
```

## Approach, and the one judgement call

The obviously "correct" fix is to fold `dstNodeId` into every edge id. I did **not** do that: it rewrites the id of every edge in every existing graph and forces a full re-ingest to avoid orphans.

Instead a pre-pass finds the id tuples that genuinely resolve to more than one destination, and salts **only those**. Every other edge keeps a byte-identical id, so no migration is needed. Verified directly by building the same file against both revisions — 46 edges, identical ids — and asserted in `leaves ids of non-colliding edges unsalted`.

Happy to switch to the wholesale derivation if you would rather take the churn once and have the id match the identity by construction.

The destination resolution moves into a pure `resolveDst` helper so the pre-pass can ask the same question the emission loop does. External-node minting stays exactly where it was, so op order is unchanged.

## Verification

Real reproducer (`ix-gemini-plugin/mcp` after `npm ci`), local backend 1.0.27:

| | before | after |
|---|---|---|
| `[patch build error]` lines | **48** | **0** |

The three new tests fail on `main` with the exact production error (`Conflicting UpsertEdge identity for deterministic id 0ca69949-…`) and pass here.

Suites: core-ingestion **354 passed** (351 + 3 new); ix-cli **1447 passed**, 2 skipped; lint 0 errors; typecheck clean.

> Note: 6 core-ingestion tests fail on `main` in my environment (Scala/Rust grammar snapshots) — unchanged by this PR, and they look like CI does not run this package's suite. Flagging separately.