### PR TITLE
fix(cli): --path is a hard filter, so stop calling it a preference

### DIFF
--- a/ix-cli/src/cli/commands/context.ts
+++ b/ix-cli/src/cli/commands/context.ts
@@ -225,7 +225,7 @@ export function registerContextCommand(program: Command): void {
       "Build a bounded, deterministic context bundle for a symbol, file, or entity (or resume/diff a saved investigation without a target)",
     )
     .option("--kind <kind>", "Filter target entity by kind")
-    .option("--path <path>", "Prefer symbols from files matching this path substring")
+    .option("--path <path>", "Restrict to symbols from files matching this path substring")
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
     .option(
       "--depth <depth>",

--- a/ix-cli/src/cli/commands/depends.ts
+++ b/ix-cli/src/cli/commands/depends.ts
@@ -191,7 +191,7 @@ export function registerDependsCommand(program: Command): void {
     .command("depends <symbol>")
     .description("Show upstream dependents of the given entity (full tree by default)")
     .option("--kind <kind>", "Filter target entity by kind")
-    .option("--path <path>", "Prefer symbols from files matching this path substring")
+    .option("--path <path>", "Restrict to symbols from files matching this path substring")
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
     .option("--depth <n>", "Cap traversal depth")
     .option("--cap <n>", "Cap number of nodes visited")

--- a/ix-cli/src/cli/commands/diff.ts
+++ b/ix-cli/src/cli/commands/diff.ts
@@ -469,7 +469,7 @@ export function registerDiffCommand(program: Command): void {
     .option("--full", "Return all changes (no limit)")
     .option("--format <fmt>", "Output format (text|json|llm)", "text")
     .option("--kind <kind>", "Filter target entity by kind")
-    .option("--path <path>", "Prefer symbols from files matching this path substring")
+    .option("--path <path>", "Restrict to symbols from files matching this path substring")
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
     .addHelpText("after", `\nExamples:
   ix diff 3 5

--- a/ix-cli/src/cli/commands/explain.ts
+++ b/ix-cli/src/cli/commands/explain.ts
@@ -18,7 +18,7 @@ export function registerExplainCommand(program: Command): void {
     .command("explain <symbol>")
     .description("Explain an entity — infers role, importance, and structural context")
     .option("--kind <kind>", "Filter target entity by kind")
-    .option("--path <path>", "Prefer symbols from files matching this path substring")
+    .option("--path <path>", "Restrict to symbols from files matching this path substring")
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
     .option("--format <fmt>", "Output format (text|json|llm)", "text")
     .option("--raw", "Show raw metadata dump (legacy format)")

--- a/ix-cli/src/cli/commands/history.ts
+++ b/ix-cli/src/cli/commands/history.ts
@@ -28,7 +28,7 @@ export function registerHistoryCommand(program: Command): void {
     .command("history <target>")
     .description("Show provenance chain for a file or entity")
     .option("--kind <kind>", "Filter target entity by kind")
-    .option("--path <path>", "Prefer symbols from files matching this path substring")
+    .option("--path <path>", "Restrict to symbols from files matching this path substring")
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
     .option("--format <fmt>", "Output format (text|json|llm)", "text")
     .addHelpText("after", `\nExamples:

--- a/ix-cli/src/cli/commands/locate.ts
+++ b/ix-cli/src/cli/commands/locate.ts
@@ -36,7 +36,7 @@ export function registerLocateCommand(program: Command): void {
     .command("locate <symbol>")
     .description("Resolve a symbol to its position in the codebase and system hierarchy")
     .option("--kind <kind>", "Filter target entity by kind")
-    .option("--path <path>", "Prefer results from files matching this path substring")
+    .option("--path <path>", "Restrict to results from files matching this path substring")
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
     .option("--format <fmt>", "Output format (text|json|llm)", "text")
     .addHelpText("after", `\nExamples:

--- a/ix-cli/src/cli/commands/overview.ts
+++ b/ix-cli/src/cli/commands/overview.ts
@@ -37,7 +37,7 @@ export function registerOverviewCommand(program: Command): void {
     .command("overview <target>")
     .description("Structural summary — what a target contains or what surrounds it")
     .option("--kind <kind>", "Filter target entity by kind")
-    .option("--path <path>", "Prefer symbols from files matching this path substring")
+    .option("--path <path>", "Restrict to symbols from files matching this path substring")
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
     .option("--format <fmt>", "Output format (text|json|llm)", "text")
     .addHelpText(

--- a/ix-cli/src/cli/commands/read.ts
+++ b/ix-cli/src/cli/commands/read.ts
@@ -196,7 +196,7 @@ export function registerReadCommand(program: Command): void {
     .description("Read raw file content, line ranges, or symbol source code")
     .option("--format <fmt>", "Output format (text|json|llm)", "text")
     .option("--kind <kind>", "Filter symbol by kind")
-    .option("--path <path>", "Prefer symbols from files matching this path substring")
+    .option("--path <path>", "Restrict to symbols from files matching this path substring")
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
     .option("--root <dir>", "Workspace root directory")
     .addHelpText("after", `\nResolution order:

--- a/ix-cli/src/cli/commands/trace.ts
+++ b/ix-cli/src/cli/commands/trace.ts
@@ -416,7 +416,7 @@ export function registerTraceCommand(program: Command): void {
     .option("--depth <n>", "Cap traversal depth")
     .option("--cap <n>", "Cap number of nodes visited, per direction")
     .option("--pick <n>", "Pick Nth candidate from ambiguous results (1-based)", parsePickOption)
-    .option("--path <path>", "Prefer symbols from files matching this path substring")
+    .option("--path <path>", "Restrict to symbols from files matching this path substring")
     .option("--format <fmt>", "Output format (text|json|llm)", "text")
     .option("--include-tests", "Include test and fixture entities")
     .option("--tests-only", "Show only test and fixture entities")

--- a/skills/ix/references/flags.md
+++ b/skills/ix/references/flags.md
@@ -138,7 +138,7 @@ Build a bounded, deterministic context bundle for a symbol, file, or entity (or 
 | Flag | Value | Default | Effect |
 |---|---|---|---|
 | `--kind` | `<kind>` | — | Filter target entity by kind |
-| `--path` | `<path>` | — | Prefer symbols from files matching this path substring |
+| `--path` | `<path>` | — | Restrict to symbols from files matching this path substring |
 | `--pick` | `<n>` | — | Pick Nth candidate from ambiguous results (1-based) |
 | `--depth` | `compact\|standard\|full\|shallow\|deep` | — | Context-graph expansion depth (compact\|standard\|full\|shallow\|deep) |
 | `--as-of-rev` | `<n>` | — | Historical context as of a graph revision |
@@ -160,7 +160,7 @@ Show upstream dependents of the given entity (full tree by default).
 | Flag | Value | Default | Effect |
 |---|---|---|---|
 | `--kind` | `<kind>` | — | Filter target entity by kind |
-| `--path` | `<path>` | — | Prefer symbols from files matching this path substring |
+| `--path` | `<path>` | — | Restrict to symbols from files matching this path substring |
 | `--pick` | `<n>` | — | Pick Nth candidate from ambiguous results (1-based) |
 | `--depth` | `<n>` | — | Cap traversal depth |
 | `--cap` | `<n>` | — | Cap number of nodes visited |
@@ -181,7 +181,7 @@ Show diff between two revisions, optionally scoped to a file or entity.
 | `--full` | — | off | Return all changes (no limit) |
 | `--format` | `text\|json\|llm` | `text` | Output format — see [output-formats.md](output-formats.md) |
 | `--kind` | `<kind>` | — | Filter target entity by kind |
-| `--path` | `<path>` | — | Prefer symbols from files matching this path substring |
+| `--path` | `<path>` | — | Restrict to symbols from files matching this path substring |
 | `--pick` | `<n>` | — | Pick Nth candidate from ambiguous results (1-based) |
 
 ### `ix docker`
@@ -251,7 +251,7 @@ Explain an entity — infers role, importance, and structural context.
 | Flag | Value | Default | Effect |
 |---|---|---|---|
 | `--kind` | `<kind>` | — | Filter target entity by kind |
-| `--path` | `<path>` | — | Prefer symbols from files matching this path substring |
+| `--path` | `<path>` | — | Restrict to symbols from files matching this path substring |
 | `--pick` | `<n>` | — | Pick Nth candidate from ambiguous results (1-based) |
 | `--format` | `text\|json\|llm` | `text` | Output format — see [output-formats.md](output-formats.md) |
 | `--raw` | — | off | Show raw metadata dump (legacy format) |
@@ -276,7 +276,7 @@ Show provenance chain for a file or entity.
 | Flag | Value | Default | Effect |
 |---|---|---|---|
 | `--kind` | `<kind>` | — | Filter target entity by kind |
-| `--path` | `<path>` | — | Prefer symbols from files matching this path substring |
+| `--path` | `<path>` | — | Restrict to symbols from files matching this path substring |
 | `--pick` | `<n>` | — | Pick Nth candidate from ambiguous results (1-based) |
 | `--format` | `text\|json\|llm` | `text` | Output format — see [output-formats.md](output-formats.md) |
 
@@ -356,7 +356,7 @@ Resolve a symbol to its position in the codebase and system hierarchy.
 | Flag | Value | Default | Effect |
 |---|---|---|---|
 | `--kind` | `<kind>` | — | Filter target entity by kind |
-| `--path` | `<path>` | — | Prefer results from files matching this path substring |
+| `--path` | `<path>` | — | Restrict to results from files matching this path substring |
 | `--pick` | `<n>` | — | Pick Nth candidate from ambiguous results (1-based) |
 | `--format` | `text\|json\|llm` | `text` | Output format — see [output-formats.md](output-formats.md) |
 
@@ -413,7 +413,7 @@ Structural summary — what a target contains or what surrounds it.
 | Flag | Value | Default | Effect |
 |---|---|---|---|
 | `--kind` | `<kind>` | — | Filter target entity by kind |
-| `--path` | `<path>` | — | Prefer symbols from files matching this path substring |
+| `--path` | `<path>` | — | Restrict to symbols from files matching this path substring |
 | `--pick` | `<n>` | — | Pick Nth candidate from ambiguous results (1-based) |
 | `--format` | `text\|json\|llm` | `text` | Output format — see [output-formats.md](output-formats.md) |
 
@@ -459,7 +459,7 @@ Read raw file content, line ranges, or symbol source code.
 |---|---|---|---|
 | `--format` | `text\|json\|llm` | `text` | Output format — see [output-formats.md](output-formats.md) |
 | `--kind` | `<kind>` | — | Filter symbol by kind |
-| `--path` | `<path>` | — | Prefer symbols from files matching this path substring |
+| `--path` | `<path>` | — | Restrict to symbols from files matching this path substring |
 | `--pick` | `<n>` | — | Pick Nth candidate from ambiguous results (1-based) |
 | `--root` | `<dir>` | — | Workspace root directory |
 
@@ -587,7 +587,7 @@ Follow how it connects.
 | `--depth` | `<n>` | — | Cap traversal depth |
 | `--cap` | `<n>` | — | Cap number of nodes visited, per direction |
 | `--pick` | `<n>` | — | Pick Nth candidate from ambiguous results (1-based) |
-| `--path` | `<path>` | — | Prefer symbols from files matching this path substring |
+| `--path` | `<path>` | — | Restrict to symbols from files matching this path substring |
 | `--format` | `text\|json\|llm` | `text` | Output format — see [output-formats.md](output-formats.md) |
 | `--include-tests` | — | off | Include test and fixture entities |
 | `--tests-only` | — | off | Show only test and fixture entities |


### PR DESCRIPTION
Found while reviewing #628, which adds `--path` to five more commands. Checking whether its wording matched the existing flags turned up that **the existing flags describe the wrong behaviour**.

Nine commands advertise:

```
--path <path>   Prefer symbols from files matching this path substring
```

It does not prefer anything. All nine thread `opts.path` into `resolveEntityFull`, which excludes non-matching candidates outright — the code says so itself:

```ts
// Hard path filter: when --path is provided, exclude candidates whose
// sourceUri does not contain the filter string. If no candidates survive,
// return "not found" rather than ...
if (effectivePath && filteredNodes.length === 0) {
  stderr(`No entity named "${symbol}" found in paths matching "${effectivePath}".`);
  return { resolved: false, ambiguous: false, hiddenTestCount };
}
```

## Why the wording matters

A preference cannot fail. This can — and since #547/#559 an unresolved target also **exits non-zero**. So someone who reads the help and adds `--path src` to narrow a noisy result is told the flag will merely reorder things, and instead gets a not-found plus a failing exit code when the symbol lives somewhere they did not expect. For anything scripted, that is the difference between "slightly different ordering" and "the command failed".

There is also a scoring bonus for path matches further up (`score -= 4 + …`), which is probably where "Prefer" came from. It is real, but it only ranks among candidates that already survived the hard filter, so it never rescues a non-matching one.

## Changed

`Prefer …` → `Restrict to …` for **history, explain, diff, context, read, trace, locate, overview, depends**, plus the nine matching rows in `skills/ix/references/flags.md`.

## Deliberately not changed — these are already accurate

| command | text | why it is right |
|---|---|---|
| `search` | "Boost results …" | genuinely a boost — calls `scoreCandidate()` directly, never the hard filter |
| `inventory` | "Filter …" | its own `.filter()` |
| `rank` | "Filter entities …" | its own `.filter()` |
| `contains` | "Filter target …" | resolver, and already says filter |

That `search` really is a boost is the reason this is a wording fix rather than a blanket rename: the two behaviours both exist and the help should tell them apart.

```
check-doc-parity   54 commands, 196 flags — parity
check-api-parity   42 documented, 42 called — parity
tsc --noEmit       clean
eslint             0 errors
```

No test pinned the old strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnMJopSVeUMFifL74DJ2Gk