### PR TITLE
chore(install): label installer output per host and add --help

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,7 +373,9 @@ jobs:
 
           install_out=$(bash scripts/install-skill.sh --dry-run)
           printf '%s\n' "$install_out"
-          grep -Fq 'would install: /tmp/ix-harness-home/.claude/skills/ix' <<<"$install_out"
+          grep -Fq 'would install [claude]: /tmp/ix-harness-home/.claude/skills/ix' <<<"$install_out"
+          grep -Fq 'Add --json for a machine-readable report' <<<"$install_out"
+          bash scripts/install-skill.sh --help | grep -Fq 'Valid harness ids:'
           test ! -e "$HOME/.claude/skills/ix"
 
           shell_json=$(bash scripts/install-skill.sh --dry-run --json)
@@ -479,7 +481,9 @@ jobs:
           install_out=$(bash scripts/install-skill.sh --dry-run)
           printf '%s\n' "$install_out"
           dest="$HOME/.claude/skills/ix"
-          grep -Fq "would install: $dest" <<<"$install_out"
+          grep -Fq "would install [claude]: $dest" <<<"$install_out"
+          grep -Fq 'Add --json for a machine-readable report' <<<"$install_out"
+          bash scripts/install-skill.sh --help | grep -Fq 'Valid harness ids:'
           test ! -e "$dest"
 
           shell_json=$(bash scripts/install-skill.sh --dry-run --json)

--- a/scripts/install-skill.sh
+++ b/scripts/install-skill.sh
@@ -36,8 +36,6 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SRC="$ROOT/skills/ix"
 [ -f "$SRC/SKILL.md" ] || { echo "error: $SRC/SKILL.md not found" >&2; exit 1; }
 
-# Argument parsing runs after the harness registry is read (below) so --help
-# can list the real registry ids; nothing between here and the read uses flags.
 
 # A machine-readable report replaces the human output: one object per harness
 # with the action this run takes (would-install | would-refuse | installed |
@@ -45,8 +43,53 @@ SRC="$ROOT/skills/ix"
 # (toolscan | path | config-dir | none), mirroring `ix mcp install`'s report.
 # CI asserts the JSON fields instead of grepping the human lines.
 
-# --- Read the harness registry (hosts.ts via the helper, no built CLI) ------
 HELPER="$ROOT/ix-cli/scripts/skill-harnesses.mjs"
+
+# --- Argument parsing --------------------------------------------------------
+#
+# BEFORE the registry read below, deliberately. Both the node requirement and
+# the probe `exit 1`, so parsing after them meant `--help` on a machine without
+# node answered
+#     error: node is required to read the harness registry
+# and `--bogus` did too -- reporting the toolchain instead of the option. Usage
+# and option validation must not depend on a toolchain; someone reaching for
+# --help is often someone who has not got one yet.
+#
+# Listing the REAL registry ids is still worth having, so --help asks for them
+# separately and treats failure as silence: they enrich a help message, they are
+# never a reason to withhold one.
+usage() {
+  echo "Usage: bash scripts/install-skill.sh [options] [harness-ids...]"
+  echo "  --force     overwrite a same-name foreign skill"
+  echo "  --dry-run   show the targets, write nothing"
+  echo "  --json      machine-readable report (same shape as ix mcp install)"
+  echo "  --help      this message"
+  # Best effort. `|| true` because this runs under `set -e` and a missing node,
+  # a broken helper or an empty probe must all leave --help exiting 0.
+  local ids=""
+  if command -v node >/dev/null 2>&1; then
+    ids="$(node "$HELPER" --probe 2>/dev/null | cut -d'|' -f1 | tr '\n' ' ')" || true
+  fi
+  [ -n "${ids// /}" ] && echo "Valid harness ids: ${ids% }"
+  return 0
+}
+
+FORCE=0
+DRY_RUN=0
+JSON=0
+EXPLICIT=()
+for arg in "$@"; do
+  case "$arg" in
+    --force) FORCE=1 ;;
+    --dry-run) DRY_RUN=1 ;;
+    --json) JSON=1 ;;
+    --help|-h) usage; exit 0 ;;
+    -*) echo "error: unknown option $arg" >&2; echo "       try: bash scripts/install-skill.sh --help" >&2; exit 1 ;;
+    *) EXPLICIT+=("$arg") ;;
+  esac
+done
+
+# --- Read the harness registry (hosts.ts via the helper, no built CLI) ------
 if [ ! -f "$HELPER" ]; then
   echo "error: $HELPER not found (the harness registry helper)" >&2
   exit 1
@@ -73,29 +116,6 @@ if [ "${#IDS[@]}" = "0" ]; then
   echo "error: harness registry produced no entries" >&2
   exit 1
 fi
-
-# --- Argument parsing (--help lists the real registry ids) -------------------
-FORCE=0
-DRY_RUN=0
-JSON=0
-EXPLICIT=()
-for arg in "$@"; do
-  case "$arg" in
-    --force) FORCE=1 ;;
-    --dry-run) DRY_RUN=1 ;;
-    --json) JSON=1 ;;
-    --help|-h)
-      echo "Usage: bash scripts/install-skill.sh [options] [harness-ids...]"
-      echo "  --force     overwrite a same-name foreign skill"
-      echo "  --dry-run   show the targets, write nothing"
-      echo "  --json      machine-readable report (same shape as ix mcp install)"
-      echo "  --help      this message"
-      echo "Valid harness ids: ${IDS[*]}"
-      exit 0 ;;
-    -*) echo "error: unknown option $arg" >&2; echo "       try: bash scripts/install-skill.sh --help" >&2; exit 1 ;;
-    *) EXPLICIT+=("$arg") ;;
-  esac
-done
 
 # --- Explicit harness id selection (unknown ids are an error, not a no-op) ---
 if [ "${#EXPLICIT[@]}" -gt 0 ]; then

--- a/scripts/install-skill.sh
+++ b/scripts/install-skill.sh
@@ -36,19 +36,8 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SRC="$ROOT/skills/ix"
 [ -f "$SRC/SKILL.md" ] || { echo "error: $SRC/SKILL.md not found" >&2; exit 1; }
 
-FORCE=0
-DRY_RUN=0
-JSON=0
-EXPLICIT=()
-for arg in "$@"; do
-  case "$arg" in
-    --force) FORCE=1 ;;
-    --dry-run) DRY_RUN=1 ;;
-    --json) JSON=1 ;;
-    -*) echo "error: unknown option $arg" >&2; exit 1 ;;
-    *) EXPLICIT+=("$arg") ;;
-  esac
-done
+# Argument parsing runs after the harness registry is read (below) so --help
+# can list the real registry ids; nothing between here and the read uses flags.
 
 # A machine-readable report replaces the human output: one object per harness
 # with the action this run takes (would-install | would-refuse | installed |
@@ -84,6 +73,29 @@ if [ "${#IDS[@]}" = "0" ]; then
   echo "error: harness registry produced no entries" >&2
   exit 1
 fi
+
+# --- Argument parsing (--help lists the real registry ids) -------------------
+FORCE=0
+DRY_RUN=0
+JSON=0
+EXPLICIT=()
+for arg in "$@"; do
+  case "$arg" in
+    --force) FORCE=1 ;;
+    --dry-run) DRY_RUN=1 ;;
+    --json) JSON=1 ;;
+    --help|-h)
+      echo "Usage: bash scripts/install-skill.sh [options] [harness-ids...]"
+      echo "  --force     overwrite a same-name foreign skill"
+      echo "  --dry-run   show the targets, write nothing"
+      echo "  --json      machine-readable report (same shape as ix mcp install)"
+      echo "  --help      this message"
+      echo "Valid harness ids: ${IDS[*]}"
+      exit 0 ;;
+    -*) echo "error: unknown option $arg" >&2; echo "       try: bash scripts/install-skill.sh --help" >&2; exit 1 ;;
+    *) EXPLICIT+=("$arg") ;;
+  esac
+done
 
 # --- Explicit harness id selection (unknown ids are an error, not a no-op) ---
 if [ "${#EXPLICIT[@]}" -gt 0 ]; then
@@ -148,7 +160,7 @@ for ((i = 0; i < ${#IDS[@]}; i++)); do
     continue
   fi
   if [ "$DRY_RUN" = "1" ]; then
-    say "would install: $dest"
+    say "would install [$id]: $dest"
     DECISIONS+=("$id"$'\t'"would-install"$'\t'"$dest"$'\t'"$via")
     installed=$((installed + 1))
     continue
@@ -158,7 +170,7 @@ for ((i = 0; i < ${#IDS[@]}; i++)); do
     rm -rf "$dest"
   fi
   cp -R "$SRC" "$dest"
-  say "Installed: $dest"
+  say "Installed [$id]: $dest"
   DECISIONS+=("$id"$'\t'"installed"$'\t'"$dest"$'\t'"$via")
   installed=$((installed + 1))
 done
@@ -184,6 +196,7 @@ fi
 if [ "$DRY_RUN" = "1" ]; then
     echo
     echo "Dry run: $installed harness(es) would receive the skill."
+    echo "Add --json for a machine-readable report (same shape as ix mcp install)."
     # The preview and the real run must agree: a conflict in the real run
     # exits 1, so a preview that predicts a refusal exits 1 too.
     [ "$conflicts" = "0" ] || exit 1


### PR DESCRIPTION
## Status: DRAFT — smallest installer-UX polish, re-derived onto current main

This pull request is intentionally a **draft**. Feedback and suggestions are welcome at any stage — each point gets addressed on this branch, folded in or answered. The change below is accurate and complete; the branch may still move before it is marked ready.

Refs #611 — this delivers the id-label half of that request. The per-host summary table is deliberately held for a follow-up so this PR stays smallest-first (see Scope).

## What this ships

Three output-text changes to `scripts/install-skill.sh` plus the two CI assertions that must move with them, grounded at current main `8c0e6b00eabc`:

1. **Id-labeled install lines.** `Installed: <dest>` becomes `Installed [claude]: <dest>` (same for `would install [claude]: <dest>` in previews) — four long look-alike paths are distinguishable at a glance, and the id is already in hand in the loop. No behavior change.
2. **A real `--help`.** Prints the usage block and the valid harness ids from the registry (`claude agents codex cursor`), exits 0. Unknown options keep their exit-1 error and gain `try: bash scripts/install-skill.sh --help`. Argument parsing moves after the registry read so `--help` lists real ids; nothing between the two points reads the flags.
3. **Dry-run footer names the JSON variant.** One added line: `Add --json for a machine-readable report (same shape as ix mcp install).` — an in-band signal that `--json` exists, on a shape-parity claim that is already true.

**CI updated in the same change** (both the posix and windows install-smoke jobs): the `would install:` grep assertions become `would install [claude]:`, and each job additionally asserts the new footer line and the `--help` ids line. The old assertions break without this — verified, not assumed (see Validation).

## Deliberately not in this PR

- The per-host summary table (the second half of #611): larger output change, deserves its own review; happy to follow with it.
- No `--prefix`/`--root` flag, no progress bars, no color, no change to guard order, exit codes, or the JSON shape — the audit verified those as sound.

## Scope

- `scripts/install-skill.sh` and `.github/workflows/ci.yml` only. No product code, no README, no registry change.

## Validation

- Hermetic `HOME`-redirected runs on this machine: `--dry-run` shows the four labeled targets and the new footer; `--dry-run --json` parses and carries the same `id/action/dest/detectedVia` shape as before; the foreign-skill refusal still exits 1 with the destination untouched while other hosts install; `--force` bypasses the ix-ownership guard for any existing target (its documented purpose is overwriting a same-name foreign skill), while a bare re-run overwrites a previous Ix install and still refuses a foreign skill.
- CI-assertion simulation at the CI's `/tmp/ix-harness-home` fixture: every new grep passes against the actual job output, and the old `would install:` assertion fails against it — confirming the CI lines must move in the same commit, which they do here.