### PR TITLE
fix(map): stop blaming the language when the ingest was deduplicated

### DIFF
--- a/ix-cli/src/cli/__tests__/map-auto-skip.test.ts
+++ b/ix-cli/src/cli/__tests__/map-auto-skip.test.ts
@@ -110,6 +110,7 @@ describe('describeEmptyCompletedMap', () => {
     const message = describeEmptyCompletedMap(emptyResult, {
       filesDiscovered: 260,
       patchesApplied: 260,
+      idempotentPatches: 0,
       parseErrors: 0,
       commitErrors: 0,
     });
@@ -120,10 +121,58 @@ describe('describeEmptyCompletedMap', () => {
     expect(message).toContain("the next 'ix map' can reuse unchanged files");
   });
 
+  it('blames deduplication, not the language, when every commit was a replay (#527)', () => {
+    const message = describeEmptyCompletedMap(emptyResult, {
+      filesDiscovered: 1,
+      patchesApplied: 1,
+      idempotentPatches: 1,
+      parseErrors: 0,
+      commitErrors: 0,
+    });
+
+    expect(message).toContain("answered every one of the 1 committed patch with 'already applied'");
+    expect(message).toContain('this run wrote nothing');
+    expect(message).toContain('expire within 24 hours');
+    // The old diagnosis is actively wrong here: the source parsed fine, and
+    // nothing about it reached the backend's graph to be mapped.
+    expect(message).not.toContain('may not map this source language');
+    expect(message).not.toContain('The source graph was ingested');
+    expect(message).toContain("the next 'ix map' can reuse unchanged files");
+  });
+
+  it('keeps the language diagnosis when only some commits were replays', () => {
+    const message = describeEmptyCompletedMap(emptyResult, {
+      filesDiscovered: 10,
+      patchesApplied: 10,
+      idempotentPatches: 9,
+      parseErrors: 0,
+      commitErrors: 0,
+    });
+
+    expect(message).toContain('may not map this source language');
+    expect(message).not.toContain("already applied");
+  });
+
+  it('does not claim deduplication when nothing was committed at all', () => {
+    // patchesApplied 0 with files discovered is the hash-skip path, not a
+    // replay; `idempotentPatches >= patchesApplied` is trivially true there.
+    const message = describeEmptyCompletedMap(emptyResult, {
+      filesDiscovered: 30,
+      patchesApplied: 0,
+      idempotentPatches: 0,
+      parseErrors: 0,
+      commitErrors: 0,
+    });
+
+    expect(message).toContain('may not map this source language');
+    expect(message).not.toContain("already applied");
+  });
+
   it('does not reject an actually empty workspace', () => {
     expect(describeEmptyCompletedMap(emptyResult, {
       filesDiscovered: 0,
       patchesApplied: 0,
+      idempotentPatches: 0,
       parseErrors: 0,
       commitErrors: 0,
     })).toBeUndefined();
@@ -133,12 +182,14 @@ describe('describeEmptyCompletedMap', () => {
     expect(describeEmptyCompletedMap(emptyResult, {
       filesDiscovered: 12,
       patchesApplied: 12,
+      idempotentPatches: 0,
       parseErrors: 1,
       commitErrors: 0,
     })).toBeUndefined();
     expect(describeEmptyCompletedMap(emptyResult, {
       filesDiscovered: 12,
       patchesApplied: 12,
+      idempotentPatches: 0,
       parseErrors: 0,
       commitErrors: 1,
     })).toBeUndefined();
@@ -150,6 +201,7 @@ describe('describeEmptyCompletedMap', () => {
     expect(describeEmptyCompletedMap({ ...emptyResult, outcome: 'ok' }, {
       filesDiscovered: 260,
       patchesApplied: 260,
+      idempotentPatches: 0,
       parseErrors: 0,
       commitErrors: 0,
     })).toBeUndefined();
@@ -160,6 +212,7 @@ describe('describeEmptyCompletedMap', () => {
       expect(describeEmptyCompletedMap({ ...emptyResult, outcome }, {
         filesDiscovered: 260,
         patchesApplied: 260,
+        idempotentPatches: 0,
         parseErrors: 0,
         commitErrors: 0,
       })).toBeUndefined();
@@ -170,18 +223,21 @@ describe('describeEmptyCompletedMap', () => {
     expect(describeEmptyCompletedMap({ ...emptyResult, outcome: 'local_map_not_recommended' }, {
       filesDiscovered: 12,
       patchesApplied: 12,
+      idempotentPatches: 0,
       parseErrors: 0,
       commitErrors: 0,
     })).toBeUndefined();
     expect(describeEmptyCompletedMap({ ...emptyResult, file_count: 12 }, {
       filesDiscovered: 12,
       patchesApplied: 12,
+      idempotentPatches: 0,
       parseErrors: 0,
       commitErrors: 0,
     })).toBeUndefined();
     expect(describeEmptyCompletedMap({ ...emptyResult, region_count: 1 }, {
       filesDiscovered: 12,
       patchesApplied: 12,
+      idempotentPatches: 0,
       parseErrors: 0,
       commitErrors: 0,
     })).toBeUndefined();
@@ -192,6 +248,7 @@ describe('describeEmptyCompletedMap', () => {
     const message = invalidateBaselineForIncompleteCompletedMap(emptyResult, {
       filesDiscovered: 260,
       patchesApplied: 0,
+      idempotentPatches: 0,
       parseErrors: 0,
       commitErrors: 0,
     }, '/workspace/account', invalidate);
@@ -206,6 +263,7 @@ describe('describeEmptyCompletedMap', () => {
     expect(describeEmptyCompletedMap({ ...emptyResult, outcome: 'coupling_unchanged' }, {
       filesDiscovered: 260,
       patchesApplied: 0,
+      idempotentPatches: 0,
       parseErrors: 0,
       commitErrors: 0,
     })).toBeDefined();
@@ -216,6 +274,7 @@ describe('describeRegionlessCompletedMap', () => {
   const cleanIngest = {
     filesDiscovered: 200,
     patchesApplied: 200,
+    idempotentPatches: 0,
     parseErrors: 0,
     commitErrors: 0,
   };
@@ -272,6 +331,7 @@ describe('describeRegionlessCompletedMap', () => {
     }, {
       filesDiscovered: 2,
       patchesApplied: 2,
+      idempotentPatches: 0,
       parseErrors: 0,
       commitErrors: 0,
     }, '/workspace/mixed', invalidate);

--- a/ix-cli/src/cli/__tests__/map-auto-skip.test.ts
+++ b/ix-cli/src/cli/__tests__/map-auto-skip.test.ts
@@ -111,6 +111,7 @@ describe('describeEmptyCompletedMap', () => {
       filesDiscovered: 260,
       patchesApplied: 260,
       idempotentPatches: 0,
+      filesSkippedAsUnchanged: 0,
       parseErrors: 0,
       commitErrors: 0,
     });
@@ -126,6 +127,7 @@ describe('describeEmptyCompletedMap', () => {
       filesDiscovered: 1,
       patchesApplied: 1,
       idempotentPatches: 1,
+      filesSkippedAsUnchanged: 0,
       parseErrors: 0,
       commitErrors: 0,
     });
@@ -140,11 +142,34 @@ describe('describeEmptyCompletedMap', () => {
     expect(message).toContain("the next 'ix map' can reuse unchanged files");
   });
 
+  it('does not blame deduplication when the run skipped files as unchanged', () => {
+    // Joey's case on #570: a workspace on a language the backend cannot build a
+    // hierarchy for. 99 files are mtime-clean and never submitted — which is
+    // itself proof the backend still holds their source hashes, and so their
+    // nodes. The user reverts one file to content ingested earlier, its patch id
+    // matches a record that is still there, and the backend answers Idempotent.
+    // Every patch this run submitted was a replay, but the graph is intact and
+    // waiting 24 hours changes nothing.
+    const message = describeEmptyCompletedMap(emptyResult, {
+      filesDiscovered: 100,
+      patchesApplied: 1,
+      idempotentPatches: 1,
+      filesSkippedAsUnchanged: 99,
+      parseErrors: 0,
+      commitErrors: 0,
+    });
+
+    expect(message).not.toContain('deduplicated');
+    expect(message).not.toContain('expire within 24 hours');
+    expect(message).toContain('may not map this source language');
+  });
+
   it('keeps the language diagnosis when only some commits were replays', () => {
     const message = describeEmptyCompletedMap(emptyResult, {
       filesDiscovered: 10,
       patchesApplied: 10,
       idempotentPatches: 9,
+      filesSkippedAsUnchanged: 0,
       parseErrors: 0,
       commitErrors: 0,
     });
@@ -160,6 +185,7 @@ describe('describeEmptyCompletedMap', () => {
       filesDiscovered: 30,
       patchesApplied: 0,
       idempotentPatches: 0,
+      filesSkippedAsUnchanged: 0,
       parseErrors: 0,
       commitErrors: 0,
     });
@@ -173,6 +199,7 @@ describe('describeEmptyCompletedMap', () => {
       filesDiscovered: 0,
       patchesApplied: 0,
       idempotentPatches: 0,
+      filesSkippedAsUnchanged: 0,
       parseErrors: 0,
       commitErrors: 0,
     })).toBeUndefined();
@@ -183,6 +210,7 @@ describe('describeEmptyCompletedMap', () => {
       filesDiscovered: 12,
       patchesApplied: 12,
       idempotentPatches: 0,
+      filesSkippedAsUnchanged: 0,
       parseErrors: 1,
       commitErrors: 0,
     })).toBeUndefined();
@@ -190,6 +218,7 @@ describe('describeEmptyCompletedMap', () => {
       filesDiscovered: 12,
       patchesApplied: 12,
       idempotentPatches: 0,
+      filesSkippedAsUnchanged: 0,
       parseErrors: 0,
       commitErrors: 1,
     })).toBeUndefined();
@@ -202,6 +231,7 @@ describe('describeEmptyCompletedMap', () => {
       filesDiscovered: 260,
       patchesApplied: 260,
       idempotentPatches: 0,
+      filesSkippedAsUnchanged: 0,
       parseErrors: 0,
       commitErrors: 0,
     })).toBeUndefined();
@@ -213,6 +243,7 @@ describe('describeEmptyCompletedMap', () => {
         filesDiscovered: 260,
         patchesApplied: 260,
         idempotentPatches: 0,
+        filesSkippedAsUnchanged: 0,
         parseErrors: 0,
         commitErrors: 0,
       })).toBeUndefined();
@@ -224,6 +255,7 @@ describe('describeEmptyCompletedMap', () => {
       filesDiscovered: 12,
       patchesApplied: 12,
       idempotentPatches: 0,
+      filesSkippedAsUnchanged: 0,
       parseErrors: 0,
       commitErrors: 0,
     })).toBeUndefined();
@@ -231,6 +263,7 @@ describe('describeEmptyCompletedMap', () => {
       filesDiscovered: 12,
       patchesApplied: 12,
       idempotentPatches: 0,
+      filesSkippedAsUnchanged: 0,
       parseErrors: 0,
       commitErrors: 0,
     })).toBeUndefined();
@@ -238,6 +271,7 @@ describe('describeEmptyCompletedMap', () => {
       filesDiscovered: 12,
       patchesApplied: 12,
       idempotentPatches: 0,
+      filesSkippedAsUnchanged: 0,
       parseErrors: 0,
       commitErrors: 0,
     })).toBeUndefined();
@@ -249,6 +283,7 @@ describe('describeEmptyCompletedMap', () => {
       filesDiscovered: 260,
       patchesApplied: 0,
       idempotentPatches: 0,
+      filesSkippedAsUnchanged: 0,
       parseErrors: 0,
       commitErrors: 0,
     }, '/workspace/account', invalidate);
@@ -264,6 +299,7 @@ describe('describeEmptyCompletedMap', () => {
       filesDiscovered: 260,
       patchesApplied: 0,
       idempotentPatches: 0,
+      filesSkippedAsUnchanged: 0,
       parseErrors: 0,
       commitErrors: 0,
     })).toBeDefined();
@@ -275,6 +311,7 @@ describe('describeRegionlessCompletedMap', () => {
     filesDiscovered: 200,
     patchesApplied: 200,
     idempotentPatches: 0,
+    filesSkippedAsUnchanged: 0,
     parseErrors: 0,
     commitErrors: 0,
   };
@@ -332,6 +369,7 @@ describe('describeRegionlessCompletedMap', () => {
       filesDiscovered: 2,
       patchesApplied: 2,
       idempotentPatches: 0,
+      filesSkippedAsUnchanged: 0,
       parseErrors: 0,
       commitErrors: 0,
     }, '/workspace/mixed', invalidate);

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -912,7 +912,6 @@ export type CommitOutcome =
   | { kind: "warn"; message: string }
   | { kind: "fatal"; message: string };
 
-/** Minimal local-ingest facts needed by commands that continue after ingestion. */
 /**
  * The wire value the backend sends for a commit it short-circuited because it
  * had already recorded the patch id — `CommitStatus.Idempotent.toString` in
@@ -920,6 +919,15 @@ export type CommitOutcome =
  */
 const COMMIT_STATUS_IDEMPOTENT = 'Idempotent';
 
+/**
+ * The wire value for a commit the backend refused because the optimistic
+ * base-rev check lost a race — `CommitStatus.BaseRevMismatch`. It writes
+ * nothing, exactly like `Idempotent`, but unlike `Idempotent` it means the
+ * work still needs doing.
+ */
+const COMMIT_STATUS_BASE_REV_MISMATCH = 'BaseRevMismatch';
+
+/** Minimal local-ingest facts needed by commands that continue after ingestion. */
 export interface IngestFilesSummary {
   filesDiscovered: number;
   patchesApplied: number;
@@ -927,13 +935,40 @@ export interface IngestFilesSummary {
    * How many of `patchesApplied` the backend answered `Idempotent` — it had
    * already recorded that patch id, so the commit wrote nothing.
    *
-   * Normally uninteresting: `--full` re-submits every file, so an unchanged
-   * repo legitimately deduplicates everything against a graph that is already
-   * correct. It matters only when the graph turns out to be EMPTY afterwards,
-   * because then the deduplication is the reason nothing was written rather
-   * than a sign that nothing needed to be (#527).
+   * Normally uninteresting: `ix ingest --force` re-submits every file (and a
+   * lost or blank local baseline has the same effect against a backend that
+   * still holds the patch records), so a repo whose graph is already correct
+   * legitimately deduplicates everything. Note `ix map --full` is NOT such a
+   * case — it forwards `full` to the backend map and never sets `force` on the
+   * ingest below it, so it re-submits nothing.
+   *
+   * It matters only when the graph turns out to be EMPTY afterwards, because
+   * then the deduplication is the reason nothing was written rather than a
+   * sign that nothing needed to be (#527).
    */
   idempotentPatches: number;
+  /**
+   * Files this run skipped because they were already unchanged — mtime-clean
+   * against the local baseline, or hash-clean against the backend.
+   *
+   * Load-bearing for the #527 diagnosis, not informational. `idempotentPatches`
+   * only describes the patches a run actually submitted; it says nothing about
+   * the files the run never submitted, and those are what separate a graph
+   * deleted under its own patch records from a graph that is simply fine. A run
+   * in the #527 state skips nothing here: the DB-reset guard clears the mtime
+   * cache and the hash lookup comes back empty, so every file is re-submitted
+   * and every one is answered `Idempotent`. A run that skipped even one file as
+   * unchanged has proof the backend still holds that file's source hash, and
+   * therefore its nodes.
+   *
+   * Counts only the unchanged skips — empty, oversized and minified files are
+   * skipped for reasons that carry no such proof. It is the same counter the
+   * stitch-completeness gate reads, which also means it inherits that counter's
+   * Path-B reset: a run with no baseline re-reads and re-hashes every file, so
+   * the stat loop's mtime skips did not actually happen and are subtracted
+   * back out. That is the shape a #527 run has, and it is exactly right here.
+   */
+  filesSkippedAsUnchanged: number;
   parseErrors: number;
   commitErrors: number;
   stitchErrors: number;
@@ -2124,6 +2159,12 @@ export async function ingestFiles(
                 recordMs(chunkMs);
                 timings.fallbackCommitMs += chunkMs;
                 latestRev = advanceRev(latestRev, result.rev);
+                // See onBulkCommitted: a lost base-rev race wrote nothing and
+                // must not be reported as applied.
+                if (result.status === COMMIT_STATUS_BASE_REV_MISMATCH) {
+                  commitErrors++;
+                  continue;
+                }
                 patchesApplied++;
                 patchesTheBackendTook++;
                 commitBreaker.recordSuccess();
@@ -2441,6 +2482,21 @@ export async function ingestFiles(
             },
             onBulkCommitted: (items, result) => {
               latestRev = advanceRev(latestRev, result.rev);
+              // `BaseRevMismatch` wrote nothing: the backend read the latest rev
+              // outside the transaction and it moved before the commit ran. It
+              // is a lost race, not a replay, so it must not count as applied —
+              // and it belongs in commitErrors, because that is what stops
+              // `persistIngestBaselineIfClean` caching these files as unchanged
+              // and leaving them missing from the graph until the next edit.
+              if (result.status === COMMIT_STATUS_BASE_REV_MISMATCH) {
+                commitErrors += items.length;
+                if (debug) {
+                  process.stderr.write(
+                    `\n  [commit lost the base-rev race] ${items.length} patches wrote nothing; they will be re-sent next run\n`
+                  );
+                }
+                return;
+              }
               patchesApplied += items.length;
               patchesTheBackendTook += items.length;
               commitBreaker.recordSuccess();
@@ -3359,6 +3415,7 @@ export async function ingestFiles(
     filesDiscovered,
     patchesApplied,
     idempotentPatches,
+    filesSkippedAsUnchanged,
     // `+ crashedParses()`, as the baseline and delete guards already do. Files
     // lost to a dead parse pool raise `filesSkippedUnparsed`, never
     // `parseErrors`, so without this everything downstream read the run as

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -913,9 +913,27 @@ export type CommitOutcome =
   | { kind: "fatal"; message: string };
 
 /** Minimal local-ingest facts needed by commands that continue after ingestion. */
+/**
+ * The wire value the backend sends for a commit it short-circuited because it
+ * had already recorded the patch id — `CommitStatus.Idempotent.toString` in
+ * `PatchCommitRoutes` / `BulkPatchCommitRoutes`.
+ */
+const COMMIT_STATUS_IDEMPOTENT = 'Idempotent';
+
 export interface IngestFilesSummary {
   filesDiscovered: number;
   patchesApplied: number;
+  /**
+   * How many of `patchesApplied` the backend answered `Idempotent` — it had
+   * already recorded that patch id, so the commit wrote nothing.
+   *
+   * Normally uninteresting: `--full` re-submits every file, so an unchanged
+   * repo legitimately deduplicates everything against a graph that is already
+   * correct. It matters only when the graph turns out to be EMPTY afterwards,
+   * because then the deduplication is the reason nothing was written rather
+   * than a sign that nothing needed to be (#527).
+   */
+  idempotentPatches: number;
   parseErrors: number;
   commitErrors: number;
   stitchErrors: number;
@@ -1568,6 +1586,7 @@ export async function ingestFiles(
   let filesDiscovered = 0;
   let filesChanged = 0;
   let patchesApplied = 0;
+  let idempotentPatches = 0;
   let filesSkipped = 0;
   /**
    * Files skipped because we ASSUMED THEY WERE UNCHANGED. (Ix#568)
@@ -2108,6 +2127,7 @@ export async function ingestFiles(
                 patchesApplied++;
                 patchesTheBackendTook++;
                 commitBreaker.recordSuccess();
+                if (result.status === COMMIT_STATUS_IDEMPOTENT) idempotentPatches++;
                 opts?.onCommitted?.(item, result.rev);
               } catch (commitErr) {
                 // Counted apart from parseErrors: a patch that parsed fine and
@@ -2255,6 +2275,13 @@ export async function ingestFiles(
             patchesApplied += chunk.length;
             patchesTheBackendTook += chunk.length;
             commitBreaker.recordSuccess();
+            // The cutoff drain is a third commit site, added after this counter
+            // was written (Ix#571). It is a plain bulk commit carrying a status,
+            // so it counts like the other one -- a run whose held patches were
+            // all placed here and all deduplicated would otherwise report
+            // `idempotentPatches: 0` and fall back to the language hypothesis
+            // this change exists to retire.
+            if (result.status === COMMIT_STATUS_IDEMPOTENT) idempotentPatches += chunk.length;
             for (const item of chunk) opts?.onCommitted?.(item, result.rev);
             if (debug) process.stderr.write(`  [cutoff] bulk placed ${chunk.length} of ${items.length} held
 `);
@@ -2417,6 +2444,9 @@ export async function ingestFiles(
               patchesApplied += items.length;
               patchesTheBackendTook += items.length;
               commitBreaker.recordSuccess();
+              // One status covers the whole bulk: the backend commits the chunk
+              // as a unit, so `Idempotent` means every patch in it was a replay.
+              if (result.status === COMMIT_STATUS_IDEMPOTENT) idempotentPatches += items.length;
               for (const item of items) opts?.onCommitted?.(item, result.rev);
             },
             commitIndividually,
@@ -3328,6 +3358,7 @@ export async function ingestFiles(
   const summary: IngestFilesSummary = {
     filesDiscovered,
     patchesApplied,
+    idempotentPatches,
     // `+ crashedParses()`, as the baseline and delete guards already do. Files
     // lost to a dead parse pool raise `filesSkippedUnparsed`, never
     // `parseErrors`, so without this everything downstream read the run as
@@ -3409,6 +3440,7 @@ export async function ingestFiles(
       filesChanged,
       patchesApplied,
       filesSkipped,
+      idempotentPatches,
       entitiesParsed,
       latestRev,
       // `unchanged` is the files we ASSUMED unchanged, not every skip. It used

--- a/ix-cli/src/cli/commands/map.ts
+++ b/ix-cli/src/cli/commands/map.ts
@@ -154,7 +154,7 @@ export function describeEmptyCompletedMap(
   ingest:
     | Pick<
         IngestFilesSummary,
-        "filesDiscovered" | "patchesApplied" | "idempotentPatches" | "parseErrors" | "commitErrors"
+        "filesDiscovered" | "patchesApplied" | "idempotentPatches" | "filesSkippedAsUnchanged" | "parseErrors" | "commitErrors"
       >
     | undefined,
 ): string | undefined {
@@ -178,7 +178,17 @@ export function describeEmptyCompletedMap(
   // idempotency keys, so the identical re-ingest was accepted as a replay and
   // committed nothing (Ix-memory#174). Those keys expire after 24h, which is
   // why waiting is a real workaround and worth saying out loud.
-  if (patches > 0 && ingest.idempotentPatches >= patches) {
+  // `filesSkippedAsUnchanged === 0` is load-bearing, not a belt-and-braces extra.
+  // `idempotentPatches >= patches` only says every patch this run *submitted*
+  // was a replay; it says nothing about the files the run never submitted, and
+  // those are what disprove the diagnosis. A workspace on a language the
+  // backend cannot build a hierarchy for skips its 99 clean files, and one
+  // reverted file whose content was ingested before commits as `Idempotent` —
+  // giving patches === 1, idempotentPatches === 1, file_count === 0 with a
+  // graph that is perfectly intact and a 24-hour wait that changes nothing.
+  // A real #527 run skips nothing: the DB-reset guard clears the mtime cache
+  // and the hash lookup comes back empty, so every file is re-submitted.
+  if (patches > 0 && ingest.idempotentPatches >= patches && ingest.filesSkippedAsUnchanged === 0) {
     return `Backend reported ${result.outcome}, but mapped 0 files after local ingest found ${files}. The backend answered every one of the ${patches} committed ${patchWord} with 'already applied', so this run wrote nothing — the graph is empty because the commits were deduplicated against patch records the backend still holds, not because the source could not be parsed. That is what a workspace whose graph was deleted without its patch records looks like; the records expire within 24 hours, or an upgraded backend clears them with the reset. ${tail}`;
   }
 
@@ -273,7 +283,7 @@ export function invalidateBaselineForIncompleteCompletedMap(
   ingest:
     | Pick<
         IngestFilesSummary,
-        "filesDiscovered" | "patchesApplied" | "idempotentPatches" | "parseErrors" | "commitErrors"
+        "filesDiscovered" | "patchesApplied" | "idempotentPatches" | "filesSkippedAsUnchanged" | "parseErrors" | "commitErrors"
       >
     | undefined,
   projectRoot: string,

--- a/ix-cli/src/cli/commands/map.ts
+++ b/ix-cli/src/cli/commands/map.ts
@@ -151,7 +151,12 @@ const COMPLETED_MAP_OUTCOMES = new Set([
  */
 export function describeEmptyCompletedMap(
   result: Pick<MapResult, "file_count" | "region_count" | "regions" | "outcome">,
-  ingest: Pick<IngestFilesSummary, "filesDiscovered" | "patchesApplied" | "parseErrors" | "commitErrors"> | undefined,
+  ingest:
+    | Pick<
+        IngestFilesSummary,
+        "filesDiscovered" | "patchesApplied" | "idempotentPatches" | "parseErrors" | "commitErrors"
+      >
+    | undefined,
 ): string | undefined {
   if (!ingest || ingest.filesDiscovered <= 0 || ingest.parseErrors > 0 || ingest.commitErrors > 0) {
     return undefined;
@@ -161,7 +166,23 @@ export function describeEmptyCompletedMap(
 
   const sourceFiles = ingest.filesDiscovered;
   const patches = ingest.patchesApplied;
-  return `Backend reported ${result.outcome}, but mapped 0 files after local ingest found ${sourceFiles} supported source ${sourceFiles === 1 ? "file" : "files"} (${patches} ${patches === 1 ? "patch" : "patches"} committed). The source graph was ingested, but no architecture hierarchy was created. The active backend may not map this source language yet. The source ingest baseline was preserved, so the next 'ix map' can reuse unchanged files.`;
+  const files = `${sourceFiles} supported source ${sourceFiles === 1 ? "file" : "files"}`;
+  const patchWord = patches === 1 ? "patch" : "patches";
+  const tail = "The source ingest baseline was preserved, so the next 'ix map' can reuse unchanged files.";
+
+  // The backend deduplicated every commit, so this run wrote nothing at all —
+  // and the two sentences below are then both false: nothing was ingested, and
+  // the language had no chance to be the reason (#527). The observed cause is a
+  // graph deleted out from under the backend's own patch records: a scoped
+  // reset used to remove a workspace's nodes and patches while leaving its
+  // idempotency keys, so the identical re-ingest was accepted as a replay and
+  // committed nothing (Ix-memory#174). Those keys expire after 24h, which is
+  // why waiting is a real workaround and worth saying out loud.
+  if (patches > 0 && ingest.idempotentPatches >= patches) {
+    return `Backend reported ${result.outcome}, but mapped 0 files after local ingest found ${files}. The backend answered every one of the ${patches} committed ${patchWord} with 'already applied', so this run wrote nothing — the graph is empty because the commits were deduplicated against patch records the backend still holds, not because the source could not be parsed. That is what a workspace whose graph was deleted without its patch records looks like; the records expire within 24 hours, or an upgraded backend clears them with the reset. ${tail}`;
+  }
+
+  return `Backend reported ${result.outcome}, but mapped 0 files after local ingest found ${files} (${patches} ${patchWord} committed). The source graph was ingested, but no architecture hierarchy was created. The active backend may not map this source language yet. ${tail}`;
 }
 
 /**
@@ -249,7 +270,12 @@ function emitDroppedFileWarning(
  */
 export function invalidateBaselineForIncompleteCompletedMap(
   result: Pick<MapResult, "file_count" | "region_count" | "regions" | "outcome">,
-  ingest: Pick<IngestFilesSummary, "filesDiscovered" | "patchesApplied" | "parseErrors" | "commitErrors"> | undefined,
+  ingest:
+    | Pick<
+        IngestFilesSummary,
+        "filesDiscovered" | "patchesApplied" | "idempotentPatches" | "parseErrors" | "commitErrors"
+      >
+    | undefined,
   projectRoot: string,
   invalidate: (root: string) => void = clearMapBaseline,
 ): string | undefined {


### PR DESCRIPTION
Addresses the CLI half of #527. The write that gets swallowed is a backend bug — ix-infrastructure/Ix-memory#177 fixes that — but what `ix map` *says* about it is ours, and today it points at the wrong thing.

## Problem

`describeEmptyCompletedMap` has one hypothesis for a completed-but-empty map and states it as a conclusion:

> Backend reported full_local_completed, but mapped 0 files after local ingest found 1 supported source file (1 patch committed). **The source graph was ingested**, but no architecture hierarchy was created. **The active backend may not map this source language yet.**

For #527 both bolded claims are false. The backend answered the commit `Idempotent` — it still held the patch record for a graph that had been deleted underneath it — so the run wrote nothing. The TypeScript parsed fine; it never reached the graph to be mapped. A reader who trusts this message goes looking at language support, which is the one thing that was never involved.

## Why the CLI can tell the difference

It already has the answer and throws it away. `PatchCommitResult.status` is on the wire (`CommitStatus.toString` from `PatchCommitRoutes` / `BulkPatchCommitRoutes`), and both commit sites in `ingest.ts` read `result` — they just count every answer as applied:

```ts
latestRev = advanceRev(latestRev, result.rev);
patchesApplied++;                      // Ok and Idempotent, indistinguishable
```

So `ingestFiles` now also counts `idempotentPatches`, and `describeEmptyCompletedMap` uses it. One status covers a whole bulk chunk — the backend commits it as a unit — so `Idempotent` there means every patch in the chunk was a replay.

## The new message

```
Error: Backend reported full_local_completed, but mapped 0 files after local ingest
found 1 supported source file. The backend answered every one of the 1 committed
patch with 'already applied', so this run wrote nothing — the graph is empty because
the commits were deduplicated against patch records the backend still holds, not
because the source could not be parsed. That is what a workspace whose graph was
deleted without its patch records looks like; the records expire within 24 hours, or
an upgraded backend clears them with the reset. The source ingest baseline was
preserved, so the next 'ix map' can reuse unchanged files.
```

The 24h line is a real workaround, not filler: `idempotency_keys` carries a TTL index on `created_at`, so the same command works the next day with no intervention.

## What does not change

- Exit code stays 1 and the architecture baseline is still cleared — it is still a failure, just a different one.
- A **partial** replay (`idempotentPatches < patchesApplied`) keeps the existing wording; only "every commit was a replay" is unambiguous enough to assert.
- `patchesApplied === 0` — the hash-skip path — keeps it too, and is guarded explicitly because `idempotentPatches >= patchesApplied` is trivially true at zero.
- A `--full` re-map of an intact graph deduplicates every commit as well, but it maps files, so `file_count !== 0` returns before any of this. Checked live, not just reasoned about (below).

`idempotentPatches` also joins `ix ingest --format json`, beside `commitErrors`.

## Verification

`ix` built from this branch, memory layer run from source at `Ix-memory@main` (i.e. **without** the backend fix), following #527's steps.

```
run 1                                    map: 1 files
POST /v1/reset/workspace                 {"ok":true,"message":"Workspace data deleted."}
db after reset                           {nodes: 0, keys: 1}      ← the stale record
re-map                                   Error: ...answered every one of the 1 committed
                                         patch with 'already applied'...
ix ingest --format json                  patchesApplied 1, idempotentPatches 1, commitErrors 0
```

Regression case — full re-map of an **intact** graph, baseline cleared so every file is re-submitted and every commit deduplicates:

```json
{ "file_count": 1, "region_count": 0, "outcome": "full_local_completed",
  "parse_errors": 0, "commit_errors": 0 }        exit 0
```

Gate: **1512 passed / 2 skipped** (89 files), parser smoke passed, `typecheck` clean, `lint` 0 errors (41 pre-existing warnings).

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YhVFQVEcbJZRNjpsNmxer
