### PR TITLE
feat(ingest): parse .sbt build definitions

### DIFF
--- a/core-ingestion/src/__tests__/queries.scala.test.ts
+++ b/core-ingestion/src/__tests__/queries.scala.test.ts
@@ -67,4 +67,52 @@ describe('Scala queries', () => {
       predicate: 'CALLS',
     });
   });
+
+  it('extracts modules and plugin imports from an .sbt build definition', () => {
+    const result = parseFile(
+      '/repo/build.sbt',
+      `import sbtassembly.MergeStrategy
+
+ThisBuild / scalaVersion := "2.13.16"
+
+lazy val commonSettings = Seq(scalacOptions ++= Seq("-Wunused:all"))
+
+lazy val core = (project in file("core"))
+  .settings(commonSettings, name := "ix-memory-core")
+
+lazy val root = (project in file(".")).aggregate(core)
+`,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.entities.map((entity) => entity.name)).toEqual(
+      expect.arrayContaining(['commonSettings', 'core', 'root']),
+    );
+    expect(
+      result!.relationships
+        .filter((relationship) => relationship.predicate === 'IMPORTS')
+        .map((relationship) => relationship.dstName),
+    ).toEqual(expect.arrayContaining(['sbtassembly.MergeStrategy']));
+  });
+
+  it('still ignores method-local val bindings', () => {
+    // The top-level val query must not reopen the noise the template_body
+    // restriction was written to prevent.
+    const result = parseFile(
+      '/repo/Local.scala',
+      `object Service {
+  def run(): Int = {
+    val localBinding = 41
+    localBinding + 1
+  }
+}
+`,
+    );
+
+    expect(result!.entities.map((entity) => entity.name)).not.toContain('localBinding');
+    expect(result!.entities.map((entity) => entity.name)).toEqual(
+      expect.arrayContaining(['Service', 'run']),
+    );
+  });
+
 });

--- a/core-ingestion/src/languages.ts
+++ b/core-ingestion/src/languages.ts
@@ -59,6 +59,9 @@ const EXT_MAP: Record<string, SupportedLanguages> = {
   '.swift':SupportedLanguages.Swift,
   '.scala':SupportedLanguages.Scala,
   '.sc':   SupportedLanguages.Scala,
+  // sbt build definitions are Scala expressions; the Scala grammar parses them
+  // as-is, and they are where modules are wired to their dependencies.
+  '.sbt':  SupportedLanguages.Scala,
   '.yaml': SupportedLanguages.YAML,
   '.yml':  SupportedLanguages.YAML,
   '.dockerfile': SupportedLanguages.Dockerfile,

--- a/core-ingestion/src/queries.ts
+++ b/core-ingestion/src/queries.ts
@@ -1381,6 +1381,18 @@ export const SCALA_QUERIES = `
 (template_body
   (var_definition (identifier) @name) @definition.const)
 
+; ── Top-level val/var definitions (compilation-unit level) ────────────────────
+; Scala 2 forbids these, so ordinary .scala files are unaffected. They matter
+; for .sbt build definitions, where every module is a top-level
+; \`lazy val core = (project in file("core"))\`, and for Scala 3 top-level
+; definitions. Still excludes method-local bindings, which are nested inside a
+; block rather than the compilation unit.
+(compilation_unit
+  (val_definition (identifier) @name) @definition.const)
+
+(compilation_unit
+  (var_definition (identifier) @name) @definition.const)
+
 ; ── Imports: capture full declaration for dotted-path reconstruction ─────────
 ; Handles: import ix.memory.model._  (wildcard)
 ;          import ix.memory.model.{NodeKind, GraphNode}  (selective)

--- a/ix-cli/src/cli/supported-extensions.ts
+++ b/ix-cli/src/cli/supported-extensions.ts
@@ -10,7 +10,7 @@ export const SUPPORTED_EXTENSIONS = new Set<string>([
   ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",
   ".py", ".java", ".c", ".h", ".cpp", ".cc", ".cxx", ".hpp",
   ".cs", ".go", ".rb", ".rs", ".php", ".kt", ".kts", ".swift",
-  ".scala", ".sc",
+  ".scala", ".sc", ".sbt",
   ".yaml", ".yml",
   ".dockerfile",
   ".sql",


### PR DESCRIPTION
## Why

sbt build files are where a Scala project wires its modules to their
dependencies — the structure the graph most wants from a build system, and
currently cannot see at all. This org has 14 of them across `Ix-memory`,
`core-ingestion` and `query-engine`.

They are Scala expressions, so the grammar already shipped reads them with no
new dependency.

## The extension mapping alone does nothing

`SCALA_QUERIES` restricts val/var capture to `template_body` — class and object
members only — with an explicit comment that this keeps method-local bindings
out of the graph. Every sbt module is a top-level

```scala
lazy val core = (project in file("core"))
```

which sits at the compilation unit, not in a `template_body`. So mapping the
extension produced a file node and nothing else. Measured on
`backend/Ix-memory/build.sbt`:

```
before:  file:build.sbt, module:sbtassembly.MergeStrategy, module:sbtassembly.AssemblyPlugin.autoImport
after:   file:build.sbt, function:commonSettings, function:standardMergeStrategy, function:root, + the same 2 imports
```

`backend/query-engine/build.sbt` went from a bare file node to its six version
vals plus `root`.

## Why the added query is safe

Capturing val/var at compilation-unit level:

- **Scala 2 forbids top-level definitions**, so ordinary `.scala` files in this
  codebase are unchanged.
- **Scala 3 allows them**, where capturing is the correct behaviour anyway.
- **Method-local bindings are nested in a block**, not the compilation unit, so
  the noise guard the `template_body` restriction was written for still holds.
  There is a test asserting a `val` inside a `def` body is still not an entity.

`definition.const` maps to the `function` kind — that is the pre-existing global
mapping used by every language's const capture, not something this PR changes.

## Verification

- `core-ingestion`: 362 passed (2 new)
- `ix-cli`: 1510 passed + parser smoke
- lint 0 errors, typecheck clean
