### PR TITLE
docs: document ix savings, its flags, and its llm records

### DIFF
--- a/docs/llm-format.md
+++ b/docs/llm-format.md
@@ -171,6 +171,20 @@ of two field sets it is holding. `saved_at` is on it because the `context`
 record that follows says whether the snapshot was fresh when it was taken, not
 when that was.
 
+`ix savings --detail`:
+
+```
+savings model="Claude Opus ($15/MTok in, $75/MTok out)"
+scope name=session commands=726 tokens_saved=832739 naive_tokens=1099164 actual_tokens=266425 money_saved=27.48 water_saved_ml=1665.478
+scope name=lifetime commands=4820 tokens_saved=6142880 naive_tokens=8003104 actual_tokens=1860224 money_saved=202.71 water_saved_ml=12285.76
+command scope=session name=callers count=329 tokens_saved=334995
+```
+
+The two `scope` records are always emitted; `command` records appear only under
+`--detail` and carry their own `scope=` because both scopes are broken down in
+one stream. `money_saved` is the only field `--model` moves — the token and
+water figures are model-independent.
+
 Error line:
 
 ```

--- a/docs/llm-format.md
+++ b/docs/llm-format.md
@@ -176,14 +176,22 @@ when that was.
 ```
 savings model="Claude Opus ($15/MTok in, $75/MTok out)"
 scope name=session commands=726 tokens_saved=832739 naive_tokens=1099164 actual_tokens=266425 money_saved=27.48 water_saved_ml=1665.478
-scope name=lifetime commands=4820 tokens_saved=6142880 naive_tokens=8003104 actual_tokens=1860224 money_saved=202.71 water_saved_ml=12285.76
 command scope=session name=callers count=329 tokens_saved=334995
+scope name=lifetime commands=4820 tokens_saved=6142880 naive_tokens=8003104 actual_tokens=1860224 money_saved=202.72 water_saved_ml=12285.76
+command scope=lifetime name=callers count=2104 tokens_saved=2210488
 ```
+
+(Truncated: one `command` record is shown per scope, and a real run emits one
+per entry in that scope's breakdown.)
 
 The two `scope` records are always emitted; `command` records appear only under
 `--detail` and carry their own `scope=` because both scopes are broken down in
-one stream. `money_saved` is the only field `--model` moves — the token and
-water figures are model-independent.
+one stream. They are emitted inside the scope loop, so they follow their own
+`scope` record rather than being grouped at the end — a parser reading the
+stream in order sees session's breakdown before the lifetime `scope` line.
+
+`money_saved` is the only field `--model` moves — the token and water figures
+are model-independent.
 
 Error line:
 

--- a/skills/ix/references/commands.md
+++ b/skills/ix/references/commands.md
@@ -65,6 +65,43 @@ These aggregate multiple graph operations into single bounded responses.
 | Start backend | `ix docker start` | `ix docker start` |
 | Graph statistics | `ix stats` | `ix stats --format json` |
 
+## Session Metrics
+
+| Goal | Command | Example |
+|---|---|---|
+| Token savings so far | `ix savings` | `ix savings --format llm` |
+| Per-command breakdown | `ix savings --detail` | `ix savings --detail --format llm` |
+| Clear lifetime totals | `ix savings reset` | `ix savings reset` |
+
+`ix savings` reports how many tokens the graph saved against a naive
+read-the-files baseline, in two scopes — `session` (this shell's commands) and
+`lifetime` (every command against this backend). Each scope carries the command
+count, `tokens_saved`, the `naive_tokens` / `actual_tokens` it was derived
+from, and money and water estimates.
+
+| Flag | Value | Default | Effect |
+|---|---|---|---|
+| `--detail` | — | off | Add one record per command type, within each scope |
+| `--model <model>` | `opus\|sonnet\|haiku\|gpt-4o` | `opus` | Pricing table for `money_saved` only — token and water figures do not change |
+| `--format <fmt>` | `text\|json\|llm` | `text` | See references/output-formats.md |
+
+`ix savings reset` clears the **lifetime** totals (`DELETE /v1/savings`). It
+takes no flags and does not prompt.
+
+`--format llm` emits one `savings` header record and one `scope` record per
+scope; `--detail` adds `command` records that name their scope:
+
+```
+savings model="Claude Opus ($15/MTok in, $75/MTok out)"
+scope name=session commands=726 tokens_saved=832739 naive_tokens=1099164 actual_tokens=266425 money_saved=27.48 water_saved_ml=1665.478
+scope name=lifetime commands=4820 tokens_saved=6142880 naive_tokens=8003104 actual_tokens=1860224 money_saved=202.71 water_saved_ml=12285.76
+command scope=session name=callers count=329 tokens_saved=334995
+command scope=session name=entity count=308 tokens_saved=423741
+```
+
+Reading a graph command's savings needs the backend up: the numbers come from
+`GET /v1/savings`, not from a local file.
+
 ## Decomposition Recipes
 
 **"How does ingestion work?"**

--- a/skills/ix/references/commands.md
+++ b/skills/ix/references/commands.md
@@ -74,19 +74,26 @@ These aggregate multiple graph operations into single bounded responses.
 | Clear lifetime totals | `ix savings reset` | `ix savings reset` |
 
 `ix savings` reports how many tokens the graph saved against a naive
-read-the-files baseline, in two scopes — `session` (this shell's commands) and
-`lifetime` (every command against this backend). Each scope carries the command
-count, `tokens_saved`, the `naive_tokens` / `actual_tokens` it was derived
-from, and money and water estimates.
+read-the-files baseline, in two scopes. Neither is per-terminal: the CLI sends a
+bare `GET /v1/savings` with no session id, so the backend has nothing to
+attribute a count to one shell with. `session` is an in-memory counter the
+backend process has accumulated since it started, **shared by every client that
+talks to it**; `lifetime` is the persisted total. So a fresh shell against a
+backend that has been up all day reads that day's traffic from every other
+shell as its "session". Each scope carries the command count, `tokens_saved`,
+the `naive_tokens` / `actual_tokens` it was derived from, and money and water
+estimates.
 
 | Flag | Value | Default | Effect |
 |---|---|---|---|
 | `--detail` | — | off | Add one record per command type, within each scope |
 | `--model <model>` | `opus\|sonnet\|haiku\|gpt-4o` | `opus` | Pricing table for `money_saved` only — token and water figures do not change |
-| `--format <fmt>` | `text\|json\|llm` | `text` | See references/output-formats.md |
+| `--format <fmt>` | `text\|json\|llm` | `text` | See output-formats.md |
 
-`ix savings reset` clears the **lifetime** totals (`DELETE /v1/savings`). It
-takes no flags and does not prompt.
+`ix savings reset` clears **both** scopes (`DELETE /v1/savings`, which runs
+`session.set(empty) *> store.resetSavings`). It takes no flags, does not prompt,
+and cannot be undone — there is no way to zero one scope and keep the other,
+despite the CLI's own "Reset lifetime savings totals" description.
 
 `--format llm` emits one `savings` header record and one `scope` record per
 scope; `--detail` adds `command` records that name their scope:
@@ -94,10 +101,15 @@ scope; `--detail` adds `command` records that name their scope:
 ```
 savings model="Claude Opus ($15/MTok in, $75/MTok out)"
 scope name=session commands=726 tokens_saved=832739 naive_tokens=1099164 actual_tokens=266425 money_saved=27.48 water_saved_ml=1665.478
-scope name=lifetime commands=4820 tokens_saved=6142880 naive_tokens=8003104 actual_tokens=1860224 money_saved=202.71 water_saved_ml=12285.76
 command scope=session name=callers count=329 tokens_saved=334995
 command scope=session name=entity count=308 tokens_saved=423741
+scope name=lifetime commands=4820 tokens_saved=6142880 naive_tokens=8003104 actual_tokens=1860224 money_saved=202.72 water_saved_ml=12285.76
+command scope=lifetime name=callers count=2104 tokens_saved=2210488
 ```
+
+`command` records are emitted inside the scope loop, so each scope's breakdown
+follows its own `scope` record rather than being grouped at the end. (Truncated
+above: a real run emits one `command` record per entry in each breakdown.)
 
 Reading a graph command's savings needs the backend up: the numbers come from
 `GET /v1/savings`, not from a local file.


### PR DESCRIPTION
Closes #573.

Confirmed the finding before writing anything. `savings` on `main` (`a2cab21`):

| surface | mentions |
|---|---|
| `docs/api/README.md` | 6 — but those are the **backend** endpoints, `GET`/`DELETE /v1/savings` |
| `docs/llm-format.md` | 1 — its name in the Tier-5 list, nothing about the output |
| `skills/ix/SKILL.md`, `references/*.md`, `README.md`, `CLAUDE.md`, `CONTRIBUTING.md` | **0** |

Meanwhile `registerSavingsCommand` ships `--detail`, `--model <model>`, `--format <fmt>`, a `reset` subcommand, and `renderSavingsLlm`. The llm-format promise is what makes this load-bearing rather than cosmetic: the doc tells agents `--format llm` works on every command it lists, `savings` is on that list, and nothing said what came back.

## Change

**`skills/ix/references/commands.md`** — a `## Session Metrics` section: routing rows in the same shape as the other tables, what the `session` and `lifetime` scopes actually mean, a flag table with values and defaults, `ix savings reset`, and the llm record shape.

**`docs/llm-format.md`** — an `ix savings --detail` example beside the other per-command examples, placed before the `Error line:` block so that lead-in still owns the snippet under it. Plus the two things the shape does not show on its own:

- `command` records appear **only** under `--detail`, and carry their own `scope=` because both scopes are broken down into one flat stream.
- `--model` moves `money_saved` and nothing else — token and water figures are model-independent. Verified: `--model sonnet` on identical data gives `money_saved=5.50` against opus's `27.48`, with `tokens_saved` and `water_saved_ml` byte-identical.

## Sourcing

Flags, defaults and choices come from the registered commander tree, not from prose; the HTTP calls from `IxClient.savings` / `savingsReset` (`GET /v1/savings?detail=true`, `DELETE /v1/savings`), which matches `docs/api/README.md`. Record shapes are real `ix savings --format llm` output against a live backend, with the sample figures swapped for modest ones rather than publishing a real account's lifetime totals.

Documentation only — no source, no tests, no behaviour touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YhVFQVEcbJZRNjpsNmxer
