### PR TITLE
fix(deps): bump fast-uri to 3.1.7 for four HIGH CVEs

### DIFF
--- a/ix-cli/package-lock.json
+++ b/ix-cli/package-lock.json
@@ -3165,9 +3165,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
`Trivy (repo)` is currently failing on **every** PR in this repo, including documentation-only ones. It is not the PRs.

```
Total: 4 (HIGH: 4, CRITICAL: 0)
fast-uri  3.1.5  →  fixed in 2.4.5, 3.1.6, 4.1.3
  CVE-2026-75899  SSRF via repeated hostname percent-decoding
  CVE-2026-75931  host confusion via skipped IDN canonicalization
  CVE-2026-75975  SSRF via malformed IPv6 normalization
  CVE-2026-76172  URI parsing flaw enabling SSRF and redirects
```

Two things confirm it is the advisory database moving, not a change under review: a PR scanned an hour earlier passes on the same dependency tree, and it fires on a branch that touches only markdown.

## Scope

`fast-uri` is transitive. Two nested copies of ajv — under `@modelcontextprotocol/sdk` and `ajv-formats` — require `^3.0.1`, which 3.1.7 already satisfies, so `package.json` does not change and the lockfile is the entire fix.

It is also the only finding in the repo. Trivy's own summary:

```
│ core-ingestion/package-lock.json │ npm │ 0 │
│ ix-cli/package-lock.json         │ npm │ 4 │
```

## Why this is a hand-edit and not `npm update`'s output

The npm on hand (10.9.7) is older than the one that wrote this lockfile, and rewriting it drops the `libc` fields from **23** optional platform packages:

```
-      "libc": [
-        "glibc"
-      ],
```

That would quietly change musl/glibc package selection as a side effect of a security bump, which is not a thing to slip into an unrelated PR. So the three lines npm resolved are applied on their own and everything else is byte-identical. The integrity hash is what the registry serves for 3.1.7:

```
$ curl -s https://registry.npmjs.org/fast-uri/3.1.7 | jq -r .dist.integrity
sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==
```

3.1.7 rather than 3.1.6 because that is what `npm update` resolves within the existing range; both clear all four advisories.

## Verification

- `npm ci` against this lockfile in a clean directory: **exit 0**, installs `fast-uri 3.1.7`. That is itself the integrity check — `npm ci` verifies the hash and would fail hard on a wrong one.
- CLI suite run against **that** install, not the pre-existing one: **89 files, 1509 passed, 2 skipped**, parser smoke passed. ajv is what pulls `fast-uri` in, and the `ix-context-bundle/1` validation tests exercise it.

## Type
- [x] Bug fix

## Checklist
- [x] Tests pass
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YhVFQVEcbJZRNjpsNmxer
