### PR TITLE
fix(release): restore the CLI to the release staging, and assert it is there

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,6 +289,22 @@ jobs:
           # would silently print the plain-text heading instead of the banner —
           # the exact failure mode that shipped once because both files lived at
           # the repo root, outside every packaged layout.
+          # THE CLI ITSELF. Restored after v0.10.7 shipped without it: the banner
+          # change rewrote this block and dropped the line, so every tarball for
+          # every platform contained a `cli/` holding only `scripts/` and
+          # `assets/` -- no dist, no node_modules, no package.json. Nothing in
+          # the pipeline noticed. `release:` went green on all four platforms
+          # and the only job that failed was the Windows install check, whose
+          # message named a missing module path rather than an empty payload.
+          cp -rL ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
+          # ...and assert it, because the banner inputs below were guarded and
+          # the CLI they exist to decorate was not. A staging block is edited by
+          # people adding things to it; the guard has to cover what is already
+          # there, or the next edit removes it just as quietly as this one did.
+          test -f "$STAGING/cli/dist/cli/main.js" \
+            || { echo "::error::cli/dist/cli/main.js missing from staging — the tarball would contain no CLI at all"; exit 1; }
+          test -f "$STAGING/cli/package.json" && test -d "$STAGING/cli/node_modules" \
+            || { echo "::error::cli/package.json or cli/node_modules missing from staging — the CLI would not start"; exit 1; }
           cp -rL ix-cli/scripts/render-logo.mjs ix-cli/scripts/render-logo.d.mts "$STAGING/cli/scripts/"
           cp -rL ix-cli/assets/logo.png "$STAGING/cli/assets/"
           test -f "$STAGING/cli/scripts/render-logo.mjs" && test -f "$STAGING/cli/assets/logo.png" \


### PR DESCRIPTION
**v0.10.7 shipped a tarball with no CLI in it.** On every platform, `cli/` held only `scripts/` and `assets/`:

```
$ tar -tzf ix-0.10.7-linux-amd64.tar.gz | grep '^ix-[^/]*/cli/[^/]*/$'
ix-0.10.7-linux-amd64/cli/assets/
ix-0.10.7-linux-amd64/cli/scripts/
```

#605 rewrote the staging block to add the banner renderer and asset, and dropped

```sh
cp -rL ix-cli/dist ix-cli/node_modules ix-cli/package.json "$STAGING/cli/"
```

I merged that. My review checked that the banner files were **added** and did not check that the edit preserved what was already there.

**Mitigated already:** v0.10.7 is marked prerelease, so `/releases/latest` — which both `install.sh` and `install.ps1` use, and which excludes prereleases by design — resolves to v0.10.6. Confirmed: `latest -> v0.10.6`.

## The part worth fixing beyond the line

Nothing caught it. All four `Package` jobs went green, `release:` went green, the artifacts published. The only failure was the Windows install check, and its message named a module path rather than an empty payload:

```
Error: Cannot find module 'D:\a\_temp\ix home\cli\cli\dist\cli\main.js'
```

which reads as a layout bug — the sort this repo has actually had before — rather than "the release contains no CLI".

The asymmetry that allowed it is the sharp bit: **the same commit that removed the CLI copy added a `test -f` guard for the banner inputs.** The decoration was asserted; the thing it decorates was not. A staging block is edited by people adding to it, so its guards have to cover what is already there — otherwise the next edit removes it exactly as quietly as this one did.

`dist/cli/main.js`, `package.json` and `node_modules/` are each asserted now, before anything is archived.

## Verified

Simulated both directory shapes against the new guard:

```
good staging (with the restored cp)      -> guard PASSES
bad staging  (exactly what v0.10.7 made) -> guard FAILS, release refused
```

So this cannot be published again. Once this lands I will cut v0.10.8 and check the artifact contents before letting it become `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnMJopSVeUMFifL74DJ2Gk