### PR TITLE
docs(api): document release_version on /v1/health

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -101,7 +101,7 @@ tracked when the field is absent.
 **Response**
 
 ```json
-{ "status": "ok", "schema_version": 3 }
+{ "status": "ok", "schema_version": 3, "release_version": "1.0.28" }
 ```
 
 #### GET `/v1/capabilities`
@@ -767,7 +767,7 @@ interface PatchCommitResult { status: string; rev: number; }
 ### HealthResponse
 
 ```ts
-interface HealthResponse { status: string; schema_version?: number; }
+interface HealthResponse { status: string; schema_version?: number; release_version?: string; }
 ```
 
 ### CapabilitiesResponse

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -81,7 +81,7 @@ curl -s -X POST http://localhost:8090/v1/context \
 
 | Method | Path | Client | Purpose |
 |---|---|---|---|
-| GET | `/v1/health` | `health()` | Liveness, status, `schema_version` |
+| GET | `/v1/health` | `health()` | Liveness, status, `schema_version`, `release_version` |
 | GET | `/v1/capabilities` | `capabilities()` | Pro feature flags |
 | POST | `/v1/context` | `query()` | Structured-context QA |
 
@@ -91,9 +91,12 @@ curl -s -X POST http://localhost:8090/v1/context \
 
 #### GET `/v1/health`
 
-Liveness probe. Returns `{"status": "ok", "schema_version": 3}`. A client whose
-expected schema version differs forces a clean re-ingest (e.g. after the
-absolute→relative `source_uri` migration).
+Liveness probe. Returns `{"status": "ok", "schema_version": 3, "release_version": "1.0.28"}`.
+A client whose expected schema version differs forces a clean re-ingest (e.g. after the
+absolute→relative `source_uri` migration). `release_version` is the semver the running
+container was built as, when it knows — the container's own claim, not proof (it is an
+env var, so `docker run -e` can override it); clients fall back to the release they
+tracked when the field is absent.
 
 **Response**
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -977,6 +977,7 @@ components:
       properties:
         status: { type: string }
         schema_version: { type: integer, description: On-disk graph format version }
+        release_version: { type: string, description: Backend release semver, as claimed by the running container's build environment. Absent from backends that do not know their release. The container's own claim, not proof — an env var, so `docker run -e` can override it. }
     CapabilitiesResponse:
       type: object
       properties:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -977,7 +977,7 @@ components:
       properties:
         status: { type: string }
         schema_version: { type: integer, description: On-disk graph format version }
-        release_version: { type: string, description: Backend release semver, as claimed by the running container's build environment. Absent from backends that do not know their release. The container's own claim, not proof — an env var, so `docker run -e` can override it. }
+        release_version: { type: string, description: Backend release semver }
     CapabilitiesResponse:
       type: object
       properties:


### PR DESCRIPTION
# fix #599

## What

`docs/api/openapi.yaml` documents the `/v1/health` response (`HealthResponse`) with only `status` and `schema_version`, but the backend sends `release_version` on every response. A client reading the reference would never learn the field exists — exactly the drift class issue #599 filed with live evidence (`{"status":"ok","schema_version":3,"release_version":"1.0.28"}`, observed 2026-09-04).

This PR closes it docs-side: the spec now declares the field, and the reference docs match on every surface.

## The fix

- **`docs/api/openapi.yaml`** — `HealthResponse` gains `release_version: { type: string, description: Backend release semver }`, the exact shape #599 suggested. Optional (no `required` entry; `HealthResponse` has none), matching the client type's `release_version?: string`.
- **`docs/api/README.md`** — all four surfaces that describe the endpoint updated to match: the endpoint table row, the `GET /v1/health` prose, the response example, and the `HealthResponse` TS reference block.

## Cross-checked against the client type

`ix-cli/src/client/types.ts` has carried the field with full semantics:

```ts
release_version?: string;
// The published release the running container was built as, when it knows.
// Absent from any backend older than Ix-memory#157, and from any image not
// built by the release pipeline — both mean "fall back to what you tracked".
// This is the container's own claim, not proof: it is an env var, so
// `docker run -e` overrides it. ...
```

Docs-only — the wire format is unchanged; the reference now matches the running backend and the client type.

## On #599's parity-gate question

Issue #599 asked whether the commit-time parity gate (#586/#591's `check-api-parity.mjs`) would have caught this. Answer, verified behaviorally against the gate as it stands: **no — the gate compares endpoints and schema names against `types.ts` exports, not schema properties.** Evidence: removing `schema_version` from `HealthResponse` in the spec leaves the checker's output byte-identical, while `types.ts` has carried `release_version` all along. Property-level drift passes the gate.

Widening it (validate spec `properties` against types.ts field sets) is a real, separable improvement — left out of this docs fix deliberately so this PR stays one clean story; happy to follow up with the gate extension if wanted.

## Relation to #591

Independent of that PR's outcome: #591 adds the gate itself; this fixes the concrete instance #599 filed and answers its question about the gate's blind spot. Branch cut from current `main` (`fb46941`); no #591 files touched beyond the two docs files the trio already tracks.

Closes #599