### PR TITLE
fix(cli): support path disambiguation in graph queries

### DIFF
--- a/ix-cli/src/cli/__tests__/path-disambiguation.test.ts
+++ b/ix-cli/src/cli/__tests__/path-disambiguation.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Command } from "commander";
+import { registerCallersCommand } from "../commands/callers.js";
+import { registerImpactCommand } from "../commands/impact.js";
+
+const { search, expand } = vi.hoisted(() => ({ search: vi.fn(), expand: vi.fn() }));
+
+vi.mock("../../client/api.js", () => ({
+  IxClient: class {
+    async workspaceSystem() { return { systemId: null }; }
+    async search(...args: unknown[]) { return search(...args); }
+    async expand(...args: unknown[]) { return expand(...args); }
+  },
+}));
+
+vi.mock("../config.js", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../config.js")>(),
+  readStitchScope: () => undefined,
+  writeStitchScope: vi.fn(),
+}));
+
+vi.mock("../hierarchy.js", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../hierarchy.js")>(),
+  getSystemPath: async () => [],
+  bucketByHierarchy: async () => [],
+}));
+
+async function run(command: string, args: string[]) {
+  const program = new Command().name("ix").exitOverride();
+  registerCallersCommand(program);
+  registerImpactCommand(program);
+  const output: string[] = [];
+  vi.spyOn(console, "log").mockImplementation((...parts) => { output.push(parts.join(" ")); });
+  await program.parseAsync([command, "Duplicate", ...args, "--format", "json"], { from: "user" });
+  return JSON.parse(output.join("\n"));
+}
+
+describe.each(["impact", "callers", "callees"])("%s path disambiguation", (command) => {
+  let savedExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    savedExitCode = process.exitCode;
+    process.exitCode = undefined;
+    search.mockReset().mockResolvedValue([
+      { id: "first-id", kind: "function", name: "Duplicate", provenance: { sourceUri: "src/first.ts" } },
+      { id: "second-id", kind: "function", name: "Duplicate", provenance: { sourceUri: "src/second.ts" } },
+    ]);
+    expand.mockReset().mockResolvedValue({
+      nodes: command === "impact" ? [] : [{ id: "related-id", kind: "function", name: "Related" }],
+      edges: [],
+    });
+  });
+
+  afterEach(() => {
+    process.exitCode = savedExitCode;
+    vi.restoreAllMocks();
+  });
+
+  it("selects only the candidate matching --path", async () => {
+    const output = await run(command, ["--path", "second.ts"]);
+    expect(process.exitCode).toBeUndefined();
+    expect(output.resolvedTarget).toMatchObject({ name: "Duplicate", kind: "function" });
+    expect(expand).toHaveBeenCalled();
+    expect(expand.mock.calls.every(([id]) => id === "second-id")).toBe(true);
+  });
+
+  it("does not silently select a candidate outside --path", async () => {
+    const output = await run(command, ["--path", "missing.ts"]);
+    expect(process.exitCode).toBe(1);
+    expect(output.error).toBe("unresolved_target");
+    expect(expand).not.toHaveBeenCalled();
+  });
+
+  it("preserves ambiguity when no filter is supplied", async () => {
+    const output = await run(command, []);
+    expect(process.exitCode).toBe(1);
+    expect(output.error).toBe("ambiguous_target");
+    expect(expand).not.toHaveBeenCalled();
+  });
+});

--- a/ix-cli/src/cli/__tests__/path-disambiguation.test.ts
+++ b/ix-cli/src/cli/__tests__/path-disambiguation.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Command } from "commander";
 import { registerCallersCommand } from "../commands/callers.js";
 import { registerImpactCommand } from "../commands/impact.js";
+import { registerImportsCommand } from "../commands/imports.js";
 
 const { search, expand } = vi.hoisted(() => ({ search: vi.fn(), expand: vi.fn() }));
 
@@ -29,13 +30,14 @@ async function run(command: string, args: string[]) {
   const program = new Command().name("ix").exitOverride();
   registerCallersCommand(program);
   registerImpactCommand(program);
+  registerImportsCommand(program);
   const output: string[] = [];
   vi.spyOn(console, "log").mockImplementation((...parts) => { output.push(parts.join(" ")); });
   await program.parseAsync([command, "Duplicate", ...args, "--format", "json"], { from: "user" });
   return JSON.parse(output.join("\n"));
 }
 
-describe.each(["impact", "callers", "callees"])("%s path disambiguation", (command) => {
+describe.each(["impact", "callers", "callees", "imports", "imported-by"])("%s path disambiguation", (command) => {
   let savedExitCode: typeof process.exitCode;
 
   beforeEach(() => {

--- a/ix-cli/src/cli/commands/callers.ts
+++ b/ix-cli/src/cli/commands/callers.ts
@@ -17,14 +17,15 @@ export function registerCallersCommand(program: Command): void {
     .command("callers <symbol>")
     .description("Show methods/functions that call the given symbol (cross-file)")
     .option("--kind <kind>", "Filter target entity by kind")
+    .option("--path <path>", "Filter target entity by file path (substring match)")
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
     .option("--limit <n>", "Max results to show", "50")
     .option("--format <fmt>", "Output format (text|json|llm)", "text")
     .addHelpText("after", "\nExamples:\n  ix callers verify_token\n  ix callers processPayment --format json\n  ix callers parse --kind method --limit 20")
-    .action(async (symbol: string, opts: { kind?: string; pick?: number; limit: string; format: string }) => {
+    .action(async (symbol: string, opts: { kind?: string; path?: string; pick?: number; limit: string; format: string }) => {
       const client = new IxClient(getEndpoint());
       const limit = parseInt(opts.limit, 10);
-      const resolveOpts = { kind: opts.kind, pick: opts.pick };
+      const resolveOpts = { kind: opts.kind, path: opts.path, pick: opts.pick };
       const target = await resolveFileOrReport(client, symbol, resolveOpts, opts.format);
       if (!target) return;
       if (opts.format === "text") printResolved(target);
@@ -120,14 +121,15 @@ export function registerCallersCommand(program: Command): void {
     .command("callees <symbol>")
     .description("Show methods/functions called by the given symbol (cross-file)")
     .option("--kind <kind>", "Filter target entity by kind")
+    .option("--path <path>", "Filter target entity by file path (substring match)")
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
     .option("--limit <n>", "Max results to show", "50")
     .option("--format <fmt>", "Output format (text|json|llm)", "text")
     .addHelpText("after", "\nExamples:\n  ix callees processPayment\n  ix callees parse --format json")
-    .action(async (symbol: string, opts: { kind?: string; pick?: number; limit: string; format: string }) => {
+    .action(async (symbol: string, opts: { kind?: string; path?: string; pick?: number; limit: string; format: string }) => {
       const client = new IxClient(getEndpoint());
       const calleeLimit = parseInt(opts.limit, 10);
-      const resolveOpts = { kind: opts.kind, pick: opts.pick };
+      const resolveOpts = { kind: opts.kind, path: opts.path, pick: opts.pick };
       const target = await resolveFileOrReport(client, symbol, resolveOpts, opts.format);
       if (!target) return;
       if (opts.format === "text") printResolved(target);

--- a/ix-cli/src/cli/commands/impact.ts
+++ b/ix-cli/src/cli/commands/impact.ts
@@ -17,6 +17,7 @@ export function registerImpactCommand(program: Command): void {
     .command("impact <target>")
     .description("System risk analysis — what behavior is at risk if this changes")
     .option("--kind <kind>", "Filter target entity by kind")
+    .option("--path <path>", "Filter target entity by file path (substring match)")
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
     .option("--depth <n>", "Expansion depth for callers/importers (default 1, max 3)", "1")
     .option("--limit <n>", "Max top-impacted members to show", "10")
@@ -28,13 +29,13 @@ export function registerImpactCommand(program: Command): void {
     .action(
       async (
         symbol: string,
-        opts: { kind?: string; pick?: number; depth: string; limit: string; format: string }
+        opts: { kind?: string; path?: string; pick?: number; depth: string; limit: string; format: string }
       ) => {
         const client = new IxClient(getEndpoint());
         const limit = parseInt(opts.limit, 10);
         const depth = Math.min(Math.max(parseInt(opts.depth, 10) || 1, 1), 3);
 
-        const resolveOpts = { kind: opts.kind, pick: opts.pick };
+        const resolveOpts = { kind: opts.kind, path: opts.path, pick: opts.pick };
         const target = await resolveFileOrReport(client, symbol, resolveOpts, opts.format);
         if (!target) return;
 

--- a/ix-cli/src/cli/commands/imports.ts
+++ b/ix-cli/src/cli/commands/imports.ts
@@ -10,14 +10,15 @@ export function registerImportsCommand(program: Command): void {
     .command("imports <symbol>")
     .description("Show what the given entity imports")
     .option("--kind <kind>", "Filter target entity by kind")
+    .option("--path <path>", "Filter target entity by file path (substring match)")
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
     .option("--limit <n>", "Max results to show", "50")
     .option("--format <fmt>", "Output format (text|json|llm)", "text")
     .addHelpText("after", "\nExamples:\n  ix imports auth.py\n  ix imports IngestionService --format json")
-    .action(async (symbol: string, opts: { kind?: string; pick?: number; limit: string; format: string }) => {
+    .action(async (symbol: string, opts: { kind?: string; path?: string; pick?: number; limit: string; format: string }) => {
       const client = new IxClient(getEndpoint());
       const limit = parseInt(opts.limit, 10);
-      const resolveOpts = { kind: opts.kind, pick: opts.pick };
+      const resolveOpts = { kind: opts.kind, path: opts.path, pick: opts.pick };
       const target = await resolveFileOrReport(client, symbol, resolveOpts, opts.format);
       if (!target) return;
       if (opts.format === "text") printResolved(target);
@@ -29,14 +30,15 @@ export function registerImportsCommand(program: Command): void {
     .command("imported-by <symbol>")
     .description("Show what imports the given entity")
     .option("--kind <kind>", "Filter target entity by kind")
+    .option("--path <path>", "Filter target entity by file path (substring match)")
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
     .option("--limit <n>", "Max results to show", "50")
     .option("--format <fmt>", "Output format (text|json|llm)", "text")
     .addHelpText("after", "\nExamples:\n  ix imported-by AuthProvider\n  ix imported-by io.circe.Json --format json")
-    .action(async (symbol: string, opts: { kind?: string; pick?: number; limit: string; format: string }) => {
+    .action(async (symbol: string, opts: { kind?: string; path?: string; pick?: number; limit: string; format: string }) => {
       const client = new IxClient(getEndpoint());
       const limit = parseInt(opts.limit, 10);
-      const resolveOpts = { kind: opts.kind, pick: opts.pick };
+      const resolveOpts = { kind: opts.kind, path: opts.path, pick: opts.pick };
       const target = await resolveFileOrReport(client, symbol, resolveOpts, opts.format);
       if (!target) return;
       if (opts.format === "text") printResolved(target);

--- a/skills/ix/references/flags.md
+++ b/skills/ix/references/flags.md
@@ -302,6 +302,7 @@ Show what imports the given entity.
 | Flag | Value | Default | Effect |
 |---|---|---|---|
 | `--kind` | `<kind>` | — | Filter target entity by kind |
+| `--path` | `<path>` | — | Filter target entity by file path (substring match) |
 | `--pick` | `<n>` | — | Pick Nth candidate from ambiguous results (1-based) |
 | `--limit` | `<n>` | `50` | Max results to show |
 | `--format` | `text\|json\|llm` | `text` | Output format — see [output-formats.md](output-formats.md) |
@@ -313,6 +314,7 @@ Show what the given entity imports.
 | Flag | Value | Default | Effect |
 |---|---|---|---|
 | `--kind` | `<kind>` | — | Filter target entity by kind |
+| `--path` | `<path>` | — | Filter target entity by file path (substring match) |
 | `--pick` | `<n>` | — | Pick Nth candidate from ambiguous results (1-based) |
 | `--limit` | `<n>` | `50` | Max results to show |
 | `--format` | `text\|json\|llm` | `text` | Output format — see [output-formats.md](output-formats.md) |

--- a/skills/ix/references/flags.md
+++ b/skills/ix/references/flags.md
@@ -70,6 +70,7 @@ Show methods/functions called by the given symbol (cross-file).
 | Flag | Value | Default | Effect |
 |---|---|---|---|
 | `--kind` | `<kind>` | — | Filter target entity by kind |
+| `--path` | `<path>` | — | Filter target entity by file path (substring match) |
 | `--pick` | `<n>` | — | Pick Nth candidate from ambiguous results (1-based) |
 | `--limit` | `<n>` | `50` | Max results to show |
 | `--format` | `text\|json\|llm` | `text` | Output format — see [output-formats.md](output-formats.md) |
@@ -81,6 +82,7 @@ Show methods/functions that call the given symbol (cross-file).
 | Flag | Value | Default | Effect |
 |---|---|---|---|
 | `--kind` | `<kind>` | — | Filter target entity by kind |
+| `--path` | `<path>` | — | Filter target entity by file path (substring match) |
 | `--pick` | `<n>` | — | Pick Nth candidate from ambiguous results (1-based) |
 | `--limit` | `<n>` | `50` | Max results to show |
 | `--format` | `text\|json\|llm` | `text` | Output format — see [output-formats.md](output-formats.md) |
@@ -287,6 +289,7 @@ System risk analysis — what behavior is at risk if this changes.
 | Flag | Value | Default | Effect |
 |---|---|---|---|
 | `--kind` | `<kind>` | — | Filter target entity by kind |
+| `--path` | `<path>` | — | Filter target entity by file path (substring match) |
 | `--pick` | `<n>` | — | Pick Nth candidate from ambiguous results (1-based) |
 | `--depth` | `<n>` | `1` | Expansion depth for callers/importers (default 1, max 3) |
 | `--limit` | `<n>` | `10` | Max top-impacted members to show |


### PR DESCRIPTION
Fixes #627

## Summary

Make the existing `--path` ambiguity guidance actionable for `impact`, `callers`, `callees`, `imports`, and `imported-by`.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Register `--path <path>` on all five commands and forward it to the existing shared resolver.
- Document the substring filter in the flag reference.
- Add fifteen regression tests using synthetic same-name candidates. Tests cover selecting only the matching candidate, refusing an unmatched path, and preserving unfiltered ambiguity for each command.

The resolver algorithm, existing exit statuses, backend API, and MCP tool schemas are unchanged. This PR does not address architecture-map language coverage or reverse-proxy configuration.

## Validation

- The original three-command fix had six failing tests before the fix. The follow-up extends the same regression coverage to imports/imported-by; all fifteen tests now pass.
- CLI full suite: 97 files passed, 1,797 tests passed and 3 skipped. Parser smoke passed.
- Core ingestion full suite: 38 files passed, 389 tests passed and 1 skipped on rerun. The initial concurrent run failed the pre-existing CUDA adversarial-input timing assertion; no core code was changed.
- Build, typecheck, lint (0 errors, 41 existing warnings), and knip passed.
- Documentation parity passed: 54 commands and 201 flags.
- Live-backend checks confirmed all five patched commands accept a matching path and return success, while a missing path returns structured `unresolved_target` JSON and exit 1.
- `git diff --check` passed.

The live checks verify this specific fix, not universal repository stability. The regression fixtures and public report contain only synthetic names and paths.

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first (maintainers only — see [Backend Development](https://github.com/ix-infrastructure/Ix/blob/main/CONTRIBUTING.md#backend-development))
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works

Release versioning is left to the maintainer. No backend or Compose changes are included.
