### PR TITLE
docs: document the review process in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,40 @@ cd ix-cli && npm test
 4. Open a PR using the pull request template
 5. Ensure CI passes before merge
 
+## Review Process
+
+### What reviewers check
+
+- **Behavior over intent.** A PR is judged by what its code does when run, not
+  by what its description promises. Cite the commands and their output for
+  every behavioral claim.
+- **Stream discipline.** Assertions that read combined output can mask
+  failures. Compare stdout and stderr separately when output routing matters.
+- **Hermetic tests.** Tests use fixture environments (`HOME`/`USERPROFILE`
+  redirection, temp dirs), never developer-machine paths, and declare
+  platform behavior explicitly — macOS, Ubuntu, and Windows differ in path
+  and shell semantics.
+- **Option classification.** Every CLI option is accounted for in tests;
+  adding an option without updating its test is a review finding.
+- **Exit codes are contract.** A documented failure path must actually exit
+  non-zero, in dry-run and real modes alike.
+
+### Review requests
+
+- GitHub requests review from code owners when a PR is **marked ready for
+  review**, not while it is a draft. Keep a PR in draft while iterating to
+  keep reviewer queues quiet.
+- A pending code-owner request cannot be removed by the PR author once it
+  fires. If one appears where it is not needed, say so on the PR thread and a
+  maintainer will dismiss it after triage.
+
+### Working through findings
+
+- Address findings point per point in the thread, with reproduced evidence —
+  actual command output beats general agreement.
+- If a finding cannot be reproduced, say so and show exactly which commands
+  you ran; the reviewer re-runs them before the PR moves forward.
+
 ## Branch Naming
 
 ```


### PR DESCRIPTION
## Status: DRAFT — feedback welcome

This PR documents the contribution review process in `CONTRIBUTING.md`. It is opened as a draft deliberately: no review request fires while it is a draft, and it can be marked ready whenever a maintainer wants it in their queue.

Feedback on wording, placement, or scope is welcome and expected. If any statement here misdescribes the project's actual review practice, that is a doc bug — say so and it gets fixed.

## Scope

`CONTRIBUTING.md` only. One new `## Review Process` section between `## Development Workflow` and `## Branch Naming`, with three subsections:

- **What reviewers check** — behavior over intent, stream discipline (stdout/stderr compared separately), hermetic tests, option classification, exit codes as contract.
- **Review requests** — GitHub requests review from code owners when a PR is marked ready for review, not while it is a draft; a pending code-owner request cannot be removed by the PR author once it fires, so flag it on-thread for maintainer triage instead.
- **Working through findings** — point-per-point replies with reproduced evidence; if a finding cannot be reproduced, show the exact commands run.

## Why

The review-request behavior (code-owner requests fire at mark-ready on a previously-drafted PR, and pending requests are unremovable by the author — GitHub bug #69208) is surprising to contributors and produces support overhead on both sides. Documenting it sets expectations: draft while iterating, ready when you want review. The "what reviewers check" list mirrors the standards the project's CI gates and review history already enforce, so the section documents existing practice rather than introducing new policy.

## Validation

- Diff is the one added section plus the `## Branch Naming` heading it precedes — no other lines touched (`git diff` viewable below).
- Content reviewed against the current `CONTRIBUTING.md` sections and the repo's actual CI gates (test matrix, doc-drift scans) for accuracy.
- No code, CI, or runtime behavior changed by this PR.

## Known limitations

The section describes current practice as observed; if maintainer workflow differs from any statement, the text should be adjusted rather than the workflow.