### PR TITLE
fix(brew): ship the banner inputs, the third delivery path #605 missed

### DIFF
--- a/Formula/ix.rb
+++ b/Formula/ix.rb
@@ -30,6 +30,21 @@ class Ix < Formula
       # Install the compiled CLI and its dependencies
       libexec.install "dist", "node_modules", "package.json"
 
+      # ...and the banner inputs, which are part of the CLI, not extras.
+      # `banner.js` resolves them as join(dirname(import.meta.url), "..", "..")
+      # -- i.e. libexec -- so without these the setup notice silently falls back
+      # to the plain text heading on every Homebrew install. Silently is the
+      # problem: renderBanner() is absent-safe by design and returns null rather
+      # than failing, so a missing input looks exactly like success.
+      #
+      # Ix#605 shipped this for the npm tarball and the release staging and
+      # missed Homebrew, which is a third delivery path with its own layout.
+      # Copied file-by-file rather than as whole directories: ix-cli/scripts/
+      # also holds the CI parity checkers and the core-ingestion build script,
+      # none of which belong in an installed prefix.
+      (libexec/"scripts").install "scripts/render-logo.mjs", "scripts/render-logo.d.mts"
+      (libexec/"assets").install "assets/logo.png"
+
       # Create a wrapper script that invokes node with the correct path
       (bin/"ix").write <<~EOS
         #!/bin/bash


### PR DESCRIPTION
Surfaced while reviewing the v0.10.8 formula bump (#626).

The formula installs only three things into the prefix:

```ruby
libexec.install "dist", "node_modules", "package.json"
```

so `libexec/scripts` and `libexec/assets` never exist. `banner.js` resolves its inputs as `join(dirname(import.meta.url), "..", "..")` — i.e. `libexec` — so on **every Homebrew install** `renderBanner()` returns null and the setup notice falls back to the plain text heading.

Simulated the layout to confirm rather than inferring it:

```
banner.js pkgDir = <libexec>
  scripts/render-logo.mjs  ABSENT -> renderBanner() returns null
  assets/logo.png          ABSENT -> renderBanner() returns null
```

and with the fix applied, both land where it looks and the renderer runs from that prefix.

## Why it slipped

`renderBanner()` is absent-safe by design — a missing input is not an error, it is indistinguishable from success. That is exactly the property that let the original bug ship, when both files lived at the repo root and *no* packaged layout carried them.

#605 fixed two delivery paths: the npm tarball (files moved under `ix-cli/`, pinned by a test) and the release staging (explicit `cp` plus a `test -f` gate). Homebrew is a third, with its own layout and its own rules, and nothing in either of those fixes reaches it.

## Note on the copy style

File-by-file rather than whole directories, deliberately: `ix-cli/scripts/` also holds `check-api-parity.mjs`, `check-doc-parity.mjs`, `check-links.mjs` and `build-core-ingestion.mjs`, none of which belong in an installed prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnMJopSVeUMFifL74DJ2Gk