### PR TITLE
fix(ingest): stop the harness timing out under load, and close four review findings

### DIFF
--- a/ix-cli/src/cli/__tests__/ingest-files.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-files.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createServer, type Server, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
@@ -147,11 +147,20 @@ class FakeBackend {
       // and fires against a closed server.
       if (refused) return send(500, { error: "500: transaction begin timeout" });
       this.rev += patches.length || 1;
+      // `status` included, because `PatchCommitResult` declares it required and
+      // the ingest path branches on it. Serving 200s without it left
+      // `result.status` undefined everywhere, so this fake could never produce
+      // an `Idempotent` or `BaseRevMismatch` answer -- the two branches that
+      // decide whether a patch lands in `patchesApplied` or `commitErrors`, and
+      // so whether the mtime baseline is written at all. A regression that
+      // flipped the applied test from "not BaseRevMismatch" to `=== "Ok"` would
+      // have counted zero patches applied against the real backend while every
+      // test here stayed green.
       send(
         200,
         path === "/v1/patches/bulk"
-          ? { rev: this.rev, applied: patches.length }
-          : { rev: this.rev },
+          ? { rev: this.rev, applied: patches.length, status: "Ok" }
+          : { rev: this.rev, status: "Ok" },
       );
       return;
     }
@@ -178,6 +187,17 @@ class FakeBackend {
 }
 
 describe("ingestFiles against a fake backend", () => {
+  // Every test here runs a REAL ingest -- discovery, a worker-thread parse
+  // pool, and an HTTP round trip per commit -- against 30 files. On an idle
+  // machine each takes about a second, comfortably inside vitest's 5s default,
+  // which is why this file went in without an explicit timeout. Under the full
+  // suite's parallelism that is not true: measured on `main`, the Ix#560 case
+  // exceeded 5s and failed in 1 of 4 full `ix-cli` runs here, and in 3 of 3
+  // when the heavier repo-root suite was running. A timeout that fires only
+  // under load reads as a real regression on whichever CI leg was busiest, so
+  // it is set from the work these tests actually do rather than inherited.
+  vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
   let home: string;
   let repo: string;
   let backend: FakeBackend;
@@ -273,17 +293,29 @@ describe("ingestFiles against a fake backend", () => {
   });
 
   afterEach(async () => {
-    // Every request the run made was one this fake actually implements. If the
-    // ingest path grows an endpoint, this fails once with its name, rather than
-    // ten tests passing against a fake that agreed with everything.
-    expect(backend.unknownPaths, "endpoints the fake does not implement").toEqual([]);
-    await backend.stop();
-    for (const [k, v] of Object.entries(saved)) {
-      if (v === undefined) delete process.env[k];
-      else process.env[k] = v;
+    try {
+      // Every request the run made was one this fake actually implements. If
+      // the ingest path grows an endpoint, this fails once with its name,
+      // rather than ten tests passing against a fake that agreed with
+      // everything.
+      expect(backend.unknownPaths, "endpoints the fake does not implement").toEqual([]);
+    } finally {
+      // In a `finally`, because the assertion above threw straight past all of
+      // this -- in exactly the case it exists for. The server stayed listening
+      // (an open handle that can stop the vitest worker exiting, turning one
+      // named failure into a job timeout), both temp trees leaked, and
+      // `HOME`/`USERPROFILE`/`IX_ENDPOINT` stayed pointed at the fixture. Worse,
+      // `saved` is shared across the describe, so the next `beforeEach`
+      // snapshotted those polluted values and the file's final restore wrote
+      // the fixture `HOME` back into the process.
+      await backend.stop();
+      for (const [k, v] of Object.entries(saved)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+      rmSync(home, { recursive: true, force: true });
+      rmSync(repo, { recursive: true, force: true });
     }
-    rmSync(home, { recursive: true, force: true });
-    rmSync(repo, { recursive: true, force: true });
   });
 
   const run = () =>

--- a/ix-cli/src/cli/commands/ingestion-loader.ts
+++ b/ix-cli/src/cli/commands/ingestion-loader.ts
@@ -48,8 +48,36 @@ const importModule = async (specifier: string): Promise<any> => {
   try {
     return await importViaFunction(specifier);
   } catch (err) {
-    if (!/dynamic import callback/i.test(String(err))) throw err;
-    return await import(specifier);
+    // Matched on `code`, not on the message. Node raises
+    // ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING and ..._FLAG here, and the
+    // previous test was a substring of the English text -- reword that upstream
+    // and this guard silently stops matching: the harness goes red with the
+    // original vm error and a real vm-hosted consumer regresses to unloadable,
+    // with nothing pointing at the guard. The message check is kept only as a
+    // fallback for an error that arrives without a code.
+    const code = (err as NodeJS.ErrnoException | null)?.code;
+    const isVmCallbackMissing = code
+      ? code.startsWith("ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING")
+      : /dynamic import callback/i.test(String(err));
+    if (!isVmCallbackMissing) throw err;
+    try {
+      // The ignore pragmas are load-bearing, not decoration. A bare
+      // `import(variable)` is exactly the static-analysis surface the
+      // `new Function` indirection above exists to avoid: bundlers analyse it
+      // whichever branch runs, and webpack/ncc turn it into a critical-
+      // dependency context module over the whole directory. A second
+      // `new Function` is not an option -- that is the path that just failed.
+      return await import(/* webpackIgnore: true */ /* @vite-ignore */ specifier);
+    } catch (fallbackErr) {
+      // Both paths failed, so report both. Discarding the vm error here meant a
+      // host where neither works blamed module resolution for what was really
+      // the missing import callback.
+      throw new Error(
+        `cannot load ${specifier}: dynamic import is unavailable in this host ` +
+          `(${String(err)}), and the direct import also failed (${String(fallbackErr)})`,
+        { cause: fallbackErr },
+      );
+    }
   }
 };
 


### PR DESCRIPTION
Follow-up to #597, which merged before its review came back. Four findings from that review, plus a flake the review could not see because it only appears under the full suite's parallelism.

## The flake (not in the review — found by running the suite)

Every test in `ingest-files.test.ts` runs a **real** ingest: discovery, a worker-thread parse pool, and an HTTP round trip per commit, over 30 files. On vitest's 5s default timeout. About a second each on an idle machine, which is why it went in without an explicit one.

Under load that is not true. Measured on `main`:

| Condition | Ix#560 test |
|---|---|
| full `ix-cli` suite | **failed 1 of 4 runs** |
| heavier repo-root suite running too | **failed 3 of 3** |
| after this change | 0 of 5 |

A test that only times out on whichever CI leg happens to be busiest reads as a real regression, on six legs. `vi.setConfig` now sets the timeout from the work these tests actually do rather than inheriting a default sized for unit tests.

## Findings from the #597 review

**medium — `afterEach` asserted before it cleaned up.** The `unknownPaths` assertion ran *before* `backend.stop()`, the env restore and both `rmSync` calls, so in exactly the case that assertion exists for, the throw skipped all of them: the HTTP server stayed listening (an open handle that can stop the vitest worker exiting, turning one named failure into a job timeout), both temp trees leaked, and `HOME`/`USERPROFILE`/`IX_ENDPOINT` stayed pointed at the fixture. Because `saved` is shared across the describe, the next `beforeEach` then snapshotted those polluted values and the file's final restore wrote the fixture `HOME` back into the process. Teardown is in a `finally` now.

**low — the fake never sent `status`.** `PatchCommitResult` declares it required and the ingest path branches on it, so every commit came back with `result.status === undefined` and the harness could never produce an `Idempotent` or `BaseRevMismatch` answer. Those are the two branches that decide whether a patch lands in `patchesApplied` or `commitErrors`, and therefore whether the mtime baseline is written at all. A regression flipping the applied test from "not `BaseRevMismatch`" to `=== "Ok"` would have counted zero patches applied against the real backend while every test here stayed green.

**low — the loader's vm fallback matched on English.** It now matches `err.code` (`ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`, plus the `..._FLAG` variant by prefix), keeping the message test only for an error that arrives without a code. Verified in both directions rather than assumed:

- message fallback disabled → suite still passes, so the `code` path is what carries it
- code prefix broken *and* fallback disabled → guard correctly stops matching, the vm error surfaces

**low — the original error was discarded** when the fallback `import()` also failed, so a host where neither path works blamed module resolution for what was really a missing import callback. Both are reported now.

**low — the fallback reintroduced a bare `import(variable)`** into the shipped bundle, which is precisely the static-analysis surface the `new Function` indirection exists to avoid: bundlers analyse it whichever branch runs at runtime, and webpack/ncc turn it into a critical-dependency context module over the whole directory. A second `new Function` is not an option — that is the path that just failed — so it carries `webpackIgnore` and `@vite-ignore` pragmas.

## Verification

- `ingest-files` suite: 10 passed
- Full `ix-cli` suite ×5: 1730 passed each; the 3 failures are the `read-containment` symlink tests that need Windows Developer Mode locally and pass on CI's `windows-2022` runner
- `tsc --noEmit` and `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5bkc5oUL4SapwDE13UgHt