### PR TITLE
docs(contributing): a non-zero exit is a breaking change for plugins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,51 @@ Breaking changes: use `feat!:` or `fix!:` prefix.
 - Follow existing Ix command voice and terminology
 - Match output patterns of existing commands
 
+### Exit codes
+
+Making a command exit non-zero is a **breaking change to every plugin and MCP
+client**, even when the payload it prints is an improvement. Both consumers
+throw stdout away on a failed run:
+
+- **Plugins** run `ix` through wrappers that treat a non-zero exit as an error
+  and discard the output — bun's `` $`…` `` throws, and the shell hooks branch on
+  `||` under `set -euo pipefail`.
+- **`ix mcp`** prefers stderr over stdout when the exit is non-zero
+  (`runCommand` in `ix-cli/src/mcp/server.ts`), so a structured record written
+  to stdout is replaced by whatever prose happened to reach stderr — usually
+  the resolver's human guidance.
+
+The failure mode is counter-intuitive: you add `{"error": "...", "message": "..."}`
+so machine callers can tell a refusal from an empty result, set the exit code
+to match, and the exit code is what stops anyone from ever seeing the payload.
+
+**Before adding a non-zero exit to an existing command, check whether anything
+calls it programmatically:**
+
+```bash
+# from a directory holding checkouts of the plugin repos
+grep -rnE '\$`ix <command>|runIx\(\["<command>"|\$\(ix <command>' . | grep -v '\.md:'
+```
+
+Those three forms cover every call site today — bun shell, the TypeScript
+`runIx` helper, and shell command substitution. They are literal on purpose:
+no plugin builds the command name from a variable, so a literal search is
+exhaustive. Re-check that assumption if the grep comes back empty for a command
+you expected to find.
+
+Matches in `.md` files or agent prompt strings are prose telling a model to run
+the command — those are fine, the model sees stdout either way. Matches in
+`.ts`, `.sh` or `.py` are runners, and those break.
+
+If a runner consumes it, the plugin change has to land **first**, in its own
+repo, and the Ix change follows. Say so in the PR body and open it as a draft
+until the dependency is merged.
+
+Applies to: `ix-claude-plugin`, `ix-codex-plugin`, `ix-cursor-plugin`,
+`ix-gemini-plugin`, `ix-openclaw-plugin`, `ix-opencode-plugin`. Five of the six
+carry runners today, so "no plugin calls this" is a claim to verify, not
+assume.
+
 ## Security Checks
 
 PRs and pushes to `main` run automated security checks:


### PR DESCRIPTION
Writes down the rule that stopped #547, because it has now cost us twice and is invisible from inside this repo.

## The pattern

Both times it looked like an unambiguous improvement: a command returned an empty-but-successful result where it should have signalled a refusal, so the fix added a structured `{"error": ..., "message": ...}` body **and** a matching non-zero exit code. The exit code is what then stopped anyone from seeing the body.

Two independent consumers throw stdout away on a failed run:

- **Plugins** wrap `ix` in runners that treat non-zero as an error — bun's `` $`…` `` throws, and the shell hooks branch on `||` under `set -euo pipefail`.
- **`ix mcp`** prefers stderr over stdout when the exit is non-zero:

  ```ts
  if (!result.ok) {
    const detail = result.stderr.trim() || result.stdout.trim() || `… failed without output`;
    return textResult(JSON.stringify({ error: detail, tool }), true);
  }
  ```

  and the resolver has usually already written human guidance to stderr — so the structured record loses to prose.

Neither is visible from the file being edited. #539 hit it (which is why #559 is a draft), and #547 is open right now for the same reason, across 10 commands and 10 MCP tools.

## What the section adds

The check, as a grep you can actually run against the plugin checkouts, plus how to read the results (`.md` and agent prompt strings are fine — a model sees stdout either way; `.ts`/`.sh`/`.py` are runners and break), and what to do when a runner does consume it: land the plugin change first, open the Ix PR as a draft behind it.

## Verified rather than asserted

- **The three grep forms are exhaustive.** Checked that no plugin builds the command name from a variable — searched for `runIx([<non-literal>`, `` $`ix ${ ``, and `execFile`/`spawn` with `ix`: no hits. So a literal search finds every call site. The doc says to re-check that assumption if a grep comes back unexpectedly empty.
- **Spot-checked against three commands with known answers:** `impact` → 8 runners across 4 repos; `read` and `doctor` → none, both appearing only in agent prompt prose. Those two are exactly why #553 and #549 were safe to merge today while #547 was not.
- Running it also corrected my own earlier count: `ix-cursor-plugin` and `ix-gemini-plugin` have runners too, so it is **5 of the 6** plugin repos, not 3. The doc says so, because "no plugin calls this" is a claim worth verifying rather than assuming.

Docs only — no code, no behaviour change.