### PR TITLE
docs(readme): point the Docs link at the in-repo docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@ target/
 # better kept that way so the intent of each is visible.
 /dist/
 
-# Session/tooling artifacts (Freebuff preview state, generated knowledge graphs)
+# Session/tooling artifacts (preview state, generated knowledge graphs; the
+# desktop tool writes .freebuff/ at session start)
 .freebuff/
 .understand-anything/
 .bsp/

--- a/README.md
+++ b/README.md
@@ -219,10 +219,10 @@ Windows (PowerShell):
 irm https://raw.githubusercontent.com/ix-infrastructure/ix-cursor-plugin/main/install.ps1 | iex
 ```
 
-## Claude Code / Freebuff Skill
+## Claude Code / .agents Skill
 
 [`skills/ix/`](skills/ix/SKILL.md) is a self-contained **Claude Code skill** (also
-loaded natively by Freebuff / Codebuff) that teaches any LLM agent to drive the
+loaded natively through the `.agents` surface) that teaches any LLM agent to drive the
 `ix` CLI: build the graph, explain symbols, trace flows, analyze impact, and
 detect smells — instead of grepping and guessing.
 
@@ -251,7 +251,7 @@ powershell -ExecutionPolicy Bypass -File skills/ix/scripts/bootstrap.ps1 .
 The skill follows the progressive-disclosure layout — a lean `SKILL.md` with the
 full command reference, output-format rules, and troubleshooting split into
 `references/`, plus `scripts/` for first-run setup — so it is portable to Claude
-Code, Freebuff, and any other skill-compatible agent. Edit `skills/ix/` and
+Code, the `.agents` surface, and any other skill-compatible agent. Edit `skills/ix/` and
 re-run `scripts/install-skill.sh` to update your installed copy. To produce a
 distributable zip:
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@
 
 <p align="center">
   <a href="https://www.ix-infra.com">Website</a> ·
-  <a href="https://www.ix-infra.com/docs">Docs</a> ·
-  <a href="https://compass.ix-infra.com">Demo</a> .
+  <a href="https://github.com/ix-infrastructure/Ix/tree/main/docs">Docs</a> ·
+  <a href="https://compass.ix-infra.com">Demo</a> ·
   <a href="https://discord.gg/ncEYVHVqZ8">Discord</a>
 </p>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# Ix documentation
+
+- [HTTP API reference](api/) — the backend JSON API exposed on `http://localhost:8090`
+- [`--format llm` output convention](llm-format.md) — the machine-readable record stream
+- [Consolidating the per-host plugins onto `ix mcp`](mcp-plugin-consolidation.md)
+- [System prerequisites](prerequisites.md) — what the installer checks for and installs

--- a/scripts/install-skill.sh
+++ b/scripts/install-skill.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 #
-# Install the Ix skill so Claude Code and Freebuff can use it.
+# Install the Ix skill for Claude Code and the .agents skill surface.
 #
 # Deploys skills/ix to:
 #   ~/.claude/skills/ix   — Claude Code (global)
-#   ~/.agents/skills/ix   — Freebuff / Codebuff (global)
+#   ~/.agents/skills/ix   — the .agents skill surface (global)
 #
-# Freebuff's skill loader searches ~/.claude/skills, ~/.agents/skills, and the
+# Skill loaders search ~/.claude/skills, ~/.agents/skills, and the
 # project's .claude/skills and .agents/skills, so a global install makes the
 # skill available in every project. Re-run after editing skills/ix.
 #
@@ -43,7 +43,7 @@ done
 
 if [ "$installed" = "1" ]; then
   echo
-  echo "Ix skill installed for Claude Code and Freebuff."
+  echo "Ix skill installed for Claude Code and the .agents surface."
   echo "Start a new session so the agent picks it up, then ask it to use Ix:"
   echo "  \"Set up Ix and map this repo\""
 fi


### PR DESCRIPTION
Fixes the README's **Docs** nav link, which points at `https://www.ix-infra.com/docs` and returns **404** (measured: every `/docs` variant 404s, `docs.ix-infra.com` has no DNS, the site has no docs route or link, GitHub Pages is not configured — receipts in #588). The only live docs are in-repo (`docs/prerequisites.md`, `docs/api/`), which the README already links to relatively elsewhere.

Changes (2 lines, README nav block):
- Docs href `https://www.ix-infra.com/docs` → `https://github.com/ix-infrastructure/Ix/tree/main/docs`
- `Demo</a> .` → `Demo</a> ·` (stray period; every other nav item uses `·`)

Closes #588