### PR TITLE
docs: note draft-first PRs in CONTRIBUTING — code owners are requested at mark-ready

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,9 @@ cd ix-cli && npm test
 1. Create a branch from `main`
 2. Make your changes
 3. Run tests locally
-4. Open a PR using the pull request template
+4. Open a PR using the pull request template — work-in-progress opens as a draft;
+   GitHub requests code owners at mark-ready, not at draft-open, and a ready-open
+   auto-request cannot be removed once a PR is a draft (see #608)
 5. Ensure CI passes before merge
 
 ## Branch Naming


### PR DESCRIPTION
## Status: DRAFT — durable-cure companion to the released train

This pull request is intentionally a **draft**. Feedback and suggestions are welcome at any stage — each point gets addressed on this branch, folded in or answered. The change below is accurate and complete; the branch may still move before it is marked ready.

Refs #608 — that issue records the behavior behind this note; the platform root cause lives upstream (community discussion #69208), so this PR references rather than closes it. The mark-ready auto-request on #605 (2026-09-06) is the first-hand instance this note teaches contributors to avoid.

## What this ships

One line added to **CONTRIBUTING.md** (Development Workflow, step 4 — the canonical "open a PR" instruction), grounded at current main `8c0e6b00eabc`:

```
4. Open a PR using the pull request template — work-in-progress opens as a draft;
   GitHub requests code owners at mark-ready, not at draft-open, and a ready-open
   auto-request cannot be removed once a PR is a draft (see #608)
```

That is the whole change. CONTRIBUTING's workflow list is where contributors read the PR step, and its exit-code section already teaches draft-until-dependency — this completes the draft guidance in one place. The PR template has no review-flow section, so no change there.

## Scope

- CONTRIBUTING.md only — one file, one line; docs-only, no tests affected.
- No CODEOWNERS, workflow, template, or product-code change.
- The removal-block is a GitHub platform bug (community #69208), tracked in #608 — not fixable from this repo.
- Nothing is promised beyond what this PR ships.

## Validation

- Consistent with live GitHub behavior, observed first-hand on this repository: #605 opened draft-from-open carried zero requested reviewers through its entire draft life; the moment it was marked ready (2026-09-06), the code-owner request fired and cannot be removed — exactly the sequence this note tells contributors to expect.
- Exact diff re-verified against CONTRIBUTING.md at main `8c0e6b00eabc` (step 4 is the single line shown above; nothing else in the file changes).