### PR TITLE
fix(rank): scope candidates by path before the fetch limit

### DIFF
--- a/ix-cli/src/cli/__tests__/rank-path-scope.test.ts
+++ b/ix-cli/src/cli/__tests__/rank-path-scope.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Command } from "commander";
+import { registerRankCommand } from "../commands/rank.js";
+
+const { listByKind, expand } = vi.hoisted(() => ({ listByKind: vi.fn(), expand: vi.fn() }));
+vi.mock("../../client/api.js", () => ({
+  IxClient: class {
+    async listByKind(...args: unknown[]) { return listByKind(...args); }
+    async expand(...args: unknown[]) { return expand(...args); }
+  },
+}));
+vi.mock("../resolve.js", () => ({
+  ensureReadScope: async () => {},
+  activeReadScope: () => ({ workspaceId: "test-workspace" }),
+}));
+
+async function run(args: string[]) {
+  const program = new Command().name("ix").exitOverride();
+  registerRankCommand(program);
+  const output: string[] = [];
+  vi.spyOn(console, "log").mockImplementation((value) => { output.push(String(value)); });
+  await program.parseAsync(["rank", "--by", "members", "--kind", "class", "--format", "json", ...args], { from: "user" });
+  return JSON.parse(output.join("\n"));
+}
+
+describe("rank path filtering before the candidate limit", () => {
+  beforeEach(() => {
+    const nodes = [
+      ...Array.from({ length: 2000 }, (_, i) => ({ id: `other-${i}`, name: `Other${i}`, kind: "class", provenance: { sourceUri: "src/other.ts" } })),
+      { id: "wanted", name: "Wanted", kind: "class", provenance: { sourceUri: "src/target.ts" } },
+    ];
+    listByKind.mockReset().mockImplementation(async (_kind, opts) =>
+      nodes.filter(n => !opts.scope || n.provenance.sourceUri.includes(opts.scope)).slice(0, opts.limit),
+    );
+    expand.mockReset().mockResolvedValue({ nodes: [{ id: "member" }], edges: [] });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("ranks a matching entity beyond the first 2000 unfiltered candidates", async () => {
+    const output = await run(["--path", "src/target.ts"]);
+    expect(listByKind).toHaveBeenCalledWith("class", { limit: 2000, scope: "src/target.ts", workspaceId: "test-workspace" });
+    expect(output.results).toEqual([{ name: "Wanted", kind: "class", score: 1 }]);
+    expect(expand).toHaveBeenCalledTimes(1);
+    expect(expand).toHaveBeenCalledWith("wanted", expect.anything());
+  });
+
+  it("preserves client-side exclusions after the scoped fetch", async () => {
+    const output = await run(["--path", "src/target.ts", "--exclude-path", "target"]);
+    expect(output.results).toEqual([]);
+    expect(expand).not.toHaveBeenCalled();
+  });
+
+  it("reports a genuinely unmatched path without expanding unrelated entities", async () => {
+    const output = await run(["--path", "missing.ts"]);
+    expect(output.results).toEqual([]);
+    expect(expand).not.toHaveBeenCalled();
+  });
+});

--- a/ix-cli/src/cli/commands/rank.ts
+++ b/ix-cli/src/cli/commands/rank.ts
@@ -173,7 +173,7 @@ export function registerRankCommand(program: Command): void {
 
         // 1. Fetch all entities of the given kind
         await ensureReadScope(client); // fold in a Path-2 stitched system (Ix#225 Half B)
-        const allNodes = await client.listByKind(opts.kind, { limit: 2000, ...activeReadScope() });
+        const allNodes = await client.listByKind(opts.kind, { limit: 2000, scope: opts.path || undefined, ...activeReadScope() });
 
         if (allNodes.length === 0) {
           if (opts.format === "llm") {


### PR DESCRIPTION
Fixes #631

## Summary
Apply `rank --path` through the existing list API before the candidate limit, so unrelated files cannot crowd a requested path out of the ranking input.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Forward a nonempty path as `scope` to `listByKind`, preserving the active workspace/system scope and the 2,000-candidate limit.
- Retain existing client-side path/kind exclusions and scoring.
- Add three command tests, including a target after 2,000 unrelated classes.

This is a scoped retrieval fix, not exhaustive global ranking or pagination. More than 2,000 matches within the requested scope can still be truncated; that existing bound is unchanged.

## Validation
- The new positive regression fails on main before the fix and passes afterward.
- Targeted rank tests: 21 passed.
- Full CLI suite: 97 files passed, 1,785 tests passed and 3 skipped; parser smoke passed.
- Build, typecheck, lint (0 errors, 41 existing warnings), knip, documentation parity, and git diff checks passed.
- Live backend 1.0.30: all three previously missed classes were returned by the scoped rank query, with member counts 3, 2, and 4. The released 0.10.8 CLI had returned empty rankings for those paths.

All public examples and regression fixtures use generic names. No private source or paths are included.

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first (maintainers only — see [Backend Development](https://github.com/ix-infrastructure/Ix/blob/main/CONTRIBUTING.md#backend-development))
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works

Release versioning is left to the maintainer. No backend or Compose changes.

