### PR TITLE
fix: drop the trailing slash from the remaining artifact ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,10 +20,15 @@ target/
 # ix-cli/node_modules in #545 and stayed tracked until #567. Without the slash
 # the rule matches the entry whatever its type, at any depth, which also makes
 # the two package-specific lines that used to sit here redundant.
+#
+# The same applies to the build outputs below. A symlinked `dist` is how a git
+# worktree borrows a build from the main clone -- the same practice that
+# produced the node_modules symlink -- so a directory-only rule there leaves
+# exactly the defect above open under a different name.
 node_modules
-core-ingestion/dist/
-ix-cli/dist/
-ix-cli/coverage/
+core-ingestion/dist
+ix-cli/dist
+ix-cli/coverage
 
 # watch-dedup.test.ts used to build a throwaway CLI into
 # ix-cli/.watch-child-runtime-*; it now builds inside node_modules/.cache,

--- a/ix-cli/src/cli/__tests__/watch-dedup.test.ts
+++ b/ix-cli/src/cli/__tests__/watch-dedup.test.ts
@@ -183,12 +183,29 @@ describe("canonical watch refresh", () => {
       // committable `ix-cli/node_modules` symlink of #545 with it. A path that
       // does not exist is not a directory as far as git is concerned, so only a
       // rule without the trailing slash matches it.
-      const nonDirectory = path.join(packageRoot, "__ix_ignore_probe__", "node_modules");
-      expect(fs.existsSync(nonDirectory), "probe path must not exist").toBe(false);
-      expect(
-        sourceOf(explain(nonDirectory)),
-        "the node_modules ignore rule is directory-only again; a symlink or file named node_modules is committable (Ix#545)",
-      ).toBe(".gitignore");
+      //
+      // Every artifact rule, not only node_modules: a symlinked `dist` is how a
+      // worktree borrows a build from the main clone, which is the same practice
+      // that produced the committed node_modules symlink. Probing one rule would
+      // let the other three regress silently, which is how they were left
+      // directory-only when node_modules was fixed.
+      const repoRootOf = (p: string): string => path.resolve(packageRoot, "..", p);
+      const probes: [string, string][] = [
+        [path.join(packageRoot, "__ix_ignore_probe__", "node_modules"), "node_modules"],
+        [repoRootOf("ix-cli/dist"), "ix-cli/dist"],
+        [repoRootOf("ix-cli/coverage"), "ix-cli/coverage"],
+        [repoRootOf("core-ingestion/dist"), "core-ingestion/dist"],
+      ];
+      for (const [probe, rule] of probes) {
+        // An existing directory matches a trailing-slash rule too, so a probe
+        // that happens to be a real build directory proves nothing. Ask about a
+        // sibling path that cannot exist instead.
+        const target = fs.existsSync(probe) ? path.join(probe, "__ix_ignore_probe__") : probe;
+        expect(
+          sourceOf(explain(target)),
+          `the '${rule}' ignore rule is directory-only again; a symlink or file with that name is committable (Ix#545)`,
+        ).toBe(".gitignore");
+      }
     } else {
       expect(path.relative(packageRoot, cacheRoot).split(path.sep)[0]).toBe("node_modules");
     }


### PR DESCRIPTION
**Rescoped after #569 merged.** That PR landed the untrack and the `node_modules` rule an hour ago, so this is now only the part it stopped short of.

## What is left

#569 states the rule exactly — a trailing slash matches **directories only**, so it does not cover a *symlink* named `node_modules`, which is how an absolute path into a contributor's home directory came to be committed. It fixed that one line. The three below it kept the slash:

```
core-ingestion/dist/
ix-cli/dist/
ix-cli/coverage/
```

so the identical defect stayed open under a different name:

```console
$ ln -s /tmp ix-cli/dist
$ git status --short -- ix-cli/dist
?? ix-cli/dist
```

Not a hypothetical shape: a symlinked `dist` is how a git worktree borrows a build from the main clone — the same practice that produced the `node_modules` symlink in the first place.

## Change

Three characters of `.gitignore`, plus the comment above them extended to say the reasoning covers build outputs too.

And #569's regression test now probes **all four** rules rather than `node_modules` alone — it would have stayed green through every line of this. One wrinkle worth the extra line: an existing directory matches a trailing-slash rule perfectly well, so probing `ix-cli/dist` where a real build lives proves nothing. The test asks about a non-existent sibling in that case.

## Verified

```console
$ git check-ignore -v --no-index <each rule>
.gitignore:28:node_modules          ix-cli/__ix_ignore_probe__/node_modules
.gitignore:29:core-ingestion/dist   core-ingestion/dist
.gitignore:30:ix-cli/dist           ix-cli/dist
.gitignore:31:ix-cli/coverage       ix-cli/coverage
```

With real symlinks at all three paths, `git status` reports only this change; before it, each showed as untracked.

## One thing for a follow-up, not this PR

#569's `builds the child CLI somewhere git cannot see` test cannot run in a checkout whose `ix-cli/node_modules` is itself a symlink:

```console
$ git check-ignore -v --no-index ix-cli/node_modules/.cache
fatal: pathspec 'ix-cli/node_modules/.cache' is beyond a symbolic link
```

`git check-ignore` refuses any path beyond a symlink, so `explain()` returns `""` and the `cacheRoot` assertion fails. Identical on unmodified `main`, so it is not from this change — and it is unreachable in CI, where `npm ci` creates a real directory. But it fails in exactly the worktree layout #569 was diagnosing, which is worth knowing before someone chases it as a flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YhVFQVEcbJZRNjpsNmxer
