### PR TITLE
fix(diff): emit the unresolved_target slug, not the sentence

### DIFF
--- a/ix-cli/src/cli/__tests__/diff-unresolved-target.test.ts
+++ b/ix-cli/src/cli/__tests__/diff-unresolved-target.test.ts
@@ -1,0 +1,90 @@
+/**
+ * diff-unresolved-target.test.ts — Ix #566
+ *
+ * `ix diff` was the one command that resolves a target and did not emit the
+ * shared `unresolved_target` record. Its `--format json` branch put the human
+ * sentence in the `error` field, where every other command puts the machine
+ * slug, and `docs/llm-format.md` says a target that does not exist is always
+ * `unresolved_target`.
+ */
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../client/api.js", () => ({
+  IxClient: class {
+    async workspaceSystem() { return { systemId: null }; }
+    async search() { return []; }
+  },
+}));
+
+async function run(args: string[]): Promise<{ stdout: string; stderr: string }> {
+  const { registerDiffCommand } = await import("../commands/diff.js");
+  const program = new Command();
+  program.name("ix").exitOverride();
+  registerDiffCommand(program);
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const log = vi.spyOn(console, "log").mockImplementation((...parts) => stdout.push(parts.join(" ")));
+  const error = vi.spyOn(console, "error").mockImplementation((...parts) => stderr.push(parts.join(" ")));
+  try {
+    await program.parseAsync(args, { from: "user" });
+  } finally {
+    log.mockRestore();
+    error.mockRestore();
+  }
+  return { stdout: stdout.join("\n"), stderr: stderr.join("\n") };
+}
+
+describe("ix diff — unresolved target", () => {
+  let savedExitCode: number | string | undefined;
+
+  beforeEach(() => {
+    savedExitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = savedExitCode;
+  });
+
+  // The symbol path: resolveEntityFull finds nothing.
+  it("emits the shared slug and message as json for a symbol target", async () => {
+    const result = await run(["diff", "3", "5", "DefinitelyMissing", "--format", "json"]);
+
+    expect(JSON.parse(result.stdout)).toEqual({
+      error: "unresolved_target",
+      message: 'No entity found matching "DefinitelyMissing".',
+    });
+  });
+
+  // The file-like path: a target with an extension skips resolveEntityFull and
+  // goes through resolveFileOrEntity, which is a separate branch with its own
+  // copy of the record. Both were wrong; both must be right.
+  it("emits the shared slug and message as json for a file-like target", async () => {
+    const result = await run(["diff", "3", "5", "DefinitelyMissing.ts", "--format", "json"]);
+
+    expect(JSON.parse(result.stdout)).toEqual({
+      error: "unresolved_target",
+      message: 'No entity found matching "DefinitelyMissing.ts".',
+    });
+  });
+
+  it("emits an llm error record with the same wording as every other command", async () => {
+    const result = await run(["diff", "3", "5", "DefinitelyMissing", "--format", "llm"]);
+
+    expect(result.stdout).toBe(
+      'error code=unresolved_target message="No entity found matching \\"DefinitelyMissing\\"."',
+    );
+  });
+
+  // Deliberate scope boundary, not an oversight. Making `ix diff` exit non-zero
+  // is a breaking change for the plugins that call it (CONTRIBUTING -> CLI
+  // Standards -> Exit codes); ix-cursor-plugin's ix_diff tool routes on the
+  // exit status. That half is queued behind Ix #547. This test fails the moment
+  // someone adds the exit code without doing that work.
+  it("does not yet exit non-zero — that half is queued behind the plugin fixes", async () => {
+    await run(["diff", "3", "5", "DefinitelyMissing", "--format", "json"]);
+
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/ix-cli/src/cli/commands/diff.ts
+++ b/ix-cli/src/cli/commands/diff.ts
@@ -11,7 +11,7 @@ import { getEndpoint } from "../config.js";
 import { resolveFileOrEntity, resolveEntityFull, printResolved, looksFileLike, type ResolvedEntity } from "../resolve.js";
 import { formatDiff, relativePath } from "../format.js";
 import { llmLine, llmError } from "../llm.js";
-import { reportFailure } from "../ui.js";
+import { reportFailure, unresolvedTargetMessage, unresolvedTargetRecord } from "../ui.js";
 import { parsePickOption } from "../options.js";
 
 /**
@@ -511,20 +511,20 @@ export function registerDiffCommand(program: Command): void {
               console.log(JSON.stringify(fullResult.result, null, 2));
               return;
             } else {
-              console.log(JSON.stringify({ error: `No entity found matching "${target}".` }, null, 2));
+              console.log(JSON.stringify(unresolvedTargetRecord(target), null, 2));
               return;
             }
           } else {
             resolved = await resolveFileOrEntity(client, target, resolveOpts);
             if (!resolved) {
-              console.log(JSON.stringify({ error: `No entity found matching "${target}".` }, null, 2));
+              console.log(JSON.stringify(unresolvedTargetRecord(target), null, 2));
               return;
             }
           }
         } else {
           resolved = await resolveFileOrEntity(client, target, resolveOpts);
           if (!resolved) {
-            if (opts.format === "llm") console.log(llmError("unresolved_target", `No entity resolved for "${target}".`));
+            if (opts.format === "llm") console.log(llmError("unresolved_target", unresolvedTargetMessage(target)));
             return;
           }
           if (opts.format === "text") printResolved(resolved);

--- a/ix-cli/src/cli/ui.ts
+++ b/ix-cli/src/cli/ui.ts
@@ -133,10 +133,27 @@ export function reportFailure(code: string, message: string, format?: string): v
 }
 
 /** Report a resolver miss without corrupting machine-readable stdout. */
+/**
+ * The one message for a target that does not exist.
+ *
+ * Split out from `reportUnresolvedTarget` so a command can emit the shared
+ * record *without* the exit code. `ix diff` needs exactly that: its payload is
+ * wrong today and can be fixed now, while the exit-code half is queued behind
+ * the plugin work (CONTRIBUTING -> CLI Standards -> Exit codes).
+ */
+export function unresolvedTargetMessage(target: string): string {
+  return `No entity found matching "${target}".`;
+}
+
+/** The `--format json` record for a target that does not exist. */
+export function unresolvedTargetRecord(target: string): { error: string; message: string } {
+  return { error: "unresolved_target", message: unresolvedTargetMessage(target) };
+}
+
 export function reportUnresolvedTarget(target: string, format?: string): void {
-  const message = `No entity found matching "${target}".`;
+  const message = unresolvedTargetMessage(target);
   if (format === "json") {
-    console.log(JSON.stringify({ error: "unresolved_target", message }, null, 2));
+    console.log(JSON.stringify(unresolvedTargetRecord(target), null, 2));
   } else if (format === "llm") {
     console.log(llmError("unresolved_target", message));
   }


### PR DESCRIPTION
`docs/llm-format.md:29` says a target that does not exist is always `unresolved_target`, whichever command was asked. #538 unified everything except `diff.ts`, and nothing has touched it since.

Found while reviewing #547: twelve commands resolve a target, #547 converts ten, #559 takes `locate`, and `diff` is the twelfth that nobody has.

## What was wrong

`ix diff --format json` on a target that does not exist emitted:

```json
{"error": "No entity found matching \"decide.ts\"."}
```

The human sentence sits in the `error` field — where every other command puts the machine slug — and there is no `message` field at all. A consumer routing on `error === "unresolved_target"` gets an English sentence; one reading `message` gets nothing.

**There are two such sites, not one.** The symbol path (`resolveEntityFull`, `diff.ts:514`) and the file-like path (`resolveFileOrEntity`, `diff.ts:520`) each carry their own copy, so `ix diff 3 5 Foo` and `ix diff 3 5 Foo.ts` were separately broken. Both are fixed and separately tested.

The `--format llm` branch already emitted the right slug, but with the older `No entity resolved for "…"` wording. That is now the shared text, so the string is gone from `diff.ts`. The eight remaining copies belong to the commands #547 converts and are **deliberately left alone** to avoid conflicting with that PR.

`unresolvedTargetMessage` and `unresolvedTargetRecord` are split out of `reportUnresolvedTarget` so a command can emit the shared record *without* the exit code — which is the whole point of this PR being separable.

## The exit code is deliberately not in this PR

Making `ix diff` exit non-zero is a breaking change for the plugins (`CONTRIBUTING.md` → CLI Standards → Exit codes). `ix-cursor-plugin`'s `ix_diff` tool routes on the exit status at `mcp/tools/map.ts:206`; today it reads `raw.summary`/`raw.total` off the error object and reports a successful **"0 changes"** for a target that does not exist. Only the exit code fixes that, and it belongs in #547's queue behind the five plugin PRs.

**A test pins the current exit behaviour** so nobody adds it without doing that work.

## Tests

Four, each mutation-checked against the code it covers:

| mutation | result |
|---|---|
| revert both json sites to the prose-in-`error` shape | 2 failed / 2 passed |
| revert the llm wording only | 1 failed / 3 passed |
| add `process.exitCode = 1` | 1 failed / 3 passed |

## Verification

typecheck, eslint and knip clean; **ix-cli 1509 passed / 2 skipped**.

One thing worth flagging separately: `src/cli/__tests__/watch-dedup.test.ts` ("starts both the tsx source CLI and a normal built CLI child") **fails when run in isolation on unmodified `main`** — 4 of 4 attempts at `793c56b` with this change stashed. It passes in the full suite, so it is order- or build-dependent rather than broken. Pre-existing and unrelated to this PR, but it should probably get an issue.