### PR TITLE
fix(ingest): say when a run's errors cost the workspace its stitch

### DIFF
--- a/ix-cli/src/cli/__tests__/ingest-commit-outcome.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-commit-outcome.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { describeCommitOutcome, describeStitchFailure, describeStitchSkipped, ingestCompletedCleanly, isStitchUnsupported } from "../commands/ingest.js";
+import { describeCommitOutcome, describeStitchFailure, describeStitchSkipped, ingestCompletedCleanly, isStitchUnsupported, shouldPrintStitchSkipped } from "../commands/ingest.js";
 
 describe("describeCommitOutcome", () => {
   it("says nothing when every patch committed", () => {
@@ -235,9 +235,64 @@ describe("describeStitchFailure", () => {
   });
 });
 
+describe("shouldPrintStitchSkipped", () => {
+  // Ix#620. `run-errors` computed a message and then never printed it, on the
+  // grounds that the run had "already said so". It had not: the line it
+  // deferred to reports that the graph is missing THOSE FILES and says to
+  // re-run `ix map` -- while what was actually withheld is the whole
+  // workspace's cross-workspace registration, and a plain re-run is
+  // incremental, lands on the silent `incomplete` branch, and never recovers
+  // it. Measured: one commit error in 2,067 patches cost a 2,066-file
+  // workspace every cross-repo edge it had, on a run that exited 0.
+  it("prints for run-errors", () => {
+    expect(shouldPrintStitchSkipped("run-errors", false)).toBe(true);
+  });
+
+  // The other half of the rule, and the reason this is not just "print
+  // everything": `incomplete` fires on nearly every incremental map, so it is
+  // the steady state rather than an event.
+  it("stays silent for incomplete", () => {
+    expect(shouldPrintStitchSkipped("incomplete", false)).toBe(false);
+  });
+
+  it("prints for every other refusal", () => {
+    for (const rule of ["lost-parses", "run-errors", "cooling", "in-flight", "deadline"] as const) {
+      expect(shouldPrintStitchSkipped(rule, false), rule).toBe(true);
+    }
+  });
+
+  // `ix map` passes suppressOutput and is deliberately one terse line per run.
+  // The machine token still carries the rule, so nothing is lost by staying
+  // quiet here -- including for the rule this issue made loud.
+  it("never prints under --silent, not even for run-errors", () => {
+    for (const rule of ["run-errors", "lost-parses", "incomplete", "deadline"] as const) {
+      expect(shouldPrintStitchSkipped(rule, true), rule).toBe(false);
+    }
+  });
+});
+
 describe("describeStitchSkipped", () => {
   const cooling = "the last stitch was cut off after 62s and may still be running";
   const contended = "another ix run is already stitching http://localhost:8090";
+
+  // Ix#620. `run-errors` was the one rule that computed a message and then
+  // never printed it, on the grounds that the run had "already said so". The
+  // line it was deferring to says the graph is missing THOSE FILES and tells
+  // the user to re-run `ix map` — neither of which is true of the stitch: the
+  // whole workspace's registration is withheld, and a plain re-run is
+  // incremental, lands on the silent `incomplete` branch, and never recovers
+  // it. So the text has to name the consequence and name `--force`.
+  it("names the registration and the only remedy that recovers it (run-errors)", () => {
+    const msg = describeStitchSkipped(
+      "this run had parse or commit errors, so its registration would be built from an incomplete picture of the repo",
+      "run-errors",
+    );
+    expect(msg.startsWith("Note:")).toBe(true);
+    // Not "those files" — the thing withheld is the cross-workspace registration.
+    expect(msg).toContain("Cross-workspace stitch not started");
+    // `ix map` alone does NOT get back in; only a forced re-ingest does.
+    expect(msg).toContain("--force");
+  });
 
   it("is a Note, not a failure, and leads with the reason", () => {
     const msg = describeStitchSkipped(cooling, "cooling");

--- a/ix-cli/src/cli/commands/ingest.ts
+++ b/ix-cli/src/cli/commands/ingest.ts
@@ -1068,6 +1068,48 @@ export function describeStitchFailure(error: unknown): string {
  * the ways back in: a fresh map, `--force`, or a post-reset re-map. What the
  * cooldown changes is only how often this path is taken, not where it leads.
  */
+/**
+ * Does a skipped stitch get a human Note, or only the machine surfaces?
+ *
+ * Extracted so the rule is pinned by a test rather than by reading a
+ * conditional buried in `ingestFiles` (Ix#620). Every rule is always on
+ * `stitchSkipped` / `stitch_skipped`; this decides stderr only.
+ */
+export function shouldPrintStitchSkipped(
+  rule: StitchRefusal | undefined,
+  suppressOutput: boolean,
+): boolean {
+  // Never on `--silent`. `ix map` always passes `suppressOutput`, and that
+  // surface is deliberately one terse line per run; the machine token still
+  // carries the rule, so nothing is lost.
+  if (suppressOutput) return false;
+
+  // `incomplete` is the one silent rule, and stays that way: it fires on nearly
+  // every incremental map, so what it reports is the ordinary steady state
+  // rather than an event worth a ~250-character Note on every save.
+  //
+  // `run-errors` PRINTS (Ix#620). It was suppressed on the grounds that it
+  // "restates lines the run has already printed", and that is false in both
+  // halves. What the run actually prints is
+  //
+  //   Warning: 1 of 2067 file patches failed to commit; the graph is missing
+  //   those files. Re-run 'ix map' to retry, or --debug to see why.
+  //
+  // which is about THOSE FILES. It never says the whole workspace's
+  // cross-workspace registration was withheld -- one file versus every
+  // cross-repo edge the workspace has. And the remedy it offers is the wrong
+  // one here: a plain `ix map` re-run is incremental, so
+  // `filesSkippedAsUnchanged > 0` lands it on `incomplete`, which is silent --
+  // the user re-runs, sees a clean exit, and the registration stays frozen.
+  // Only `--force` gets back in, which is what the `run-errors` text says.
+  //
+  // Noise is not the objection either. Unlike `incomplete`, this can only fire
+  // on a run that already had errors. Measured on a 2,066-file ingest: one
+  // commit error out of 2,067 patches silently cost the largest workspace in
+  // the graph its entire cross-repo registration, on a run that exited 0.
+  return rule !== "incomplete";
+}
+
 export function describeStitchSkipped(
   reason: string,
   rule?: StitchRefusal,
@@ -3457,17 +3499,7 @@ export async function ingestFiles(
     process.exitCode = 1;
   } else if (
     stitchSkipped !== undefined &&
-    // Not on `--silent`. `ix map` always passes `suppressOutput`, and that
-    // surface is deliberately one terse line per run -- which is the stated
-    // reason `incomplete` is filtered out of its token. A ~250-character Note
-    // on every map for the whole 15-minute cooldown is the repetition the short
-    // form exists to avoid; the token still carries the rule.
-    opts.suppressOutput !== true &&
-    // The guard's refusals only. `incomplete` would print on nearly every
-    // incremental map, and `run-errors` restates lines the run has already
-    // printed; both are still on the machine surfaces.
-    stitchSkippedRule !== "incomplete" &&
-    stitchSkippedRule !== "run-errors"
+    shouldPrintStitchSkipped(stitchSkippedRule, opts.suppressOutput === true)
   ) {
     // Not an error and not an exit code: nothing failed, and the graph is
     // exactly where a failed stitch would have left it. But the sentence a


### PR DESCRIPTION
Fixes #620.

## The suppression rested on a claim that is false

`run-errors` computed a message and then never printed it. The reason given:

```ts
// The guard's refusals only. `incomplete` would print on nearly every
// incremental map, and `run-errors` restates lines the run has already
// printed; both are still on the machine surfaces.
```

It does not restate them. What the run actually prints is

```
Warning: 1 of 2067 file patches failed to commit; the graph is missing those
files. Re-run 'ix map' to retry, or --debug to see why.
```

which is about **those files**. It never says the whole workspace's cross-workspace registration was withheld — one file versus every cross-repo edge the workspace has.

And the remedy it offers is the wrong one here. A plain `ix map` re-run is incremental, so `filesSkippedAsUnchanged > 0` lands it on `incomplete`, which **is** silent: the user re-runs, sees a clean exit, and the registration stays frozen. `describeStitchSkipped`'s own comment already spells that trap out — *"an ordinary re-run is incremental, skips unchanged files, and never enters the stitch block"* — and only `--force` gets back in, which is exactly what the `run-errors` text says and what nobody was being shown.

## What it cost, measured

On a 2,066-file `--force` ingest: **one commit error out of 2,067 patches silently withheld the largest workspace in the graph's entire cross-repo registration**, on a run that exited 0.

```
provides: 2   consumes: 187   exports: 4268   symbol_consumes: 16993
```

Byte-identical across three consecutive runs, with no `POST /v1/stitch` issued at all, while smaller repos in the same session stitched in 460ms and 630ms. I only found it by diffing the four collection counts by hand.

## `incomplete` stays silent, deliberately

That half of the rule is right and is untouched: it fires on nearly every incremental map, so it reports the ordinary steady state rather than an event worth a ~250-character Note after every save. Noise is not the objection to `run-errors` either — unlike `incomplete`, it can only fire on a run that already had errors.

## Testability

The predicate moves into `shouldPrintStitchSkipped` so the rule is pinned by a test instead of by reading a conditional buried in `ingestFiles`. Four pins: `run-errors` prints, `incomplete` does not, every other refusal prints, and `--silent` prints nothing regardless (`ix map` is deliberately one terse line, and the machine token still carries the rule).

**Mutation-checked:** restoring the old `&& rule !== "run-errors"` turns exactly the two `run-errors` pins red and leaves the `incomplete` pin green.

```
ingest-commit-outcome.test.ts   39 passed
tsc --noEmit                    clean
full ix-cli suite               1757 passed / 2 skipped
```

The one suite failure is `watch-dedup`'s real-child-process test timing out at 35.7s against its 30s budget on a loaded box. It passes isolated on this branch and on `main`, and it is the same flake class #613 just fixed for `ingest-files.test.ts` — a test doing real work on a timeout sized for an idle machine. Flagging rather than folding a second fix in here.

## Not addressed here, and worth its own look

#620 also notes that **`--force` does not drive `filesSkipped` to 0** — measured 40, then 20, never zero on that repo — so the escape hatch every one of these messages recommends may not actually be reachable there. That is a separate question from whether the user is told, and I did not want to change gate semantics in the same PR that makes them visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnMJopSVeUMFifL74DJ2Gk
