### PR TITLE
fix(text): stop the search term being parsed as a ripgrep flag

### DIFF
--- a/ix-cli/src/cli/__tests__/text-arg-injection.test.ts
+++ b/ix-cli/src/cli/__tests__/text-arg-injection.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Command } from "commander";
+
+const execFile = vi.hoisted(() =>
+  vi.fn((_cmd: string, _args: string[], _opts: unknown, cb: (e: unknown, r: unknown) => void) =>
+    cb(null, { stdout: "", stderr: "" }),
+  ),
+);
+
+// Spread the real module: `config.ts`, reached through this command, imports
+// `execSync` from it.
+vi.mock("node:child_process", async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  execFile,
+}));
+
+import { registerTextCommand } from "../commands/text.js";
+
+/**
+ * `ix text` hands its search term straight to ripgrep's argv, and through
+ * `ix mcp` that term is a string a model chose. Without a `--` separator rg
+ * parses a leading `-` as one of its own flags, which is how `--files` ended up
+ * running instead of a search, and how `--pre=<cmd>`/`--file=<path>` could take
+ * the path argument away and leave rg reading stdin for ever.
+ */
+describe("ix text does not let the search term become an rg flag", () => {
+  beforeEach(() => {
+    execFile.mockClear();
+  });
+
+  async function argvFor(term: string, extra: string[] = []): Promise<string[]> {
+    const program = new Command();
+    registerTextCommand(program);
+    await program.parseAsync(["text", ...extra, "--", term], { from: "user" });
+    return execFile.mock.calls[0]?.[1] as string[];
+  }
+
+  it.each(["--files", "--pre=/bin/sh", "--file=/etc/passwd", "-l", "--no-ignore"])(
+    "passes %s as a pattern, after the separator",
+    async (term) => {
+      const args = await argvFor(term);
+
+      const sep = args.indexOf("--");
+      expect(sep).toBeGreaterThanOrEqual(0);
+      expect(args[sep + 1]).toBe(term);
+      // Nothing before the separator came from the caller.
+      expect(args.slice(0, sep)).not.toContain(term);
+      // The path is still the last positional, so rg always has one and never
+      // falls back to reading stdin.
+      expect(args).toHaveLength(sep + 3);
+    },
+  );
+
+  it("still places rg's own flags before the separator", async () => {
+    const args = await argvFor("needle", ["--limit", "5", "--language", "python"]);
+
+    expect(args.slice(0, args.indexOf("--"))).toEqual([
+      "--json", "--max-count", "5", "--glob", "*.py",
+    ]);
+  });
+});

--- a/ix-cli/src/cli/commands/text.ts
+++ b/ix-cli/src/cli/commands/text.ts
@@ -32,7 +32,16 @@ export function registerTextCommand(program: Command): void {
           }
         }
 
-        rgArgs.push(term, searchPath);
+        // `--` first. `term` reaches this argv verbatim from the caller, and
+        // through `ix mcp` the caller is a model choosing the string, so
+        // without the separator ripgrep parses any term beginning with `-` as
+        // one of its own flags. `ix text --path=. --format=json -- --files`
+        // ran rg's `--files` instead of searching for that literal, and a flag
+        // that swallows the path argument -- `--pre=<cmd>`, `--file=<path>` --
+        // leaves rg with no path to search, so it reads stdin and never
+        // returns. `ix mcp` serialises its runs, so one such call blocks every
+        // other tool until the timeout and leaves the child process behind.
+        rgArgs.push("--", term, searchPath);
 
         const { stdout } = await execFileAsync("rg", rgArgs, { maxBuffer: 10 * 1024 * 1024 });
 


### PR DESCRIPTION
Found while reviewing #543, which hardens `ix text`'s *path* handling. This is the other untrusted input to the same command, and it is independent of that PR — it reproduces on `main` today.

## The bug

`ix text` appends the caller's term straight to ripgrep's argv:

```ts
rgArgs.push(term, searchPath);
```

Any term beginning with `-` is therefore parsed by rg as one of its own flags. The CLI's `--` does not shield it: commander stops parsing there and passes the token through verbatim, and **`ix mcp` emits exactly that shape** — `toArgv` builds `[command, ...options, --format=llm, "--", ...positionals]` — so the term reaching rg is a string a *model* chose.

Reproduced on `main` (`3baa7dc`):

| invocation | result |
|---|---|
| `ix text --path=<dir> --format=json -- --files` | ran rg's `--files` listing instead of searching |
| `ix text --path=<dir> --format=json -- --pre=<script>` | **never returns** |

## Why the second one is the serious half

A flag that consumes the path argument leaves rg holding a pattern and no path, so it reads **stdin** — which under `execFile` is a pipe nothing ever writes to or closes.

`ix mcp` runs commands **one at a time** (the `activeRun` note in `mcp/runner.ts` spells out why: `process.exitCode` is global, so runs cannot be concurrent). So one such call:

- blocks *every other* MCP tool call until the 30s timeout, and
- leaves the abandoned `rg` alive afterwards — `execFileAsync` here passes no `timeout`. I watched one sit in `ps` for several minutes while confirming this.

Quieter variants just change what a search returns without saying so: `--no-ignore`, `-U`, `-l`.

## The fix

```ts
rgArgs.push("--", term, searchPath);
```

rg then always has its path argument and never falls back to stdin. Verified against real ripgrep: `--files` and `--pre=` both return `[]` immediately, and an ordinary search is unchanged.

## Notes for review

- **No conflict with #543.** That PR rewrites the lines above and below this one; this line is untouched context in its diff.
- The test asserts the separator's *position* (nothing caller-supplied precedes it; the path is still the last positional) rather than an exact argv, so it does not freeze the flag list. It fails on all six cases without the one-line change — checked by reverting.
- Not fixed here, and worth a separate decision: `execFileAsync` still has no `timeout`, so any pathological rg invocation outlives the command. With `--` in place there is no longer a known way to trigger it from input.

## Validation

- `npm run test:unit` — 85 files, 1453 passed, 2 skipped
- `npm run typecheck`, `npx knip` — clean
- Manual, against real `rg` 