### PR TITLE
test(ingest): drive ingestFiles end to end, closing the seam #560 and #568 bled from

### DIFF
--- a/ix-cli/src/cli/__tests__/ingest-files.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-files.test.ts
@@ -1,0 +1,376 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ingestFiles } from "../commands/ingest.js";
+
+/**
+ * Integration tests that drive `ingestFiles` end to end against a fake backend.
+ *
+ * They exist because that function is where every mechanical defect in Ix#560
+ * and Ix#568 lived, and none of them were reachable from a unit test. The
+ * decision tables were extracted (`perFileAction`, `drainInPasses`,
+ * `createDrainGate`) and each extraction immediately caught a bug -- but the
+ * WIRING between them stayed untested, and that is where the next one appeared
+ * every time: a counter fed from the wrong place, a list the deadline diverted
+ * to, a probe that treated proof as a failure.
+ *
+ * Nothing is mocked. `ingestFiles` builds its own `IxClient` from
+ * `getEndpoint()`, which reads `IX_ENDPOINT`, so a real HTTP server on a
+ * loopback port is the whole seam -- and the request log it keeps is exactly
+ * the thing the PRs' measurements were about.
+ *
+ * What these catch, verified by restoring the bugs and watching them go red:
+ *
+ *   - removing the cutoff entirely (the pre-#560 fan-out);
+ *   - the drain stopping on the first pass that placed nothing, which strands
+ *     every good patch between two clusters of bad ones;
+ *   - the stitch marker being cleared by a failure that is not proof, which is
+ *     the #568 stacking itself.
+ *
+ * What they do NOT catch, and are not the right tool for: the finer stopping
+ * rules inside `drainInPasses` -- two-empty-passes versus three, and the
+ * direction flip. Those need a held set shaped precisely, which at this level
+ * means contorting a fixture until it happens to produce one. They are
+ * mutation-validated directly in `commit-breaker.test.ts`, and that division is
+ * deliberate: coarse wiring here, decision tables there.
+ */
+
+/** A backend that answers the endpoints an ingest touches, and records them. */
+class FakeBackend {
+  readonly requests: Array<{ path: string; patches: number }> = [];
+
+  private server: Server | undefined;
+  private rev = 0;
+
+  /** Patch-source substrings this backend refuses, whatever else is healthy. */
+  poison: string[] = [];
+  /** Fail every commit, the Ix#560 shape. */
+  refuseEverything = false;
+  /** Milliseconds to sit on each commit before answering. */
+  commitDelayMs = 0;
+  /** Answer a bulk with 409 naming every patch as already committed. */
+  bulk409AllLanded = false;
+  /** Status for POST /v1/stitch. */
+  stitchStatus = 200;
+
+  get stitchCount(): number {
+    return this.requests.filter(r => r.path === "/v1/stitch").length;
+  }
+
+  get bulkCount(): number {
+    return this.requests.filter(r => r.path === "/v1/patches/bulk").length;
+  }
+
+  get singleCount(): number {
+    return this.requests.filter(r => r.path === "/v1/patch").length;
+  }
+
+  get commitCount(): number {
+    return this.bulkCount + this.singleCount;
+  }
+
+  async start(): Promise<string> {
+    this.server = createServer((req, res) => {
+      let body = "";
+      req.on("data", c => (body += c));
+      req.on("end", () => this.route(req.url ?? "/", body, res));
+    });
+    await new Promise<void>(resolve => this.server!.listen(0, "127.0.0.1", resolve));
+    return `http://127.0.0.1:${(this.server!.address() as AddressInfo).port}`;
+  }
+
+  async stop(): Promise<void> {
+    if (this.server) await new Promise<void>(resolve => this.server!.close(() => resolve()));
+  }
+
+  private route(url: string, body: string, res: ServerResponse): void {
+    const path = new URL(url, "http://x").pathname;
+    const send = (code: number, payload: unknown): void => {
+      res.writeHead(code, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(payload));
+    };
+
+    if (path === "/v1/patches/bulk" || path === "/v1/patch") {
+      let patches: Array<{ patchId?: string }> = [];
+      try {
+        const parsed = JSON.parse(body) as { patches?: Array<{ patchId?: string }> };
+        patches = parsed.patches ?? [parsed as { patchId?: string }];
+      } catch {
+        /* a body we cannot read is still a request */
+      }
+      this.requests.push({ path, patches: patches.length });
+
+      if (path === "/v1/patches/bulk" && this.bulk409AllLanded) {
+        const ids = patches.map(p => p.patchId).filter(Boolean);
+        return send(409, { error: "bulk group partially committed", committed_patch_ids: ids });
+      }
+      const refused = this.refuseEverything || this.poison.some(p => body.includes(p));
+      const answer = (): void => {
+        if (refused) return send(500, { error: "500: transaction begin timeout" });
+        this.rev += patches.length || 1;
+        send(200, path === "/v1/patches/bulk" ? { rev: this.rev, applied: patches.length } : { rev: this.rev });
+      };
+      if (this.commitDelayMs > 0) setTimeout(answer, this.commitDelayMs);
+      else answer();
+      return;
+    }
+
+    if (path === "/v1/health") return send(200, { status: "ok", version: "1.0.28" });
+    if (path === "/v1/source-hashes") return send(200, []);
+    if (path.startsWith("/v1/stitch/system/")) return send(200, { systemId: null });
+    if (path === "/v1/stitch") {
+      this.requests.push({ path, patches: 0 });
+      if (this.stitchStatus !== 200) return send(this.stitchStatus, { error: "AQL: query timed out" });
+      return send(200, { stitched: 0, systemId: null, edges: [] });
+    }
+    return send(200, {});
+  }
+}
+
+describe("ingestFiles against a fake backend", () => {
+  let home: string;
+  let repo: string;
+  let backend: FakeBackend;
+  const saved: Record<string, string | undefined> = {};
+
+  /** Write `count` trivially-parseable TypeScript files. */
+  function fixture(count: number): void {
+    mkdirSync(join(repo, "src"), { recursive: true });
+    for (let i = 0; i < count; i++) {
+      const name = `m${String(i).padStart(3, "0")}.ts`;
+      writeFileSync(join(repo, "src", name), `export function f${i}(): number { return ${i}; }\n`, "utf8");
+    }
+  }
+
+  beforeEach(async () => {
+    home = mkdtempSync(join(tmpdir(), "ix-ingest-home-"));
+    repo = mkdtempSync(join(tmpdir(), "ix-ingest-repo-"));
+    backend = new FakeBackend();
+    const endpoint = await backend.start();
+
+    // HOME *and* USERPROFILE: `os.homedir()` reads the latter on Windows, so
+    // redirecting only HOME leaves the run writing its mtime cache and
+    // baselines into the developer's real ~/.ix.
+    for (const k of ["HOME", "USERPROFILE", "IX_ENDPOINT", "IX_LOCK_DIR", "IX_COMMIT_FAILURE_LIMIT"]) {
+      saved[k] = process.env[k];
+    }
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    process.env.IX_ENDPOINT = endpoint;
+    process.env.IX_LOCK_DIR = join(home, "locks");
+  });
+
+  afterEach(async () => {
+    await backend.stop();
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    rmSync(home, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  const run = () =>
+    ingestFiles(repo, { format: "text", force: true, suppressOutput: true, printSummary: false });
+
+  /**
+   * A run that ends fatally. Under `suppressOutput` a fatal commit outcome is
+   * raised rather than printed, so the caller sees it -- the assertion is on
+   * the message and on what the backend was actually asked to do.
+   */
+  const runFatal = async (): Promise<string> => {
+    try {
+      await run();
+    } catch (err) {
+      return String(err);
+    }
+    throw new Error("expected the ingest to end fatally");
+  };
+
+  it("bounds the requests to a backend that refuses everything (Ix#560)", async () => {
+    // The bug: one failed bulk became one doomed request per patch, each
+    // waiting out its own timeout, against the database that is the reason
+    // they fail. `main` sends 1 + N; the cutoff stops the fan-out after
+    // IX_COMMIT_FAILURE_LIMIT and bounds the drain that follows.
+    fixture(30);
+    backend.refuseEverything = true;
+
+    const message = await runFatal();
+
+    expect(message, "every patch is accounted for, none silently dropped").toContain("30 of 30");
+    expect(message).toContain("See the cutoff above");
+    expect(backend.commitCount, "well under main's 31").toBeLessThan(25);
+    expect(backend.commitCount, "and it still tried").toBeGreaterThan(1);
+  });
+
+  it("strands nothing a healthy backend would have taken (Ix#560)", async () => {
+    // The invariant the whole drain design exists for, and the one four
+    // successive stopping rules got wrong: on a backend refusing PARTICULAR
+    // patches, the error count must equal the number of bad patches exactly.
+    // Anything higher is a committable patch reported as failed without ever
+    // being sent -- and since the mtime baseline is not written on a run with
+    // commit errors, the next map repeats it forever.
+    fixture(30);
+    backend.poison = ["m005.ts", "m006.ts", "m007.ts", "m008.ts", "m009.ts"];
+
+    const summary = await run();
+
+    expect(summary.commitErrors).toBe(5);
+    expect(summary.patchesApplied).toBe(25);
+  });
+
+  it("strands nothing when the bad patches sit at the very start", async () => {
+    // The leading-cluster shape. The fan-out trips before anything succeeds,
+    // so the drain has no evidence the backend is alive and must not guess
+    // from a single empty pass.
+    fixture(30);
+    backend.poison = ["m000.ts", "m001.ts", "m002.ts", "m003.ts", "m004.ts", "m005.ts"];
+
+    const summary = await run();
+
+    expect(summary.commitErrors).toBe(6);
+    expect(summary.patchesApplied).toBe(24);
+  });
+
+  it("strands nothing when bad patches sit at BOTH ends of the held set", async () => {
+    // The shape that defeats every simpler stopping rule, and the reason the
+    // drain samples three positions rather than one or two.
+    //
+    // Poison at the start trips the fan-out, so the held set is everything
+    // after it -- good files in the middle, poison again at the tail. The drain
+    // walks from the far end first, so its opening pass runs straight into the
+    // trailing cluster, spends its whole budget and places NOTHING. A rule that
+    // reads that as "the backend is dead" hands back every good patch between
+    // the two clusters, unsent; and because the mtime baseline is never written
+    // on a run with commit errors, the next map reproduces it exactly.
+    fixture(30);
+    backend.poison = [
+      "m000.ts", "m001.ts", "m002.ts", "m003.ts", "m004.ts", "m005.ts",
+      "m024.ts", "m025.ts", "m026.ts", "m027.ts", "m028.ts", "m029.ts",
+    ];
+
+    const summary = await run();
+
+    expect(summary.commitErrors, "exactly the poison, nothing else").toBe(12);
+    expect(summary.patchesApplied, "every file between the clusters").toBe(18);
+  });
+
+  it("bounds a bulk 409 that names every patch as already landed", async () => {
+    // Those patches are confirmed in the graph by the server's own body, so
+    // re-sending them is bookkeeping -- but nothing bounded it: the full-landed
+    // branch returns before its shouldStop check, so the whole chunk went out
+    // one at a time behind the global mutex with no way to stop.
+    fixture(30);
+    backend.bulk409AllLanded = true;
+
+    const summary = await run();
+
+    expect(summary.patchesApplied, "confirmed landed, so not errors").toBe(30);
+    expect(summary.commitErrors).toBe(0);
+
+    // PINNED, not endorsed. On a HEALTHY backend the replay re-sends all 30 one
+    // at a time even though the 409 body already named them as landed -- the
+    // Ix#495 shape, and provably unnecessary work. The bound added for Ix#560
+    // only engages when the replays FAIL, which is the case that could run away
+    // unstopped. Skipping them outright needs a revision for `onCommitted`,
+    // which the 409 does not carry, so it is left as a known residue rather
+    // than guessed at. This number failing is the signal that someone changed
+    // it deliberately.
+    expect(backend.singleCount, "known residue: one re-send per confirmed patch").toBe(30);
+  });
+
+  it("refuses a second stitch to a backend still running the last one (Ix#568)", async () => {
+    // The marker is written when a stitch STARTS and removed only on proof
+    // nothing is running. A 500 is not proof -- ArangoDB keeps executing the
+    // join -- so the next run must not start another.
+    fixture(4);
+    backend.stitchStatus = 500;
+
+    const first = await run();
+    expect(backend.stitchCount, "the first run does stitch").toBe(1);
+    expect(first.stitchSkipped).toBeUndefined();
+
+    const second = await run();
+
+    expect(backend.stitchCount, "and the second does not").toBe(1);
+    expect(second.stitchSkippedRule).toBe("cooling");
+    expect(second.stitchSkipped).toContain("may still be running");
+  });
+
+  it("stitches again once the cooldown is disabled", async () => {
+    // The refusal message tells the user IX_STITCH_COOLDOWN_MS=0 releases it,
+    // so that has to be true of a cooldown already on disk.
+    fixture(4);
+    backend.stitchStatus = 500;
+    await run();
+    expect(backend.stitchCount).toBe(1);
+
+    process.env.IX_STITCH_COOLDOWN_MS = "0";
+    try {
+      const second = await run();
+      expect(backend.stitchCount).toBe(2);
+      expect(second.stitchSkipped).toBeUndefined();
+    } finally {
+      delete process.env.IX_STITCH_COOLDOWN_MS;
+    }
+  });
+
+  it("blames the clock for the clock's losses, not the backend", async () => {
+    // The cutoff and the run deadline both abandon patches, and three separate
+    // review rounds found them attributed to each other -- the run telling the
+    // user to raise IX_MAP_DEADLINE_MS for patches the cutoff had deliberately
+    // withheld from a refusing backend, or the reverse. They are tracked in
+    // separate lists precisely so this message can be right.
+    fixture(30);
+    backend.refuseEverything = true;
+    backend.commitDelayMs = 40;
+
+    const message = await (async () => {
+      try {
+        await ingestFiles(repo, {
+          format: "text",
+          force: true,
+          suppressOutput: true,
+          printSummary: false,
+          // Long enough for the cutoff to trip FIRST -- a bulk plus five
+          // per-file failures at 40ms each -- so the run has losses of both
+          // kinds and the message has to keep them apart.
+          deadlineSignal: AbortSignal.timeout(420),
+        });
+        return "";
+      } catch (err) {
+        return String(err);
+      }
+    })();
+
+    // The clock's losses are reported as the clock's, and every patch is
+    // accounted for. An earlier revision reported them as the cutoff's --
+    // "sending them one at a time would have added load to a backend that is
+    // already the reason they fail" -- for patches the cutoff never touched.
+    expect(message).toContain("ran out of time");
+    expect(message).toContain("30 file patches");
+    // Here the clock diverted everything before the cutoff could withhold any,
+    // so the split clause must NOT appear: a zero share is not mentioned rather
+    // than mentioned as zero. The non-zero split is pinned by the unit tests in
+    // ingest-commit-outcome.test.ts, which can construct it directly.
+    expect(message).not.toContain("withheld by the commit cutoff");
+    expect(message).not.toContain("added load");
+
+
+  });
+
+  it("commits a healthy repo in one bulk, with no per-file fan-out", async () => {
+    fixture(12);
+
+    const summary = await run();
+
+    expect(summary.commitErrors).toBe(0);
+    expect(summary.patchesApplied).toBe(12);
+    expect(backend.bulkCount).toBe(1);
+    expect(backend.singleCount, "the fan-out is for failures only").toBe(0);
+  });
+});

--- a/ix-cli/src/cli/__tests__/ingest-files.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-files.test.ts
@@ -4,6 +4,7 @@ import type { AddressInfo } from "node:net";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { execFileSync } from "node:child_process";
 
 import { ingestFiles } from "../commands/ingest.js";
 
@@ -52,6 +53,16 @@ class FakeBackend {
   refuseEverything = false;
   /** Milliseconds to sit on each commit before answering. */
   commitDelayMs = 0;
+  /** Refuse re-sends of patches a 409 already confirmed. */
+  refuseReplays = false;
+  /** Fired after `abortAfterCommits` commit requests, if set. */
+  abortAfterCommits: number | undefined;
+  private readonly aborter = new AbortController();
+
+  /** A run deadline that fires at a known POINT IN THE COMMIT SEQUENCE. */
+  get deadlineSignal(): AbortSignal {
+    return this.aborter.signal;
+  }
   /** Answer a bulk with 409 naming every patch as already committed. */
   bulk409AllLanded = false;
   /** Status for POST /v1/stitch. */
@@ -75,9 +86,15 @@ class FakeBackend {
 
   async start(): Promise<string> {
     this.server = createServer((req, res) => {
-      let body = "";
-      req.on("data", c => (body += c));
-      req.on("end", () => this.route(req.url ?? "/", body, res));
+      // Collect and concat, rather than `body += chunk`. Appending a Buffer to
+      // a string decodes each TCP chunk on its own, so a multi-byte character
+      // split across a chunk boundary is corrupted -- and a bulk body for
+      // thirty patches is comfortably big enough to be split. Latent while the
+      // fixtures are ASCII; the first non-ASCII one would make `JSON.parse`
+      // throw and silently route the request down a different branch.
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => this.route(req.url ?? "/", Buffer.concat(chunks).toString("utf8"), res));
     });
     await new Promise<void>(resolve => this.server!.listen(0, "127.0.0.1", resolve));
     return `http://127.0.0.1:${(this.server!.address() as AddressInfo).port}`;
@@ -103,7 +120,13 @@ class FakeBackend {
         /* a body we cannot read is still a request */
       }
       this.requests.push({ path, patches: patches.length });
+      if (this.abortAfterCommits !== undefined && this.commitCount >= this.abortAfterCommits) {
+        this.aborter.abort();
+      }
 
+      if (path === "/v1/patch" && this.refuseReplays) {
+        return send(500, { error: "500: already committed" });
+      }
       if (path === "/v1/patches/bulk" && this.bulk409AllLanded) {
         const ids = patches.map(p => p.patchId).filter(Boolean);
         return send(409, { error: "bulk group partially committed", committed_patch_ids: ids });
@@ -137,13 +160,32 @@ describe("ingestFiles against a fake backend", () => {
   let backend: FakeBackend;
   const saved: Record<string, string | undefined> = {};
 
-  /** Write `count` trivially-parseable TypeScript files. */
+  /**
+   * Write `count` trivially-parseable TypeScript files, in a KNOWN order.
+   *
+   * The `git init` + `git add` is load-bearing, not decoration. Discovery
+   * prefers `git ls-files`, which sorts; with no repo it falls back to
+   * `walkFiles`, which yields raw `readdirSync` order -- lexicographic on NTFS,
+   * hash order on ext4 and APFS. The fixtures below are named for WHERE the
+   * poison sits, and off Windows they would have quietly degenerated into the
+   * scattered case on two of the five CI legs. The both-ends shape is the only
+   * one that reproduces the drain's first-empty-pass bug, so losing it there
+   * would have left that mutation uncaught precisely where nobody runs the
+   * suite by hand.
+   */
   function fixture(count: number): void {
     mkdirSync(join(repo, "src"), { recursive: true });
     for (let i = 0; i < count; i++) {
       const name = `m${String(i).padStart(3, "0")}.ts`;
       writeFileSync(join(repo, "src", name), `export function f${i}(): number { return ${i}; }\n`, "utf8");
     }
+    execFileSync("git", ["init", "-q"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["add", "-A"], { cwd: repo, stdio: "ignore" });
+  }
+
+  /** The order discovery will actually walk — asserted, never assumed. */
+  function discoveryOrder(): string[] {
+    return execFileSync("git", ["ls-files"], { cwd: repo, encoding: "utf8" }).split("\n").filter(Boolean);
   }
 
   beforeEach(async () => {
@@ -155,8 +197,26 @@ describe("ingestFiles against a fake backend", () => {
     // HOME *and* USERPROFILE: `os.homedir()` reads the latter on Windows, so
     // redirecting only HOME leaves the run writing its mtime cache and
     // baselines into the developer's real ~/.ix.
-    for (const k of ["HOME", "USERPROFILE", "IX_ENDPOINT", "IX_LOCK_DIR", "IX_COMMIT_FAILURE_LIMIT"]) {
+    // Saved AND cleared. Recording them was not enough: every one of these is
+    // read straight from the environment, so a developer who has exported
+    // `IX_COMMIT_FAILURE_LIMIT=0` -- the value the CLI's own failure banner
+    // tells users to set -- turns the cutoff off and makes the bounded-request
+    // assertions meaningless, and `IX_COMMIT_HTTP_MAX_FILES=1` breaks the
+    // one-bulk assertion outright.
+    for (const k of [
+      "HOME",
+      "USERPROFILE",
+      "IX_ENDPOINT",
+      "IX_LOCK_DIR",
+      "IX_COMMIT_FAILURE_LIMIT",
+      "IX_COMMIT_HTTP_MAX_FILES",
+      "IX_COMMIT_CONCURRENCY",
+      "IX_STITCH_COOLDOWN_MS",
+      "IX_STITCH_WAIT_MS",
+      "IX_MAP_DEADLINE_MS",
+    ]) {
       saved[k] = process.env[k];
+      delete process.env[k];
     }
     process.env.HOME = home;
     process.env.USERPROFILE = home;
@@ -229,6 +289,7 @@ describe("ingestFiles against a fake backend", () => {
     // from a single empty pass.
     fixture(30);
     backend.poison = ["m000.ts", "m001.ts", "m002.ts", "m003.ts", "m004.ts", "m005.ts"];
+    expect(discoveryOrder()[0], "the poison must actually come first").toContain("m000.ts");
 
     const summary = await run();
 
@@ -252,6 +313,10 @@ describe("ingestFiles against a fake backend", () => {
       "m000.ts", "m001.ts", "m002.ts", "m003.ts", "m004.ts", "m005.ts",
       "m024.ts", "m025.ts", "m026.ts", "m027.ts", "m028.ts", "m029.ts",
     ];
+    // The premise, checked rather than assumed: poison first and last.
+    const order = discoveryOrder();
+    expect(order[0]).toContain("m000.ts");
+    expect(order[order.length - 1]).toContain("m029.ts");
 
     const summary = await run();
 
@@ -274,13 +339,34 @@ describe("ingestFiles against a fake backend", () => {
 
     // PINNED, not endorsed. On a HEALTHY backend the replay re-sends all 30 one
     // at a time even though the 409 body already named them as landed -- the
-    // Ix#495 shape, and provably unnecessary work. The bound added for Ix#560
-    // only engages when the replays FAIL, which is the case that could run away
-    // unstopped. Skipping them outright needs a revision for `onCommitted`,
-    // which the 409 does not carry, so it is left as a known residue rather
-    // than guessed at. This number failing is the signal that someone changed
-    // it deliberately.
+    // Ix#495 shape, and provably unnecessary work. Skipping them outright needs
+    // a revision for `onCommitted` that the 409 does not carry, so it is left
+    // as a known residue rather than guessed at. This number failing is the
+    // signal that someone changed it deliberately.
     expect(backend.singleCount, "known residue: one re-send per confirmed patch").toBe(30);
+  });
+
+  it("bounds the replay, and counts it applied, when the re-sends fail too", async () => {
+    // The case that could actually run away, and the one the previous test
+    // cannot distinguish: there the healthy backend accepts every re-send, so
+    // `patchesApplied` reaches 30 whether or not the 409's ids are credited.
+    // Here every re-send is refused.
+    //
+    // Two things have to hold. The patches are still APPLIED -- the server's
+    // own 409 said it holds them, so counting a failed re-send as a commit
+    // error would report writes the graph has as missing and suppress the mtime
+    // baseline over them. And the replay has to STOP: the full-landed branch
+    // returns before its `shouldStop` check, so nothing else bounds it, and it
+    // would otherwise send all 30 one at a time behind the global mutex.
+    fixture(30);
+    backend.bulk409AllLanded = true;
+    backend.refuseReplays = true;
+
+    const summary = await run();
+
+    expect(summary.commitErrors, "confirmed landed, so not errors").toBe(0);
+    expect(summary.patchesApplied).toBe(30);
+    expect(backend.singleCount, "bounded by the failure limit, not one per patch").toBeLessThan(15);
   });
 
   it("refuses a second stitch to a backend still running the last one (Ix#568)", async () => {
@@ -323,11 +409,18 @@ describe("ingestFiles against a fake backend", () => {
     // The cutoff and the run deadline both abandon patches, and three separate
     // review rounds found them attributed to each other -- the run telling the
     // user to raise IX_MAP_DEADLINE_MS for patches the cutoff had deliberately
-    // withheld from a refusing backend, or the reverse. They are tracked in
-    // separate lists precisely so this message can be right.
+    // withheld, or the reverse. They are tracked in separate lists precisely so
+    // this message can be right.
+    //
+    // The deadline is fired by the BACKEND, after a known number of commit
+    // requests, rather than by a wall-clock timeout. A timeout here measured
+    // discovery and parsing, not the commit phase -- on this machine the first
+    // commit did not land for ~700ms, so a 420ms budget never reached the code
+    // under test at all, and on a faster machine the same test would have
+    // asserted the opposite branch.
     fixture(30);
     backend.refuseEverything = true;
-    backend.commitDelayMs = 40;
+    backend.abortAfterCommits = 3;
 
     const message = await (async () => {
       try {
@@ -336,10 +429,7 @@ describe("ingestFiles against a fake backend", () => {
           force: true,
           suppressOutput: true,
           printSummary: false,
-          // Long enough for the cutoff to trip FIRST -- a bulk plus five
-          // per-file failures at 40ms each -- so the run has losses of both
-          // kinds and the message has to keep them apart.
-          deadlineSignal: AbortSignal.timeout(420),
+          deadlineSignal: backend.deadlineSignal,
         });
         return "";
       } catch (err) {
@@ -347,20 +437,16 @@ describe("ingestFiles against a fake backend", () => {
       }
     })();
 
+    // Exactly three requests reached the backend, so the abort landed where it
+    // was aimed and the rest were stopped before they left.
+    expect(backend.commitCount).toBe(3);
     // The clock's losses are reported as the clock's, and every patch is
     // accounted for. An earlier revision reported them as the cutoff's --
     // "sending them one at a time would have added load to a backend that is
     // already the reason they fail" -- for patches the cutoff never touched.
     expect(message).toContain("ran out of time");
     expect(message).toContain("30 file patches");
-    // Here the clock diverted everything before the cutoff could withhold any,
-    // so the split clause must NOT appear: a zero share is not mentioned rather
-    // than mentioned as zero. The non-zero split is pinned by the unit tests in
-    // ingest-commit-outcome.test.ts, which can construct it directly.
-    expect(message).not.toContain("withheld by the commit cutoff");
     expect(message).not.toContain("added load");
-
-
   });
 
   it("commits a healthy repo in one bulk, with no per-file fan-out", async () => {

--- a/ix-cli/src/cli/__tests__/ingest-files.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-files.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createServer, type Server, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
@@ -43,6 +43,8 @@ import { ingestFiles } from "../commands/ingest.js";
 /** A backend that answers the endpoints an ingest touches, and records them. */
 class FakeBackend {
   readonly requests: Array<{ path: string; patches: number }> = [];
+  /** Paths this fake does not implement. Asserted empty after every test. */
+  readonly unknownPaths: string[] = [];
 
   private server: Server | undefined;
   private rev = 0;
@@ -51,8 +53,6 @@ class FakeBackend {
   poison: string[] = [];
   /** Fail every commit, the Ix#560 shape. */
   refuseEverything = false;
-  /** Milliseconds to sit on each commit before answering. */
-  commitDelayMs = 0;
   /** Refuse re-sends of patches a 409 already confirmed. */
   refuseReplays = false;
   /** Fired after `abortAfterCommits` commit requests, if set. */
@@ -69,15 +69,15 @@ class FakeBackend {
   stitchStatus = 200;
 
   get stitchCount(): number {
-    return this.requests.filter(r => r.path === "/v1/stitch").length;
+    return this.requests.filter((r) => r.path === "/v1/stitch").length;
   }
 
   get bulkCount(): number {
-    return this.requests.filter(r => r.path === "/v1/patches/bulk").length;
+    return this.requests.filter((r) => r.path === "/v1/patches/bulk").length;
   }
 
   get singleCount(): number {
-    return this.requests.filter(r => r.path === "/v1/patch").length;
+    return this.requests.filter((r) => r.path === "/v1/patch").length;
   }
 
   get commitCount(): number {
@@ -96,12 +96,19 @@ class FakeBackend {
       req.on("data", (c: Buffer) => chunks.push(c));
       req.on("end", () => this.route(req.url ?? "/", Buffer.concat(chunks).toString("utf8"), res));
     });
-    await new Promise<void>(resolve => this.server!.listen(0, "127.0.0.1", resolve));
+    await new Promise<void>((resolve, reject) => {
+      // Without the `error` listener a failed bind -- EACCES under a
+      // restrictive sandbox, EADDRNOTAVAIL where loopback is unusual -- never
+      // settles this promise, and surfaces as a beforeEach hook timeout plus an
+      // unhandled 'error' event rather than as the bind error it is.
+      this.server!.once("error", reject);
+      this.server!.listen(0, "127.0.0.1", resolve);
+    });
     return `http://127.0.0.1:${(this.server!.address() as AddressInfo).port}`;
   }
 
   async stop(): Promise<void> {
-    if (this.server) await new Promise<void>(resolve => this.server!.close(() => resolve()));
+    if (this.server) await new Promise<void>((resolve) => this.server!.close(() => resolve()));
   }
 
   private route(url: string, body: string, res: ServerResponse): void {
@@ -128,17 +135,24 @@ class FakeBackend {
         return send(500, { error: "500: already committed" });
       }
       if (path === "/v1/patches/bulk" && this.bulk409AllLanded) {
-        const ids = patches.map(p => p.patchId).filter(Boolean);
+        const ids = patches.map((p) => p.patchId).filter(Boolean);
         return send(409, { error: "bulk group partially committed", committed_patch_ids: ids });
       }
-      const refused = this.refuseEverything || this.poison.some(p => body.includes(p));
-      const answer = (): void => {
-        if (refused) return send(500, { error: "500: transaction begin timeout" });
-        this.rev += patches.length || 1;
-        send(200, path === "/v1/patches/bulk" ? { rev: this.rev, applied: patches.length } : { rev: this.rev });
-      };
-      if (this.commitDelayMs > 0) setTimeout(answer, this.commitDelayMs);
-      else answer();
+      const refused = this.refuseEverything || this.poison.some((p) => body.includes(p));
+      // Answered synchronously. A `commitDelayMs` knob lived here and no test
+      // ever set it -- the deadline test fires off request COUNT instead, which
+      // is what makes it deterministic. Reviving it needs care rather than a
+      // one-liner: `stop()` resolves on `server.close()` without cancelling a
+      // pending timer, so a deferred response outlives the test that armed it
+      // and fires against a closed server.
+      if (refused) return send(500, { error: "500: transaction begin timeout" });
+      this.rev += patches.length || 1;
+      send(
+        200,
+        path === "/v1/patches/bulk"
+          ? { rev: this.rev, applied: patches.length }
+          : { rev: this.rev },
+      );
       return;
     }
 
@@ -147,10 +161,19 @@ class FakeBackend {
     if (path.startsWith("/v1/stitch/system/")) return send(200, { systemId: null });
     if (path === "/v1/stitch") {
       this.requests.push({ path, patches: 0 });
-      if (this.stitchStatus !== 200) return send(this.stitchStatus, { error: "AQL: query timed out" });
+      if (this.stitchStatus !== 200)
+        return send(this.stitchStatus, { error: "AQL: query timed out" });
       return send(200, { stitched: 0, systemId: null, edges: [] });
     }
-    return send(200, {});
+    // 404, not `200 {}`. A fake that answers every unrecognised path with a
+    // cheerful empty body cannot fail: product code that starts calling a new
+    // endpoint -- or mistypes an existing one -- gets a success here where the
+    // real backend would 404, and the harness stays green while measuring a
+    // request the backend never served. The path is recorded as well as
+    // refused, so the afterEach names it rather than leaving a stray 404 to be
+    // explained.
+    this.unknownPaths.push(path);
+    return send(404, { error: `404: no such endpoint ${path}` });
   }
 }
 
@@ -177,20 +200,45 @@ describe("ingestFiles against a fake backend", () => {
     mkdirSync(join(repo, "src"), { recursive: true });
     for (let i = 0; i < count; i++) {
       const name = `m${String(i).padStart(3, "0")}.ts`;
-      writeFileSync(join(repo, "src", name), `export function f${i}(): number { return ${i}; }\n`, "utf8");
+      writeFileSync(
+        join(repo, "src", name),
+        `export function f${i}(): number { return ${i}; }\n`,
+        "utf8",
+      );
     }
     execFileSync("git", ["init", "-q"], { cwd: repo, stdio: "ignore" });
     execFileSync("git", ["add", "-A"], { cwd: repo, stdio: "ignore" });
   }
 
   /** The order discovery will actually walk — asserted, never assumed. */
+  // The same flags `tryGitLsFiles` passes, not a bare `ls-files`. The two
+  // agree only while `fixture()` stages everything; one unstaged file or a
+  // `.gitignore` and this would validate a list discovery does not use. The
+  // both-ends fixture is the only one that reproduces the drain's
+  // first-empty-pass bug, so a premise check that quietly stopped matching
+  // would retire that case with nothing going red.
   function discoveryOrder(): string[] {
-    return execFileSync("git", ["ls-files"], { cwd: repo, encoding: "utf8" }).split("\n").filter(Boolean);
+    return execFileSync("git", ["ls-files", "--cached", "--others", "--exclude-standard"], {
+      cwd: repo,
+      encoding: "utf8",
+    })
+      .split("\n")
+      .filter(Boolean);
   }
 
   beforeEach(async () => {
-    home = mkdtempSync(join(tmpdir(), "ix-ingest-home-"));
-    repo = mkdtempSync(join(tmpdir(), "ix-ingest-repo-"));
+    // realpath'd, because discovery canonicalises and the workspace root does
+    // not. `discoverIngestFilePaths` runs `realpathSync.native` over every file
+    // it finds while `workspaceRoot` stays exactly the string handed in, so the
+    // moment the two disagree `toWorkspaceRelative` gives up and emits an
+    // ESCAPING path. On the two macos-14 legs `os.tmpdir()` is `/var/folders/...`
+    // for a real `/private/var/folders/...`, so every fixture's source_uri and
+    // patch id there was `../../../private/var/...` rather than `src/m000.ts` --
+    // a materially different payload on a third of the matrix, and a trap for
+    // the first assertion that ever touches a uri. Windows junctions do it too.
+    // `ingest-discovery.test.ts:105` already carries this fix and its reason.
+    home = realpathSync(mkdtempSync(join(tmpdir(), "ix-ingest-home-")));
+    repo = realpathSync(mkdtempSync(join(tmpdir(), "ix-ingest-repo-")));
     backend = new FakeBackend();
     const endpoint = await backend.start();
 
@@ -225,6 +273,10 @@ describe("ingestFiles against a fake backend", () => {
   });
 
   afterEach(async () => {
+    // Every request the run made was one this fake actually implements. If the
+    // ingest path grows an endpoint, this fails once with its name, rather than
+    // ten tests passing against a fake that agreed with everything.
+    expect(backend.unknownPaths, "endpoints the fake does not implement").toEqual([]);
     await backend.stop();
     for (const [k, v] of Object.entries(saved)) {
       if (v === undefined) delete process.env[k];
@@ -310,8 +362,18 @@ describe("ingestFiles against a fake backend", () => {
     // on a run with commit errors, the next map reproduces it exactly.
     fixture(30);
     backend.poison = [
-      "m000.ts", "m001.ts", "m002.ts", "m003.ts", "m004.ts", "m005.ts",
-      "m024.ts", "m025.ts", "m026.ts", "m027.ts", "m028.ts", "m029.ts",
+      "m000.ts",
+      "m001.ts",
+      "m002.ts",
+      "m003.ts",
+      "m004.ts",
+      "m005.ts",
+      "m024.ts",
+      "m025.ts",
+      "m026.ts",
+      "m027.ts",
+      "m028.ts",
+      "m029.ts",
     ];
     // The premise, checked rather than assumed: poison first and last.
     const order = discoveryOrder();
@@ -324,7 +386,7 @@ describe("ingestFiles against a fake backend", () => {
     expect(summary.patchesApplied, "every file between the clusters").toBe(18);
   });
 
-  it("bounds a bulk 409 that names every patch as already landed", async () => {
+  it("pins the unbounded replay of a 409 that names every patch as landed", async () => {
     // Those patches are confirmed in the graph by the server's own body, so
     // re-sending them is bookkeeping -- but nothing bounded it: the full-landed
     // branch returns before its shouldStop check, so the whole chunk went out

--- a/ix-cli/src/cli/commands/ingestion-loader.ts
+++ b/ix-cli/src/cli/commands/ingestion-loader.ts
@@ -21,10 +21,37 @@ type LanguagesModule = {
   languageFromPath: (filePath: string) => string | null;
 };
 
-const importModule = new Function(
+const importViaFunction = new Function(
   "specifier",
   "return import(specifier);"
 ) as (specifier: string) => Promise<any>;
+
+/**
+ * Load a built `core-ingestion` module by absolute file URL.
+ *
+ * The `new Function` indirection is the primary path and stays first: it keeps
+ * a specifier pointing four levels outside this package away from anything that
+ * would try to resolve or bundle it.
+ *
+ * It cannot run everywhere, though. A host that evaluates this module inside a
+ * `vm` context with no `importModuleDynamically` hook -- vitest's vite-node,
+ * notably -- throws `A dynamic import callback was not specified` from the
+ * indirection itself, not from the module being loaded. That made `ingestFiles`
+ * impossible to drive from a test, which is why the commit path had integration
+ * coverage of exactly none while two PRs reworked it.
+ *
+ * So: fall back to a direct `import()`, and only for that one failure. A
+ * genuine module-not-found still propagates, rather than being retried and
+ * reported twice.
+ */
+const importModule = async (specifier: string): Promise<any> => {
+  try {
+    return await importViaFunction(specifier);
+  } catch (err) {
+    if (!/dynamic import callback/i.test(String(err))) throw err;
+    return await import(specifier);
+  }
+};
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 


### PR DESCRIPTION
`ingestFiles` had no test coverage at all, and that is where **every** mechanical defect in #560 and #568 lived. This adds an integration harness that drives it against a real fake backend.

## Why

Both of those PRs extracted decision tables — `perFileAction`, `drainInPasses`, `createDrainGate` — and each extraction immediately caught a bug that had already shipped. But it *moved* the untested boundary rather than closing it: the next defect always turned up in the wiring between the tables. A counter fed from the wrong place. A list the deadline diverted to. A probe that read proof as failure.

Across roughly thirty review rounds, several findings were the previous round's fix. Reviewers named the cause each time: `ingestFiles` is imported by no test, so ~350 lines of new wiring were verified by hand-run stubs that live nowhere in the repo.

## What this does

Drives the real function against a real HTTP server on a loopback port. `ingestFiles` builds its own `IxClient` from `getEndpoint()`, which reads `IX_ENDPOINT` — so nothing is mocked, and the backend's request log is the same measurement both PR bodies were built from.

Nine cases, chosen as the shapes the rounds kept breaking:

| | asserts |
|---|---|
| healthy repo | one bulk, zero per-file fan-out |
| backend refuses everything | requests bounded well under `main`'s N+1, every patch accounted for |
| poison patches mid-repo | errors equal the poison count **exactly** |
| poison at the leading edge | same, with no successes before the trip |
| poison at **both ends** | same — the shape that defeats every single-pass rule |
| bulk 409, all landed | confirmed patches counted, not reported as errors |
| deadline fires | the clock's losses reported as the clock's, not the backend's |
| stitch guard | a second attempt is refused while the marker stands |
| `IX_STITCH_COOLDOWN_MS=0` | releases a cooldown already on disk |

## Validated by restoring the bugs

Not "the tests pass" — the tests were checked against the real defects:

- removing the cutoff entirely (the pre-#560 fan-out) → **red**
- the drain stopping on its first empty pass → **red** (this is why the both-ends fixture exists; the middle and leading fixtures do not reproduce it)
- the stitch marker cleared by something that is not proof → **red**

The header also records what these do **not** catch: the finer rules inside `drainInPasses` — two empty passes versus three, and the direction flip — which need a precisely shaped held set and are mutation-validated in `commit-breaker.test.ts` instead. Coarse wiring here, decision tables there. Saying so beats implying blanket coverage.

## Two things the harness found immediately

**Why the seam had no coverage.** `loadIngestionModules` reaches `core-ingestion/dist` through a `new Function("return import(specifier)")` indirection, which keeps a specifier pointing four levels outside the package away from anything that would try to resolve it. Inside a `vm` context with no `importModuleDynamically` hook — vitest's vite-node — that throws `A dynamic import callback was not specified`, from the indirection itself rather than the module. The indirection stays first and unchanged; a direct `import()` is the fallback, taken only for that one error so a genuine module-not-found still propagates.

**A residue, pinned rather than accepted.** On a healthy backend, a bulk answering `409` with every patch id already landed still re-sends all thirty one at a time. The #560 bound only engages when those replays *fail*. Skipping them outright needs a revision for `onCommitted` that the 409 does not carry, so the test pins the exact number with a comment — if someone fixes it, the test says so rather than silently drifting.

## Verification

| check | result |
|---|---|
| `npm run typecheck` | exit 0 |
| `npx eslint` (touched files) | 0 errors |
| `ingest-files.test.ts` | 9/9, ~10s |
| `npx vitest run` (full) | **1633 passed, 3 failed, 21 skipped** |

The 3 failures are the pre-existing Windows-only `EPERM: operation not permitted, symlink` cases in `read-containment.test.ts`; they fail on `main` on this machine too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)