### PR TITLE
fix(trace): honor depth and node budgets in path searches

### DIFF
--- a/ix-cli/src/cli/__tests__/trace-path-budgets.test.ts
+++ b/ix-cli/src/cli/__tests__/trace-path-budgets.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Command } from "commander";
+import { registerTraceCommand } from "../commands/trace.js";
+
+const expand = vi.hoisted(() => vi.fn());
+vi.mock("../../client/api.js", () => ({
+  IxClient: class { async expand(...args: unknown[]) { return expand(...args); } },
+}));
+vi.mock("../resolve.js", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../resolve.js")>(),
+  resolveFileOrEntityFull: async (_client: unknown, name: string) => ({
+    resolved: true, entity: { id: name, name, kind: "function" },
+  }),
+}));
+
+async function run(args: string[], format = "json", to = "C") {
+  const program = new Command().name("ix").exitOverride();
+  registerTraceCommand(program);
+  const output: string[] = [];
+  vi.spyOn(console, "log").mockImplementation((...parts) => { output.push(parts.join(" ")); });
+  await program.parseAsync(["trace", "A", "--to", to, "--kind", "calls", ...args, "--format", format], { from: "user" });
+  return output.join("\n");
+}
+
+describe("trace --to search budgets", () => {
+  beforeEach(() => {
+    expand.mockReset().mockImplementation(async (id: string, opts: { direction: string }) => {
+      const adjacent: Record<string, string[]> = opts.direction === "out"
+        ? { A: ["B"], B: ["C"] } : { B: ["A"], C: ["B"] };
+      return { nodes: (adjacent[id] ?? []).map(name => ({ id: name, name, kind: "function" })), edges: [] };
+    });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("does not return a two-edge path at depth one", async () => {
+    const output = JSON.parse(await run(["--depth", "1"]));
+    expect(output.path).toBeNull();
+    expect(expand.mock.calls.map(([id]) => id)).toEqual(["A", "A"]);
+  });
+
+  it("finds a path exactly at the depth boundary", async () => {
+    const output = JSON.parse(await run(["--depth", "2"]));
+    expect(output.path.map((n: { name: string }) => n.name)).toEqual(["A", "B", "C"]);
+  });
+
+  it("does not expand the source at depth zero", async () => {
+    expect(JSON.parse(await run(["--depth", "0"])).path).toBeNull();
+    expect(expand).not.toHaveBeenCalled();
+  });
+
+  it("enforces the node cap before visiting the target", async () => {
+    expect(JSON.parse(await run(["--cap", "2"])).path).toBeNull();
+  });
+
+  it("finds the route when the cap includes all three nodes", async () => {
+    expect(JSON.parse(await run(["--cap", "3"])).path).toHaveLength(3);
+  });
+
+  it("does no graph expansion at cap zero", async () => {
+    expect(JSON.parse(await run(["--cap", "0"])).path).toBeNull();
+    expect(expand).not.toHaveBeenCalled();
+  });
+
+  it("returns a zero-edge self path without expansion", async () => {
+    expect(JSON.parse(await run(["--depth", "0", "--cap", "1"], "json", "A")).path).toHaveLength(1);
+    expect(expand).not.toHaveBeenCalled();
+  });
+
+  it.each(["json", "llm", "text"])("qualifies a bounded miss in %s output", async (format) => {
+    const output = await run(["--depth", "1", "--cap", "2"], format);
+    expect(output).toContain("within the requested search limits");
+  });
+
+  it("preserves an unrestricted successful route", async () => {
+    expect(JSON.parse(await run([])).path).toHaveLength(3);
+  });
+});

--- a/ix-cli/src/cli/commands/trace.ts
+++ b/ix-cli/src/cli/commands/trace.ts
@@ -229,7 +229,10 @@ export async function findPath(
   toId: string,
   predicates: string[],
   maxDepth: number = 10,
+  maxNodes: number = Infinity,
 ): Promise<PathNode[] | null> {
+  if (maxNodes < 1) return null;
+  if (fromId === toId) return [{ id: fromId, name: "", kind: "" }];
   const nodeMap = new Map<string, { name: string; kind: string }>();
 
   const queue: Array<{ id: string; path: string[] }> = [{ id: fromId, path: [fromId] }];
@@ -238,7 +241,7 @@ export async function findPath(
   while (queue.length > 0) {
     const entry = queue.shift()!;
     const { id, path } = entry;
-    if (path.length >= maxDepth) continue;
+    if (path.length - 1 >= maxDepth) continue;
 
     const [outResult, inResult] = await Promise.all([
       client.expand(id, { direction: "out", predicates, hops: 1 }),
@@ -246,6 +249,9 @@ export async function findPath(
     ]);
 
     for (const n of [...outResult.nodes, ...inResult.nodes]) {
+      if (visited.has(n.id)) continue;
+      if (visited.size >= maxNodes) return null;
+      visited.add(n.id);
       const name = n.name || n.attrs?.name || n.id.slice(0, 8);
       if (!nodeMap.has(n.id)) {
         nodeMap.set(n.id, { name, kind: n.kind ?? "unknown" });
@@ -260,8 +266,6 @@ export async function findPath(
         });
       }
 
-      if (visited.has(n.id)) continue;
-      visited.add(n.id);
       queue.push({ id: n.id, path: [...path, n.id] });
     }
   }
@@ -355,13 +359,14 @@ const finiteDepth = (d: number): LlmValue => (Number.isFinite(d) ? d : undefined
 export function renderTracePathLlm(
   from: { name: string; kind: string }, to: { name: string; kind: string },
   relKind: string, pathNodes: PathNode[],
+  noPathMessage?: string,
 ): string[] {
   const lines = [llmLine("trace", [
     ["mode", "path"], ["from", from.name], ["to", to.name], ["kind", relKind],
     ["length", pathNodes.length > 0 ? pathNodes.length : undefined],
   ])];
   if (pathNodes.length === 0) {
-    lines.push(llmLine("diagnostic", [["code", "no_path"], ["message", `No route found from ${from.name} to ${to.name}.`]]));
+    lines.push(llmLine("diagnostic", [["code", "no_path"], ["message", noPathMessage ?? `No route found from ${from.name} to ${to.name}.`]]));
     return lines;
   }
   for (const n of pathNodes) lines.push(llmLine("step", [["name", n.name], ["kind", n.kind]]));
@@ -413,8 +418,8 @@ export function registerTraceCommand(program: Command): void {
     .option("--upstream", "Show who calls/imports this (same as depends)")
     .option("--downstream", "Show what this calls/imports (outward flow)")
     .option("--kind <kind>", "Relationship kind: calls|imports|depends|contains")
-    .option("--depth <n>", "Cap traversal depth")
-    .option("--cap <n>", "Cap number of nodes visited, per direction")
+    .option("--depth <n>", "Cap traversal depth in edges (also applies to --to)")
+    .option("--cap <n>", "Cap nodes visited per direction, or across the --to search (including the source)")
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
     .option("--path <path>", "Prefer symbols from files matching this path substring")
     .option("--format <fmt>", "Output format (text|json|llm)", "text")
@@ -485,7 +490,9 @@ export function registerTraceCommand(program: Command): void {
           const relKind = opts.kind ?? "mixed";
           const predicates = kindToPredicates(opts.kind);
 
-          const rawPath = await findPath(client, fromTarget.id, toTarget.id, predicates, maxDepth + 7);
+          const rawPath = await findPath(client, fromTarget.id, toTarget.id, predicates, maxDepth, maxNodes);
+          const bounded = Number.isFinite(maxDepth) || Number.isFinite(maxNodes);
+          const noPathMessage = `No route found from ${fromTarget.name} to ${toTarget.name}${bounded ? " within the requested search limits" : ""}.`;
 
           // Fill in the from-node name (was left blank above)
           const pathNodes: PathNode[] = rawPath
@@ -511,7 +518,7 @@ export function registerTraceCommand(program: Command): void {
               output.diagnostics = [
                 {
                   code: "no_path",
-                  message: `No route found from ${fromTarget.name} to ${toTarget.name}.`,
+                  message: noPathMessage,
                 },
               ];
             }
@@ -521,7 +528,7 @@ export function registerTraceCommand(program: Command): void {
 
           // ── llm output ─────────────────────────────────────────
           if (opts.format === "llm") {
-            for (const line of renderTracePathLlm(fromTarget, toTarget, relKind, pathNodes)) console.log(line);
+            for (const line of renderTracePathLlm(fromTarget, toTarget, relKind, pathNodes, noPathMessage)) console.log(line);
             return;
           }
 
@@ -533,7 +540,7 @@ export function registerTraceCommand(program: Command): void {
           renderKeyValue("Kind", cap(relKind));
 
           if (pathNodes.length === 0) {
-            console.log(`\nNo route found from ${chalk.bold(fromTarget.name)} to ${chalk.bold(toTarget.name)}.`);
+            console.log(`\n${noPathMessage}`);
             return;
           }
 

--- a/skills/ix/references/flags.md
+++ b/skills/ix/references/flags.md
@@ -584,8 +584,8 @@ Follow how it connects.
 | `--upstream` | — | off | Show who calls/imports this (same as depends) |
 | `--downstream` | — | off | Show what this calls/imports (outward flow) |
 | `--kind` | `<kind>` | — | Relationship kind: calls\|imports\|depends\|contains |
-| `--depth` | `<n>` | — | Cap traversal depth |
-| `--cap` | `<n>` | — | Cap number of nodes visited, per direction |
+| `--depth` | `<n>` | — | Cap traversal depth in edges (also applies to `--to`) |
+| `--cap` | `<n>` | — | Cap nodes visited per direction, or across the `--to` search (including the source) |
 | `--pick` | `<n>` | — | Pick Nth candidate from ambiguous results (1-based) |
 | `--path` | `<path>` | — | Prefer symbols from files matching this path substring |
 | `--format` | `text\|json\|llm` | `text` | Output format — see [output-formats.md](output-formats.md) |


### PR DESCRIPTION
Fixes #633

## Summary
Honor explicit depth and node budgets when `trace --to` searches for a route.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] CI

## Changes
- Remove the hidden `+ 7` depth allowance and count depth in graph edges.
- Forward `--cap` to the bidirectional BFS and count unique discovered nodes, including the source, across that search.
- Handle zero budgets and a zero-edge self path without expanding the graph.
- Qualify bounded misses in text, JSON, and LLM output.
- Document the path-mode budget semantics in help and the flag reference.

Successful output shapes and exit statuses are unchanged. Bounded misses retain the existing `no_path` code but explicitly say the route was not found within the requested limits. This node budget bounds graph traversal, not the size of a single backend expand response. No default traversal limits or backend API changes are added.

## Validation
- Eight of eleven new command-registration tests fail before the fix; all eleven pass after it.
- Targeted path tests: 17 passed, including existing inbound traversal cases.
- Full CLI suite: 97 files passed, 1,793 tests passed and 3 skipped; parser smoke passed.
- Build, typecheck, lint (0 errors, 41 existing warnings), knip, documentation parity, and git diff checks passed.
- Live backend 1.0.30: a known two-edge route is no longer returned at depth 0/1, or with a node cap of 2; depth 2 and a sufficient cap return the original three-node route.
- Synthetic A/B/C tests cover exact depth/cap boundaries, a self path, all three output formats, and an unrestricted successful route.

The regression fixtures contain only generic symbols. No private graph identifiers, paths, or source are included.

## Checklist
- [x] Tests pass
- [x] Smoke tests pass
- [x] No raw errors introduced
- [x] CLI output follows Ix format

## Release checklist (if merging to main)
- [ ] `ix-cli/package.json` version bumped
- [ ] After merge: tag pushed (`git tag vX.Y.Z && git push origin vX.Y.Z`)
- [ ] If backend changes: `ix-memory-layer` tagged and released first (maintainers only — see [Backend Development](https://github.com/ix-infrastructure/Ix/blob/main/CONTRIBUTING.md#backend-development))
- [ ] If `docker-compose.standalone.yml` changed: verified `curl | sh` install works

Release versioning is left to the maintainer. No backend or Compose changes.

