### PR TITLE
docs: fix the dead backend repo link, and say what external contributors do

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,5 +24,5 @@ How did you test this?
 ## Release checklist (if merging to main)
 - [ ] `ix-cli/package.json` version bumped
 - [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
-- [ ] If backend changes: `ix-memory-layer` tagged and released first
+- [ ] If backend changes: `ix-memory-layer` tagged and released first (maintainers only — see [Backend Development](../CONTRIBUTING.md#backend-development))
 - [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,5 +24,5 @@ How did you test this?
 ## Release checklist (if merging to main)
 - [ ] `ix-cli/package.json` version bumped
 - [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
-- [ ] If backend changes: `ix-memory-layer` tagged and released first (maintainers only — see [Backend Development](../CONTRIBUTING.md#backend-development))
+- [ ] If backend changes: `ix-memory-layer` tagged and released first (maintainers only — see [Backend Development](https://github.com/ix-infrastructure/Ix/blob/main/CONTRIBUTING.md#backend-development))
 - [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ name: Release
 #   and linux-arm64. Each platform must build its own native binding.
 #
 # Note: The Scala backend (memory-layer) is built and released separately
-# from the private ix-memory-layer repo. Docker images are pushed to
+# from the private Ix-memory repo. Docker images are pushed to
 # ghcr.io/ix-infrastructure/ix-memory-layer from that repo.
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,4 +30,4 @@ jobs:
           exit-code: 1
           scanners: vuln,misconfig
 
-  # Docker image scanning is handled in the private ix-memory-layer repo
+  # Docker image scanning is handled in the private Ix-memory repo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,15 +155,18 @@ All checks fail on CRITICAL or HIGH severity findings. If a check fails on your 
 The Scala memory-layer backend is developed in a separate, **private** repository
 (`ix-infrastructure/Ix-memory`). Its source is not publicly accessible, so cloning
 it is a maintainer-only step. Note that `ix-memory-layer` — the name used in the
-PR template, the release notes and `docker-compose.standalone.yml` — is the
-published *artifact*, not a repository you can clone.
+release notes, `docker-compose.standalone.yml` and the image path in
+`.github/workflows/` — is the published *artifact*, not a repository you can
+clone.
 
 **You do not need the backend source to work on this repository.** Everything in
 the `ix` CLI is developed against the published backend image, which is public and
 pullable anonymously. `./scripts/backend.sh up` in [Local Setup](#local-setup)
 starts it (`ghcr.io/ix-infrastructure/ix-memory-layer:latest` plus ArangoDB, on
-`127.0.0.1:8090` and `:8529`); see [docs/prerequisites.md](docs/prerequisites.md)
-for what it installs and which ports it opens.
+`127.0.0.1:8090` and `:8529`). It installs nothing itself — it runs
+`docker compose -f docker-compose.standalone.yml` against an already-installed
+Docker. What the `curl | sh` *installer* puts on the machine is a separate list:
+[docs/prerequisites.md](docs/prerequisites.md).
 
 If a change you want needs the backend itself — a new endpoint, a different
 response shape, a query that is too slow — open an issue here describing the CLI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,26 @@ All checks fail on CRITICAL or HIGH severity findings. If a check fails on your 
 
 ## Backend Development
 
-The Scala backend (memory-layer) lives in a [separate private repo](https://github.com/ix-infrastructure/ix-memory-layer). For backend changes, clone that repo directly.
+The Scala memory-layer backend is developed in a separate, **private** repository
+(`ix-infrastructure/Ix-memory`). Its source is not publicly accessible, so cloning
+it is a maintainer-only step. Note that `ix-memory-layer` — the name used in the
+PR template, the release notes and `docker-compose.standalone.yml` — is the
+published *artifact*, not a repository you can clone.
+
+**You do not need the backend source to work on this repository.** Everything in
+the `ix` CLI is developed against the published backend image, which is public and
+pullable anonymously. `./scripts/backend.sh up` in [Local Setup](#local-setup)
+starts it (`ghcr.io/ix-infrastructure/ix-memory-layer:latest` plus ArangoDB, on
+`127.0.0.1:8090` and `:8529`); see [docs/prerequisites.md](docs/prerequisites.md)
+for what it installs and which ports it opens.
+
+If a change you want needs the backend itself — a new endpoint, a different
+response shape, a query that is too slow — open an issue here describing the CLI
+behaviour you need and what the backend would have to do. A maintainer will carry
+it across. Please do not open a PR against this repository that assumes an
+endpoint the released backend does not serve. `ix doctor` reports the running
+graph schema version, and `curl -s localhost:8090/v1/health` returns both that
+and the backend's release version — that release is what to write against.
 
 ## OSS vs Pro Boundary
 


### PR DESCRIPTION
Refs #574 — deliberately not `Closes`. #574 names three gaps and this PR fixes
two of them; the `SECURITY.md` line ("has its own reporting channel" with no
channel named) is left alone, and auto-closing the issue would leave an external
reporter with a backend vulnerability nowhere documented to send it, and no
tracker to remind anyone. The report is right, and the underlying fact is
sharper than it says.

## The link is not private — it does not exist

```console
$ gh repo view ix-infrastructure/ix-memory-layer
GraphQL: Could not resolve to a Repository with the name 'ix-infrastructure/ix-memory-layer'.

$ gh repo view ix-infrastructure/Ix-memory
PRIVATE — https://github.com/ix-infrastructure/Ix-memory — Backend for OSS, Ix.
```

That first command runs with a token that *can* see the private backend repo, so this is not a permissions 404 — there is no repository at that path under any visibility. The private repo is `Ix-memory`. `ix-memory-layer` is the published **artifact** name, which is why it is correct in the PR template, `release.yml` and `docker-compose.standalone.yml`, and wrong only as a clone target.

## The path out was already in this file

`CONTRIBUTING.md` > Local Setup already says `./scripts/backend.sh up`, which runs `docker-compose.standalone.yml` against `ghcr.io/ix-infrastructure/ix-memory-layer:latest`. That image is genuinely public — an **anonymous** ghcr token fetches its manifest:

```console
$ TOKEN=$(curl -s "https://ghcr.io/token?scope=repository:ix-infrastructure/ix-memory-layer:pull&service=ghcr.io" | jq -r .token)
$ curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $TOKEN" \
    https://ghcr.io/v2/ix-infrastructure/ix-memory-layer/manifests/latest
200
```

So nobody needs the backend source to work on the CLI. The Backend Development section just never connected the two, and instead sent people to a dead link.

## Change

`CONTRIBUTING.md` — the section now names the real repo, says plainly that cloning it is a maintainer-only step, separates the artifact name from the repo name (so the PR template and compose file stop looking inconsistent), points back at the Local Setup step that already exists, and says what to do when a change genuinely needs the backend: open an issue describing the CLI behaviour, rather than a PR against an endpoint the released backend does not serve.

`.github/PULL_REQUEST_TEMPLATE.md` — the backend line reads as a step every contributor must complete; it is now marked maintainers-only and links to that section.

Every factual claim is checked rather than repeated: the anonymous pull above, `scripts/backend.sh` really using `docker-compose.standalone.yml`, and the version advice. That last one caught a mistake — I first wrote that `ix status` reports the backend release and schema version. It does not; it prints status, endpoint and revision. `ix doctor` reports the schema (`schema v3`), and `/v1/health` returns both:

```console
$ curl -s localhost:8090/v1/health
{"status":"ok","schema_version":3,"release_version":"1.0.28"}
```

## One part left for you

The issue also flags `SECURITY.md`:

> This policy covers the `ix` CLI and the artifacts published from this repository. The memory-layer backend is released from a separate repository and **has its own reporting channel.**

That channel is not named anywhere, and an external reporter cannot use the private repo's advisories tab. The only channels this repo names are its own Security Advisories tab and `security@ix-infra.com`. I have not touched it, because guessing which address should receive backend vulnerability reports is not a documentation edit. Tell me which it is and I will add it — or if `security@ix-infra.com` covers both, that sentence should say so instead of pointing away.

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YhVFQVEcbJZRNjpsNmxer

