### PR TITLE
test(ix-cli): budget the suite for the work it actually does

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,18 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
+      # vitest 4 -> 5 is the same category, and it does not merely break: the
+      # lockfile Dependabot generates for it CANNOT BE INSTALLED here. ix-cli
+      # has no `.npmrc`, so `npm ci` resolves peers strictly and dies:
+      #   ERESOLVE: peer vitest@"5.0.0" from @vitest/coverage-v8@5.0.0
+      #   peer overridden vite@">=7.3.2 <8.0.0" (was "^6.4.0 || ^7.0.0 || ^8.0.0")
+      # Every job in the workflow failed on that single `npm ci`, which reads as
+      # fourteen unrelated breakages rather than one bad bump. Capped with its
+      # coverage provider, which pins vitest exactly and so must move with it.
+      - dependency-name: "vitest"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@vitest/coverage-v8"
+        update-types: ["version-update:semver-major"]
     groups:
       dev-dependencies:
         dependency-type: development
@@ -37,6 +49,17 @@ updates:
       # deliberate migration validated by the tsc build plus the vitest suite over
       # the tree-sitter grammars, not an auto-bump. Minor/patch still flow.
       - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      # vitest 4 -> 5, capped for the same reason as in /ix-cli but failing a
+      # WORSE way here. This directory sets `legacy-peer-deps=true`, so npm does
+      # not refuse the bad resolution -- it installs a tree with `vite` simply
+      # missing (91 packages against main's 140, zero `vite` entries in the
+      # lock). `npm ci` then reports success and vitest cannot start at all:
+      #   Startup Error: Cannot find package 'vite' imported from
+      #   core-ingestion/node_modules/vitest/dist/...
+      # The strict directory fails loudly at install; this one fails quietly and
+      # only at the point of running the suite.
+      - dependency-name: "vitest"
         update-types: ["version-update:semver-major"]
     groups:
       dev-dependencies:

--- a/ix-cli/src/cli/__tests__/watch-dedup.test.ts
+++ b/ix-cli/src/cli/__tests__/watch-dedup.test.ts
@@ -429,7 +429,11 @@ describe("canonical watch refresh", () => {
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }
-  }, 30_000);
+    // 60s, not the suite default and not the 30s this used to carry. It starts
+    // TWO real CLI children, one of them through tsx, which compiles on the way
+    // up -- and it still timed out at 35.7s against 30s on a loaded Windows
+    // runner. The budget has to cover the slowest leg, not the median one.
+  }, 60_000);
 
   it("delegates the workspace root to the existing map command with full ingest enabled", () => {
     const root = "/workspace/project";

--- a/ix-cli/vitest.config.ts
+++ b/ix-cli/vitest.config.ts
@@ -8,6 +8,45 @@ export default defineConfig({
     // `src/`). Re-exclude it. parser.test.ts is run separately via
     // `test/parser.smoke.mjs`, so keep it out of the default `vitest run`.
     exclude: [...configDefaults.exclude, "dist/**", "test/parser.test.ts"],
+    // Sized for what this suite actually DOES, not for unit tests.
+    //
+    // Vitest defaults to 5s per test and 10s per hook, which suits pure
+    // functions. Twenty-plus files here spawn real child processes, start real
+    // HTTP servers, run a worker-thread parse pool, shell out to `tar`, and
+    // mkdtemp real trees. On an idle machine those take 1-6s; under the full
+    // suite's parallelism on a loaded runner they take several times that, and
+    // whichever test is running when the runner is busiest fails on the clock
+    // rather than on an assertion.
+    //
+    // Three separate files did exactly that in one day: ingest-files (1 of 4
+    // runs, 3 of 3 under added load), watch-dedup (35.7s against its own 30s
+    // budget), and upgrade-compass-bundle (6356ms against the 5s default, on a
+    // PR whose only change was a YAML file). Each read as a real regression on
+    // whichever leg happened to be slowest.
+    //
+    // 20s is not arbitrary -- it is what this codebase already chose, fifteen
+    // separate times, as the explicit budget for tests of exactly this shape.
+    // Making it the default is what stops the next one being written without
+    // it: only 5 of 98 files carry an explicit timeout today, while more than
+    // twenty do real I/O.
+    //
+    // Raising the default does not weaken anything, and that is worth stating
+    // because it is the obvious objection. Two reasons:
+    //
+    //   - No test depends on a short timeout. The ones that care about not
+    //     waiting forever assert on the CLOCK instead --
+    //     `expect(elapsed).toBeLessThan(ParsePool.SHUTDOWN_GRACE_MS * 4)` --
+    //     and parse-pool's comment says outright that its timeout exists only
+    //     so the failure carries an explanation. Those assertions are
+    //     unaffected by what the budget is.
+    //   - An explicit third argument still wins. Verified rather than assumed:
+    //     with `shutdown` mutated never to settle, that test failed at its own
+    //     15000ms, not at this 20000.
+    //
+    // The cost is real but small: a genuinely hung test now reports 15s later
+    // than it used to, on a suite that runs in ~70s.
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
     coverage: {
       provider: "v8",
       // Reporters: text for the CI log, json/html as the uploaded artifact.


### PR DESCRIPTION
Three separate files timed out on the clock in a single day, none of them because anything was wrong:

| file | how it failed |
|---|---|
| `ingest-files.test.ts` | 1 of 4 runs, 3 of 3 under added load — fixed per-file in #613 |
| `watch-dedup.test.ts` | 35.7s against its own 30s budget |
| `upgrade-compass-bundle.test.ts` | 6356ms against the 5s default, on a PR whose only change was a YAML file |

Vitest defaults to **5s per test, 10s per hook**, which is right for pure functions. This suite is not that: twenty-plus files spawn real child processes, start real HTTP servers, run a worker-thread parse pool, shell out to `tar`, and mkdtemp real trees. They take 1-6s idle and several times that under the full suite's parallelism on a loaded runner — so whichever test happens to be running when the runner is busiest fails, on six legs, reading as a real regression.

## Why as a class, not a file at a time

```
98 test files
 5 carry an explicit timeout
20+ do real I/O
```

Every one of those twenty is a flake waiting for a busy runner, and the next such test gets written without a budget too — which is exactly how `upgrade-compass-bundle` ended up on the 5s default.

**20s is not invented.** It is what this codebase already chose, fifteen separate times, as the explicit budget for tests of exactly this shape. Making it the default just stops each new one having to rediscover it.

`watch-dedup`'s two-real-CLI-children case goes to **60s** separately, because it already had 30s and still lost — one of those children runs through `tsx` and compiles on the way up.

## Raising the default weakens nothing

The obvious objection, and it deserves an answer rather than an assurance:

- **No test depends on a short timeout.** The ones that care about not waiting forever assert on the clock instead — `expect(elapsed).toBeLessThan(ParsePool.SHUTDOWN_GRACE_MS * 4)` — and parse-pool's own comment says its timeout exists only so the failure carries an explanation.
- **An explicit argument still wins.** Verified rather than assumed: with `shutdown` mutated never to settle, that test failed at its own `15000ms`, not at the new 20000 default.

Cost is real but small: a genuinely hung test now reports ~15s later, on a suite that runs in ~70s.

## Scope

`core-ingestion` is deliberately untouched — its 38 test files do **zero** real I/O (checked, not assumed), so the default suits them.

```
vitest   99 files, 1813 passed / 2 skipped, 66.6s (was ~70s)
tsc      clean
eslint   0 errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnMJopSVeUMFifL74DJ2Gk