### PR TITLE
docs(api): document release_version on /v1/health (#599)

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -977,6 +977,7 @@ components:
       properties:
         status: { type: string }
         schema_version: { type: integer, description: On-disk graph format version }
+        release_version: { type: string, description: The published release the running container was built as, when it knows (#599) }
     CapabilitiesResponse:
       type: object
       properties:


### PR DESCRIPTION
Closes #599.

## The gap (measured)

The live backend answers `/v1/health` with three fields, the schema documents two:

```json
{"status":"ok","schema_version":3,"release_version":"1.0.28"}
```

`docs/api/openapi.yaml` → `HealthResponse` documented only `status` + `schema_version`. The client type (`ix-cli/src/client/types.ts`) has carried `release_version?: string` since the release-tracking work; the schema was the only laggard.

## The fix

One optional property added, matching the client type exactly (absent from backends older than Ix-memory#157 and from images not built by the release pipeline):

```yaml
HealthResponse:
  type: object
  properties:
    status: { type: string }
    schema_version: { type: integer, description: On-disk graph format version }
    release_version: { type: string, description: The published release the running container was built as, when it knows (#599) }
```

## Would the commit-time parity gate have caught this? No.

The gate on #587 compares four surfaces: paths+methods called by the client, `$ref` integrity, schema-name ↔ types.ts-name existence, and README endpoint coverage. A property added *inside* an already-known schema is invisible to every pass — the gate cannot see response-shape fields. Verified directly: with the gate's own tree plus this one-line addition, parity stays `42 documented, 42 called, 13 schemas, 13 refs — exit 0`; with main's pre-#587 yaml it reports the pre-existing drift the gate exists to fix. Response-shape drift is a real hole in the gate's surface; naming it here so it can be extended deliberately rather than discovered by accident.

## Coordination

This touches `docs/api/openapi.yaml` in the same region #587 also edits (schema components vs. the decisions path+requestBody) — no textual overlap, but whichever merges second may need a trivial rebase.