### PR TITLE
build(deps): cap vitest majors, which arrive as an uninstallable lockfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,18 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
+      # vitest 4 -> 5 is the same category, and it does not merely break: the
+      # lockfile Dependabot generates for it CANNOT BE INSTALLED here. ix-cli
+      # has no `.npmrc`, so `npm ci` resolves peers strictly and dies:
+      #   ERESOLVE: peer vitest@"5.0.0" from @vitest/coverage-v8@5.0.0
+      #   peer overridden vite@">=7.3.2 <8.0.0" (was "^6.4.0 || ^7.0.0 || ^8.0.0")
+      # Every job in the workflow failed on that single `npm ci`, which reads as
+      # fourteen unrelated breakages rather than one bad bump. Capped with its
+      # coverage provider, which pins vitest exactly and so must move with it.
+      - dependency-name: "vitest"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@vitest/coverage-v8"
+        update-types: ["version-update:semver-major"]
     groups:
       dev-dependencies:
         dependency-type: development
@@ -37,6 +49,17 @@ updates:
       # deliberate migration validated by the tsc build plus the vitest suite over
       # the tree-sitter grammars, not an auto-bump. Minor/patch still flow.
       - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      # vitest 4 -> 5, capped for the same reason as in /ix-cli but failing a
+      # WORSE way here. This directory sets `legacy-peer-deps=true`, so npm does
+      # not refuse the bad resolution -- it installs a tree with `vite` simply
+      # missing (91 packages against main's 140, zero `vite` entries in the
+      # lock). `npm ci` then reports success and vitest cannot start at all:
+      #   Startup Error: Cannot find package 'vite' imported from
+      #   core-ingestion/node_modules/vitest/dist/...
+      # The strict directory fails loudly at install; this one fails quietly and
+      # only at the point of running the suite.
+      - dependency-name: "vitest"
         update-types: ["version-update:semver-major"]
     groups:
       dev-dependencies:


### PR DESCRIPTION
The weekly dev-dependencies group proposed **vitest 4 → 5** in both npm directories (#640, #639). Neither can be merged, and they fail *differently* because the two directories resolve peers differently.

## /ix-cli — strict, fails loudly

No `.npmrc`, so `npm ci` refuses outright:

```
npm error ERESOLVE could not resolve
npm error While resolving: vitest@5.0.0
npm error   peer overridden vite@">=7.3.2 <8.0.0" (was "^6.4.0 || ^7.0.0 || ^8.0.0")
npm error Could not resolve dependency:
npm error   peer vitest@"5.0.0" from @vitest/coverage-v8@5.0.0
```

That `npm ci` is the first step of every job, so **all fourteen checks went red at once** — Lint, five Test legs, four Package jobs, E2E, both parity gates, both install smokes. It presents as fourteen unrelated breakages rather than one bad bump.

## /core-ingestion — permissive, fails quietly and later

`legacy-peer-deps=true`, so npm does not refuse. It installs a tree with `vite` **missing**:

```
main lockfile:   vitest 4.1.11    vite entries = 1     (140 packages)
#639 lockfile:   vitest 5.0.0     vite entries = 0     ( 91 packages)
```

`npm ci` reports success, and the suite dies on startup:

```
Startup Error
Cannot find package 'vite' imported from core-ingestion/node_modules/vitest/dist/...
```

The permissive directory is the worse one. On #639 the ix-cli suite ran first and **passed — 99 files, 1814 tests** — so the log shows a full green run, a coverage table, and then `exit 1` with an error naming a missing package rather than a rejected bump.

That difference is worth stating because it changes how you diagnose it: I initially reproduced #639's failure as an ERESOLVE and was wrong — I had not copied the `.npmrc` into my scratch dir. Running `main` through the same harness as a control is what caught it.

## The cap

Major-only, so 5.x → 5.y and every 4.x patch still flow. Same rule and same reasoning already applied here to `typescript` and `@types/node` — toolchain majors need a deliberate, tested migration. `@vitest/coverage-v8` is capped alongside because it pins vitest exactly (`peer vitest@"5.0.0"`) and cannot move independently.

Closing #639 and #640 after this lets next week's run re-propose the four harmless minors in that group — `knip`, `tsx`, `typescript-eslint`, `@babel/types` — on a PR that can actually be validated.

**Not addressed here:** whether Ix *should* move to vitest 5. That is a real migration (it wants `vite` as a direct dependency) and wants its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnMJopSVeUMFifL74DJ2Gk