### PR TITLE
fix(ingest): make the code clause of the vm guard load-bearing, and guard the teardown properly

### DIFF
--- a/ix-cli/src/cli/__tests__/ingest-files.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-files.test.ts
@@ -150,7 +150,19 @@ class FakeBackend {
   }
 
   async stop(): Promise<void> {
-    if (this.server) await new Promise<void>((resolve) => this.server!.close(() => resolve()));
+    if (!this.server) return;
+    const server = this.server;
+    // `closeAllConnections` first, and a deadline behind it. `close()` waits for
+    // every open socket, so one keep-alive connection the run did not finish
+    // with leaves this pending -- and a hook that never settles takes its
+    // timeout, at which point NEITHER `finally` in the teardown runs and both
+    // temp trees leak anyway. The teardown can only be made safe if this cannot
+    // hang, so the fix belongs here rather than in another `try`.
+    server.closeAllConnections?.();
+    await Promise.race([
+      new Promise<void>((resolve) => server.close(() => resolve())),
+      new Promise<void>((resolve) => setTimeout(resolve, 2000).unref?.()),
+    ]);
   }
 
   private route(url: string, body: string, res: ServerResponse): void {
@@ -363,7 +375,14 @@ describe("ingestFiles against a fake backend", () => {
       // the ingest path grows an endpoint, this fails once with its name,
       // rather than ten tests passing against a fake that agreed with
       // everything.
-      expect(backend.unknownPaths, "endpoints the fake does not implement").toEqual([]);
+      // Guarded, because this is the line that runs FIRST. An earlier revision
+      // optional-chained `backend?.stop()` in the `finally` below for the case
+      // where `beforeEach` throws before assigning it -- but this dereference
+      // comes first, so it threw the TypeError and the guard down there could
+      // never help.
+      if (backend !== undefined) {
+        expect(backend.unknownPaths, "endpoints the fake does not implement").toEqual([]);
+      }
     } finally {
       // In a `finally`, because the assertion above threw straight past all of
       // this -- in exactly the case it exists for. The server stayed listening
@@ -374,9 +393,12 @@ describe("ingestFiles against a fake backend", () => {
       // snapshotted those polluted values and the file's final restore wrote
       // the fixture `HOME` back into the process.
       // And the steps do not share fate. Env first, because it is the one that
-      // leaks OUT of this file: a `stop()` that rejects or outruns the hook
-      // timeout would otherwise skip it and leave the whole process pointed at
-      // a deleted fixture home. `backend` is optional-chained because a
+      // leaks OUT of this file: a `stop()` that REJECTS would otherwise skip it
+      // and leave the whole process pointed at a deleted fixture home. Note
+      // what this does NOT buy -- on a hook timeout the hook promise is rejected
+      // from outside while the `await` is still pending, so no `finally` here
+      // runs at all. That case is handled where it has to be, by making
+      // `stop()` unable to hang. `backend` is optional-chained because a
       // `beforeEach` that throws in `mkdtempSync` leaves it unassigned, and a
       // TypeError here would bury that failure.
       for (const [k, v] of Object.entries(saved)) {
@@ -386,8 +408,14 @@ describe("ingestFiles against a fake backend", () => {
       try {
         await backend?.stop();
       } finally {
-        rmSync(home, { recursive: true, force: true });
-        rmSync(repo, { recursive: true, force: true });
+        // Guarded like `backend`, for the same scenario. `force: true`
+        // suppresses ENOENT, not the argument-type check: `rmSync(undefined,
+        // ...)` throws ERR_INVALID_ARG_TYPE, so a first `beforeEach` failing
+        // inside `mkdtempSync` would raise a second, unrelated error here and
+        // skip the `repo` removal entirely -- leaking the tree in exactly the
+        // case cleanup exists for.
+        if (home) rmSync(home, { recursive: true, force: true });
+        if (repo) rmSync(repo, { recursive: true, force: true });
       }
     }
   });

--- a/ix-cli/src/cli/__tests__/ingest-files.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-files.test.ts
@@ -350,18 +350,28 @@ describe("ingestFiles against a fake backend", () => {
     // a materially different payload on a third of the matrix, and a trap for
     // the first assertion that ever touches a uri. Windows junctions do it too.
     // `ingest-discovery.test.ts:105` already carries this fix and its reason.
-    // Cleared FIRST, and the fake built before anything that can throw.
+    // THIS is what makes the teardown correct. The guards down there are the
+    // decorative half, and an earlier version of this comment had it backwards.
     //
-    // These are describe-scoped and `afterEach` never reset them, so from the
-    // second test onward they held the PREVIOUS test's values -- which made the
-    // three guards in the teardown decorative in exactly the scenario their
-    // comments name. A `beforeEach` that threw inside `mkdtempSync` left
-    // `backend !== undefined` passing against the previous test's
-    // already-stopped fake, `stop()` closing an already-closed server, and both
-    // `rmSync` calls pointed at already-deleted paths, while the directory this
-    // test had just created leaked. Resetting here is what makes the guards
-    // discriminate; the alternative was `string | undefined` and a non-null
-    // assertion at forty use sites.
+    // All three are describe-scoped and `afterEach` never reset them, so from
+    // the second test onward they held the PREVIOUS test's values. A
+    // `beforeEach` that throws inside `mkdtempSync` then left the teardown
+    // asserting against the previous test's already-stopped fake and calling
+    // `rmSync` on its already-deleted paths, while the directory this test had
+    // just created leaked -- and `rmSync` of a stale path is a silent no-op
+    // under `force: true`, so nothing went red. Clearing here is the only
+    // reason each test's teardown sees its own state.
+    //
+    // `""` rather than `undefined`, because typing these as `string |
+    // undefined` costs a non-null assertion at forty use sites for no extra
+    // safety -- and `rmSync("")` is a no-op on Node 26, checked, where
+    // `rmSync(undefined)` throws ERR_INVALID_ARG_TYPE.
+    //
+    // The fake is constructed HERE, before anything that can throw, and that
+    // position is load-bearing: `backend` has no sentinel, so a statement
+    // inserted above it that can throw would leave it holding the previous
+    // test's fake and the teardown would assert against the wrong object and
+    // pass vacuously. Keep it first.
     home = "";
     repo = "";
     backend = new FakeBackend();
@@ -405,11 +415,12 @@ describe("ingestFiles against a fake backend", () => {
       // the ingest path grows an endpoint, this fails once with its name,
       // rather than ten tests passing against a fake that agreed with
       // everything.
-      // Guarded, because this is the line that runs FIRST. An earlier revision
-      // optional-chained `backend?.stop()` in the `finally` below for the case
-      // where `beforeEach` throws before assigning it -- but this dereference
-      // comes first, so it threw the TypeError and the guard down there could
-      // never help.
+      // The guard is cheap insurance, not the mechanism -- `backend` is assigned
+      // unconditionally in `beforeEach` before anything that can throw, so this
+      // is never false today. It stays because the cost is a line and the
+      // failure it would catch (a throw introduced above the assignment) is
+      // silent: the assertion would run against the previous test's fake and
+      // pass.
       if (backend !== undefined) {
         expect(backend.unknownPaths, "endpoints the fake does not implement").toEqual([]);
       }
@@ -438,12 +449,12 @@ describe("ingestFiles against a fake backend", () => {
       try {
         await backend?.stop();
       } finally {
-        // Guarded like `backend`, for the same scenario. `force: true`
-        // suppresses ENOENT, not the argument-type check: `rmSync(undefined,
-        // ...)` throws ERR_INVALID_ARG_TYPE, so a first `beforeEach` failing
-        // inside `mkdtempSync` would raise a second, unrelated error here and
-        // skip the `repo` removal entirely -- leaking the tree in exactly the
-        // case cleanup exists for.
+        // Explicit rather than load-bearing: the `""` reset in `beforeEach` is
+        // what makes these correct, and `rmSync("")` is a silent no-op anyway.
+        // They say "only remove what this test created" out loud, so the reset
+        // above cannot be mistaken for redundant and deleted -- which would put
+        // a stale path here, no-op under `force: true`, and leak the directory
+        // the failed `beforeEach` had just made, with nothing red.
         if (home) rmSync(home, { recursive: true, force: true });
         if (repo) rmSync(repo, { recursive: true, force: true });
       }

--- a/ix-cli/src/cli/__tests__/ingest-files.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-files.test.ts
@@ -175,8 +175,7 @@ class FakeBackend {
       // mysteriously slow file, with every later `afterEach` eating 2s too.
       // A future socket regression should read as a message, not as flakiness.
       process.stderr.write(
-        "FakeBackend.stop: server did not close within 2s; leaving it open rather than hanging the hook" +
-          String.fromCharCode(10),
+        "FakeBackend.stop: server did not close within 2s; leaving it open rather than hanging the hook\n",
       );
     }
   }
@@ -294,6 +293,14 @@ describe("ingestFiles against a fake backend", () => {
   let home: string;
   let repo: string;
   let backend: FakeBackend;
+  // The sentinel for `backend`, in the same spirit as the `""` reset that
+  // `home` and `repo` get. `backend` cannot use `undefined` as its own: it is
+  // read as a plain `FakeBackend` at ~35 call sites in the tests below, and
+  // widening the type to make teardown honest would put a narrowing burden on
+  // every one of them. So the freshness lives beside it instead. False means
+  // "`backend` does not refer to THIS test's fake" -- either the first test
+  // has not constructed one yet, or a `beforeEach` threw before it got there.
+  let backendIsCurrent = false;
   const saved: Record<string, string | undefined> = {};
 
   /**
@@ -367,14 +374,19 @@ describe("ingestFiles against a fake backend", () => {
     // safety -- and `rmSync("")` is a no-op on Node 26, checked, where
     // `rmSync(undefined)` throws ERR_INVALID_ARG_TYPE.
     //
-    // The fake is constructed HERE, before anything that can throw, and that
-    // position is load-bearing: `backend` has no sentinel, so a statement
-    // inserted above it that can throw would leave it holding the previous
-    // test's fake and the teardown would assert against the wrong object and
-    // pass vacuously. Keep it first.
+    // Cleared FIRST, then set immediately after the construction it describes,
+    // so the window in which `backendIsCurrent` is false is exactly the window
+    // in which `backend` is stale. A statement inserted above the assignment
+    // that throws now leaves the flag false and the teardown skips rather than
+    // asserting against the previous test's fake and passing vacuously.
+    // Constructing first is still the better position -- keep it first -- but
+    // it is no longer the only thing standing between that edit and a silent
+    // pass.
+    backendIsCurrent = false;
     home = "";
     repo = "";
     backend = new FakeBackend();
+    backendIsCurrent = true;
     home = realpathSync(mkdtempSync(join(tmpdir(), "ix-ingest-home-")));
     repo = realpathSync(mkdtempSync(join(tmpdir(), "ix-ingest-repo-")));
     const endpoint = await backend.start();
@@ -415,13 +427,14 @@ describe("ingestFiles against a fake backend", () => {
       // the ingest path grows an endpoint, this fails once with its name,
       // rather than ten tests passing against a fake that agreed with
       // everything.
-      // The guard is cheap insurance, not the mechanism -- `backend` is assigned
-      // unconditionally in `beforeEach` before anything that can throw, so this
-      // is never false today. It stays because the cost is a line and the
-      // failure it would catch (a throw introduced above the assignment) is
-      // silent: the assertion would run against the previous test's fake and
-      // pass.
-      if (backend !== undefined) {
+      // Guarded on freshness, not on existence. `backend` is typed
+      // non-nullable and holds the PREVIOUS test's fake after the first one,
+      // so an `!== undefined` test here would be true in precisely the case
+      // worth catching -- a `beforeEach` that threw above the assignment --
+      // and would assert against the wrong object and pass. That is the shape
+      // this PR was opened to fix, and it was reproduced one level up in this
+      // very hook.
+      if (backendIsCurrent) {
         expect(backend.unknownPaths, "endpoints the fake does not implement").toEqual([]);
       }
     } finally {
@@ -439,15 +452,18 @@ describe("ingestFiles against a fake backend", () => {
       // what this does NOT buy -- on a hook timeout the hook promise is rejected
       // from outside while the `await` is still pending, so no `finally` here
       // runs at all. That case is handled where it has to be, by making
-      // `stop()` unable to hang. `backend` is optional-chained because a
-      // `beforeEach` that throws in `mkdtempSync` leaves it unassigned, and a
-      // TypeError here would bury that failure.
+      // `stop()` unable to hang. The stop is guarded on the same freshness
+      // flag: a `beforeEach` that threw above the construction leaves
+      // `backend` pointing at the previous test's fake, which its own
+      // teardown already stopped. (It is NOT guarded on `mkdtempSync`
+      // throwing -- the fake is constructed above both of those calls, so a
+      // throw there leaves this test's own fake live and needing the stop.)
       for (const [k, v] of Object.entries(saved)) {
         if (v === undefined) delete process.env[k];
         else process.env[k] = v;
       }
       try {
-        await backend?.stop();
+        if (backendIsCurrent) await backend.stop();
       } finally {
         // Explicit rather than load-bearing: the `""` reset in `beforeEach` is
         // what makes these correct, and `rmSync("")` is a silent no-op anyway.

--- a/ix-cli/src/cli/__tests__/ingest-files.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-files.test.ts
@@ -169,13 +169,19 @@ class FakeBackend {
     ]);
     clearTimeout(timer);
     if (!closed) {
-      // Say so. Trading a hang for a leak is the right call, but a silent leak
-      // is the condition the teardown exists to prevent -- an open handle that
-      // keeps the vitest worker from exiting -- and it would surface only as a
-      // mysteriously slow file, with every later `afterEach` eating 2s too.
-      // A future socket regression should read as a message, not as flakiness.
+      // Not expected to fire, and it never has: `closeAllConnections()` above
+      // destroys every open socket, so `close()` drains and its callback wins
+      // this race. It is kept for the case that would break that -- a socket
+      // opened AFTER that call -- because the alternative is a hook that
+      // takes its timeout and surfaces as a mysteriously slow file, with
+      // every later `afterEach` eating 2s too.
+      //
+      // The message says what is actually true on that path. The LISTENING
+      // handle is already released -- `close()` does that synchronously --
+      // so the port is free; what can still be holding the worker open is a
+      // late socket.
       process.stderr.write(
-        "FakeBackend.stop: server did not close within 2s; leaving it open rather than hanging the hook\n",
+        "FakeBackend.stop: close did not drain within 2s; a socket opened after closeAllConnections is still up\n",
       );
     }
   }
@@ -387,8 +393,15 @@ describe("ingestFiles against a fake backend", () => {
     repo = "";
     backend = new FakeBackend();
     backendIsCurrent = true;
-    home = realpathSync(mkdtempSync(join(tmpdir(), "ix-ingest-home-")));
-    repo = realpathSync(mkdtempSync(join(tmpdir(), "ix-ingest-repo-")));
+    // Two steps each, deliberately. `realpathSync(mkdtempSync(...))` leaves
+    // nothing in `home` if the OUTER call throws -- and the directory exists
+    // by then, so the `if (home)` cleanup below skips a tree that is already
+    // on disk. Assigning the created path first means the variable always
+    // names whatever was created, resolved or not.
+    home = mkdtempSync(join(tmpdir(), "ix-ingest-home-"));
+    home = realpathSync(home);
+    repo = mkdtempSync(join(tmpdir(), "ix-ingest-repo-"));
+    repo = realpathSync(repo);
     const endpoint = await backend.start();
 
     // HOME *and* USERPROFILE: `os.homedir()` reads the latter on Windows, so
@@ -431,9 +444,17 @@ describe("ingestFiles against a fake backend", () => {
       // non-nullable and holds the PREVIOUS test's fake after the first one,
       // so an `!== undefined` test here would be true in precisely the case
       // worth catching -- a `beforeEach` that threw above the assignment --
-      // and would assert against the wrong object and pass. That is the shape
-      // this PR was opened to fix, and it was reproduced one level up in this
-      // very hook.
+      // and would assert against the wrong object and pass.
+      //
+      // Be clear about what this flag is and is not. It is DORMANT: nothing
+      // between the reset and the assignment can throw today, so replacing it
+      // with `true` leaves the suite green, and no test covers it. What it
+      // buys over the `!== undefined` it replaced is not coverage but
+      // correctness WHEN it fires -- the old guard was dormant AND could not
+      // have worked, since the stale fake is never `undefined`. Verified by
+      // running both forms against a `beforeEach` that throws above the
+      // assignment: the old one asserted twice against the first test's fake,
+      // the new one skipped.
       if (backendIsCurrent) {
         expect(backend.unknownPaths, "endpoints the fake does not implement").toEqual([]);
       }
@@ -455,9 +476,10 @@ describe("ingestFiles against a fake backend", () => {
       // `stop()` unable to hang. The stop is guarded on the same freshness
       // flag: a `beforeEach` that threw above the construction leaves
       // `backend` pointing at the previous test's fake, which its own
-      // teardown already stopped. (It is NOT guarded on `mkdtempSync`
-      // throwing -- the fake is constructed above both of those calls, so a
-      // throw there leaves this test's own fake live and needing the stop.)
+      // teardown already stopped. A throw in the `mkdtempSync` calls is a
+      // different case and needs no guard of its own -- `start()` runs below
+      // them, so the fake was constructed but never listened, and `stop()`
+      // returns at its own `if (!this.server)`.
       for (const [k, v] of Object.entries(saved)) {
         if (v === undefined) delete process.env[k];
         else process.env[k] = v;
@@ -465,14 +487,27 @@ describe("ingestFiles against a fake backend", () => {
       try {
         if (backendIsCurrent) await backend.stop();
       } finally {
-        // Explicit rather than load-bearing: the `""` reset in `beforeEach` is
-        // what makes these correct, and `rmSync("")` is a silent no-op anyway.
-        // They say "only remove what this test created" out loud, so the reset
-        // above cannot be mistaken for redundant and deleted -- which would put
-        // a stale path here, no-op under `force: true`, and leak the directory
-        // the failed `beforeEach` had just made, with nothing red.
+        // These guard exactly one case: `mkdtempSync` itself threw, so nothing
+        // was created and the variable still holds the `""` from the reset
+        // above. Every other failure leaves the variable naming a real
+        // directory, which is why the assignment is split from the
+        // `realpathSync` that follows it.
+        //
+        // Do not read them as covering a stale path from a previous test --
+        // the reset does that, and `rmSync("")` is a silent no-op in any
+        // case. An earlier version of this comment credited them with
+        // preventing a leak that was not reachable, while the one that WAS
+        // reachable sat two lines up.
         if (home) rmSync(home, { recursive: true, force: true });
         if (repo) rmSync(repo, { recursive: true, force: true });
+        // Cleared on the way out, so the flag means "constructed by the
+        // `beforeEach` for the test now running" rather than "constructed at
+        // some point". Without this it stays `true` forever after the first
+        // test, and a file- or project-level `beforeEach` added later that
+        // throws BEFORE this describe's own would find it set and assert
+        // against the stale fake -- reintroducing the bug through the one
+        // door the flag does not otherwise cover.
+        backendIsCurrent = false;
       }
     }
   });

--- a/ix-cli/src/cli/__tests__/ingest-files.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-files.test.ts
@@ -158,7 +158,8 @@ class FakeBackend {
     // timeout, at which point NEITHER `finally` in the teardown runs and both
     // temp trees leak anyway. The teardown can only be made safe if this cannot
     // hang, so the fix belongs here rather than in another `try`.
-    server.closeAllConnections?.();
+    // Not optional-chained: `engines.node` is >=22 and this landed in 18.2.
+    server.closeAllConnections();
     let timer: ReturnType<typeof setTimeout> | undefined;
     const closed = await Promise.race([
       new Promise<boolean>((resolve) => server.close(() => resolve(true))),
@@ -169,19 +170,21 @@ class FakeBackend {
     ]);
     clearTimeout(timer);
     if (!closed) {
-      // Not expected to fire, and it never has: `closeAllConnections()` above
-      // destroys every open socket, so `close()` drains and its callback wins
-      // this race. It is kept for the case that would break that -- a socket
-      // opened AFTER that call -- because the alternative is a hook that
-      // takes its timeout and surfaces as a mysteriously slow file, with
-      // every later `afterEach` eating 2s too.
+      // Not expected to fire, and it never has. `Promise.race` builds its
+      // array eagerly, so `server.close()` runs in the SAME tick as
+      // `closeAllConnections()` above -- the listening handle is gone before
+      // any later turn of the loop, so nothing can connect afterwards, and
+      // every socket that existed has been destroyed. There is no "late
+      // socket" story; an earlier revision of this comment invented one.
       //
-      // The message says what is actually true on that path. The LISTENING
-      // handle is already released -- `close()` does that synchronously --
-      // so the port is free; what can still be holding the worker open is a
-      // late socket.
+      // Kept anyway, as a backstop against `close()` simply never calling
+      // back -- a socket wedged in destroy, say. Deliberately a message and
+      // not a throw: the alternative it exists to prevent is a hook that
+      // never settles, which takes the hook timeout and runs NEITHER
+      // `finally` below, leaking both trees and leaving the env pointed at a
+      // deleted home. A leak that announces itself is the better trade.
       process.stderr.write(
-        "FakeBackend.stop: close did not drain within 2s; a socket opened after closeAllConnections is still up\n",
+        "FakeBackend.stop: close() did not call back within 2s; the server handle is being abandoned\n",
       );
     }
   }
@@ -368,12 +371,15 @@ describe("ingestFiles against a fake backend", () => {
     //
     // All three are describe-scoped and `afterEach` never reset them, so from
     // the second test onward they held the PREVIOUS test's values. A
-    // `beforeEach` that throws inside `mkdtempSync` then left the teardown
+    // `beforeEach` that throws anywhere in the setup then left the teardown
     // asserting against the previous test's already-stopped fake and calling
-    // `rmSync` on its already-deleted paths, while the directory this test had
-    // just created leaked -- and `rmSync` of a stale path is a silent no-op
-    // under `force: true`, so nothing went red. Clearing here is the only
-    // reason each test's teardown sees its own state.
+    // `rmSync` on its already-deleted paths -- a silent no-op under
+    // `force: true`, so nothing went red. Clearing here is the only reason
+    // each test's teardown sees its own state.
+    //
+    // (A throw in `mkdtempSync` itself leaks nothing, since no directory got
+    // made. The leak that WAS reachable came from `realpathSync` throwing
+    // after one existed, and the split assignment below is what closes it.)
     //
     // `""` rather than `undefined`, because typing these as `string |
     // undefined` costs a non-null assertion at forty use sites for no extra
@@ -434,6 +440,22 @@ describe("ingestFiles against a fake backend", () => {
     process.env.IX_LOCK_DIR = join(home, "locks");
   });
 
+  /**
+   * Remove a temp tree without letting one failure strand the next. `rmSync`
+   * with `force` suppresses ENOENT only; EBUSY and EPERM still throw, and on
+   * Windows they are ordinary -- a handle under `IX_LOCK_DIR` is enough. The
+   * leak is reported rather than raised, because failing the teardown here
+   * would mask whatever the test itself was failing on.
+   */
+  const removeTree = (dir: string): void => {
+    if (!dir) return;
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch (err) {
+      process.stderr.write(`ingest-files teardown: could not remove ${dir}: ${String(err)}\n`);
+    }
+  };
+
   afterEach(async () => {
     try {
       // Every request the run made was one this fake actually implements. If
@@ -487,27 +509,32 @@ describe("ingestFiles against a fake backend", () => {
       try {
         if (backendIsCurrent) await backend.stop();
       } finally {
-        // These guard exactly one case: `mkdtempSync` itself threw, so nothing
-        // was created and the variable still holds the `""` from the reset
-        // above. Every other failure leaves the variable naming a real
-        // directory, which is why the assignment is split from the
-        // `realpathSync` that follows it.
+        // FIRST, and before anything that can throw. The flag means
+        // "constructed by the `beforeEach` for the test now running" rather
+        // than "constructed at some point": without clearing it, it stays
+        // `true` forever after the first test, and a file- or project-level
+        // `beforeEach` added later that throws BEFORE this describe's own
+        // would find it set and assert against the stale fake -- the bug,
+        // through the one door the flag does not otherwise cover.
         //
-        // Do not read them as covering a stale path from a previous test --
-        // the reset does that, and `rmSync("")` is a silent no-op in any
-        // case. An earlier version of this comment credited them with
-        // preventing a leak that was not reachable, while the one that WAS
-        // reachable sat two lines up.
-        if (home) rmSync(home, { recursive: true, force: true });
-        if (repo) rmSync(repo, { recursive: true, force: true });
-        // Cleared on the way out, so the flag means "constructed by the
-        // `beforeEach` for the test now running" rather than "constructed at
-        // some point". Without this it stays `true` forever after the first
-        // test, and a file- or project-level `beforeEach` added later that
-        // throws BEFORE this describe's own would find it set and assert
-        // against the stale fake -- reintroducing the bug through the one
-        // door the flag does not otherwise cover.
+        // It sat below the two removals and shared their fate, which was the
+        // same mistake the outer `finally` above exists to avoid: `rmSync`
+        // suppresses only ENOENT, so one EBUSY on Windows -- a lock file under
+        // `IX_LOCK_DIR`, a `.git` handle -- skipped it AND the second removal.
         backendIsCurrent = false;
+        // Separately, for the same reason. `removeTree` swallows per
+        // directory so `home` failing cannot strand `repo`, and so a teardown
+        // error cannot replace an in-flight `unknownPaths` failure and hide
+        // which endpoint was unimplemented.
+        //
+        // The `if` inside guards exactly one case: `mkdtempSync` itself threw,
+        // so nothing was created and the variable still holds the `""` from
+        // the reset above. Every other failure leaves it naming a real
+        // directory, which is why the assignment is split from the
+        // `realpathSync` that follows it. Not a stale path from a previous
+        // test -- the reset covers that, and `rmSync("")` is a no-op anyway.
+        removeTree(home);
+        removeTree(repo);
       }
     }
   });

--- a/ix-cli/src/cli/__tests__/ingest-files.test.ts
+++ b/ix-cli/src/cli/__tests__/ingest-files.test.ts
@@ -159,10 +159,26 @@ class FakeBackend {
     // temp trees leak anyway. The teardown can only be made safe if this cannot
     // hang, so the fix belongs here rather than in another `try`.
     server.closeAllConnections?.();
-    await Promise.race([
-      new Promise<void>((resolve) => server.close(() => resolve())),
-      new Promise<void>((resolve) => setTimeout(resolve, 2000).unref?.()),
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const closed = await Promise.race([
+      new Promise<boolean>((resolve) => server.close(() => resolve(true))),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(false), 2000);
+        timer.unref?.();
+      }),
     ]);
+    clearTimeout(timer);
+    if (!closed) {
+      // Say so. Trading a hang for a leak is the right call, but a silent leak
+      // is the condition the teardown exists to prevent -- an open handle that
+      // keeps the vitest worker from exiting -- and it would surface only as a
+      // mysteriously slow file, with every later `afterEach` eating 2s too.
+      // A future socket regression should read as a message, not as flakiness.
+      process.stderr.write(
+        "FakeBackend.stop: server did not close within 2s; leaving it open rather than hanging the hook" +
+          String.fromCharCode(10),
+      );
+    }
   }
 
   private route(url: string, body: string, res: ServerResponse): void {
@@ -334,9 +350,23 @@ describe("ingestFiles against a fake backend", () => {
     // a materially different payload on a third of the matrix, and a trap for
     // the first assertion that ever touches a uri. Windows junctions do it too.
     // `ingest-discovery.test.ts:105` already carries this fix and its reason.
+    // Cleared FIRST, and the fake built before anything that can throw.
+    //
+    // These are describe-scoped and `afterEach` never reset them, so from the
+    // second test onward they held the PREVIOUS test's values -- which made the
+    // three guards in the teardown decorative in exactly the scenario their
+    // comments name. A `beforeEach` that threw inside `mkdtempSync` left
+    // `backend !== undefined` passing against the previous test's
+    // already-stopped fake, `stop()` closing an already-closed server, and both
+    // `rmSync` calls pointed at already-deleted paths, while the directory this
+    // test had just created leaked. Resetting here is what makes the guards
+    // discriminate; the alternative was `string | undefined` and a non-null
+    // assertion at forty use sites.
+    home = "";
+    repo = "";
+    backend = new FakeBackend();
     home = realpathSync(mkdtempSync(join(tmpdir(), "ix-ingest-home-")));
     repo = realpathSync(mkdtempSync(join(tmpdir(), "ix-ingest-repo-")));
-    backend = new FakeBackend();
     const endpoint = await backend.start();
 
     // HOME *and* USERPROFILE: `os.homedir()` reads the latter on Windows, so

--- a/ix-cli/src/cli/__tests__/ingestion-loader.test.ts
+++ b/ix-cli/src/cli/__tests__/ingestion-loader.test.ts
@@ -82,7 +82,13 @@ describe("isVmDynamicImportUnavailable", () => {
     const reworded = new Error("the wording of this error changed upstream");
     (reworded as NodeJS.ErrnoException).code = (original as NodeJS.ErrnoException).code;
 
-    expect(reworded.message).not.toMatch(/dynamic import callback/i);
+    // `String(reworded)`, which is what the predicate inspects -- not
+    // `.message`, which is what an earlier version checked. They differ by the
+    // error's name prefix, so a fixture that ever carried the phrase in its
+    // NAME would satisfy the message clause while this assertion still passed,
+    // and this test would go green without the code clause -- silently
+    // reopening the gap it exists to close.
+    expect(String(reworded)).not.toMatch(/dynamic import callback/i);
     expect(isVmDynamicImportUnavailable(reworded)).toBe(true);
   });
 

--- a/ix-cli/src/cli/__tests__/ingestion-loader.test.ts
+++ b/ix-cli/src/cli/__tests__/ingestion-loader.test.ts
@@ -74,6 +74,17 @@ describe("isVmDynamicImportUnavailable", () => {
     // own code (which is precisely why test 2 exists) or Node renames it, this
     // fails as a bare `expected false to be true` pointing at the predicate,
     // when what changed is the input.
+    // `typeof` as well as the value, because the predicate demands a STRING
+    // `code` before it calls `startsWith`. Asserting only `String(code)`
+    // passes on a non-string that stringifies the same way -- exactly the
+    // shape the NUMERIC-code test below exists for -- and the failure would
+    // then land two lines down as a bare `expected false to be true` against
+    // the predicate, which is the confusion this premise assertion is here to
+    // prevent.
+    expect(
+      typeof (original as NodeJS.ErrnoException).code,
+      "the predicate reads `code` only when it is a string",
+    ).toBe("string");
     expect(
       String((original as NodeJS.ErrnoException).code),
       "the real vm failure still carries the vm code",

--- a/ix-cli/src/cli/__tests__/ingestion-loader.test.ts
+++ b/ix-cli/src/cli/__tests__/ingestion-loader.test.ts
@@ -47,10 +47,33 @@ describe("isVmDynamicImportUnavailable", () => {
     // test, never reaches the message test, and the fallback never fires on the
     // one host it is for.
     const original = (await realVmFailure()) as Error;
+    // Guarded for the same reason test 1 asserts it: if the host ever gains a
+    // dynamic-import hook this is `null`, and `original.message` would fail
+    // with an opaque TypeError instead of naming the cause.
+    expect(original, "expected the vm indirection to fail under vite-node").not.toBeNull();
     const wrapped = new Error(original.message, { cause: original });
     (wrapped as NodeJS.ErrnoException).code = "ERR_LOAD_URL";
 
     expect(isVmDynamicImportUnavailable(wrapped)).toBe(true);
+  });
+
+  it("matches on the CODE alone, when the message no longer says anything", async () => {
+    // The case that makes the code check load-bearing. The real error carries
+    // BOTH a matching code and a matching message, so `||` short-circuits on
+    // the message and the code clause is never reached: deleting it left this
+    // file 4/4 green. That is not a hypothetical gap -- a later "simplification"
+    // back to a message-only match is exactly the pre-#613 form, ships green,
+    // and then Node rewords the message and the fallback silently stops firing.
+    //
+    // Derived, like the others: the real error with its real code, and only the
+    // message replaced.
+    const original = (await realVmFailure()) as Error;
+    expect(original, "expected the vm indirection to fail under vite-node").not.toBeNull();
+    const reworded = new Error("the wording of this error changed upstream");
+    (reworded as NodeJS.ErrnoException).code = (original as NodeJS.ErrnoException).code;
+
+    expect(reworded.message).not.toMatch(/dynamic import callback/i);
+    expect(isVmDynamicImportUnavailable(reworded)).toBe(true);
   });
 
   it("does not throw when the error carries a NUMERIC code", async () => {

--- a/ix-cli/src/cli/__tests__/ingestion-loader.test.ts
+++ b/ix-cli/src/cli/__tests__/ingestion-loader.test.ts
@@ -69,6 +69,16 @@ describe("isVmDynamicImportUnavailable", () => {
     // message replaced.
     const original = (await realVmFailure()) as Error;
     expect(original, "expected the vm indirection to fail under vite-node").not.toBeNull();
+    // The premise, asserted rather than assumed -- every other test here does
+    // the same. Without it, the day vite-node wraps this failure under its
+    // own code (which is precisely why test 2 exists) or Node renames it, this
+    // fails as a bare `expected false to be true` pointing at the predicate,
+    // when what changed is the input.
+    expect(
+      String((original as NodeJS.ErrnoException).code),
+      "the real vm failure still carries the vm code",
+    ).toMatch(/^ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING/);
+
     const reworded = new Error("the wording of this error changed upstream");
     (reworded as NodeJS.ErrnoException).code = (original as NodeJS.ErrnoException).code;
 

--- a/ix-cli/src/cli/commands/ingestion-loader.ts
+++ b/ix-cli/src/cli/commands/ingestion-loader.ts
@@ -27,6 +27,21 @@ const importViaFunction = new Function(
 ) as (specifier: string) => Promise<any>;
 
 /**
+ * Is this "this host cannot do dynamic import", as opposed to any other error?
+ *
+ * Exported for its test. The shapes it has to accept are not guessable, which
+ * is why that test derives them from a real failure rather than writing plausible
+ * ones by hand.
+ */
+export function isVmDynamicImportUnavailable(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | null)?.code;
+  return (
+    (typeof code === "string" && code.startsWith("ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING")) ||
+    /dynamic import callback/i.test(String(err))
+  );
+}
+
+/**
  * Load a built `core-ingestion` module by absolute file URL.
  *
  * The `new Function` indirection is the primary path and stays first: it keeps
@@ -44,21 +59,6 @@ const importViaFunction = new Function(
  * genuine module-not-found still propagates, rather than being retried and
  * reported twice.
  */
-/**
- * Is this "this host cannot do dynamic import", as opposed to any other error?
- *
- * Exported for its test. The shapes it has to accept are not guessable, which
- * is why that test derives them from a real failure rather than writing plausible
- * ones by hand.
- */
-export function isVmDynamicImportUnavailable(err: unknown): boolean {
-  const code = (err as NodeJS.ErrnoException | null)?.code;
-  return (
-    (typeof code === "string" && code.startsWith("ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING")) ||
-    /dynamic import callback/i.test(String(err))
-  );
-}
-
 const importModule = async (specifier: string): Promise<any> => {
   try {
     return await importViaFunction(specifier);


### PR DESCRIPTION
Follow-up to #621, which merged at its first commit — these six review findings are not on `main`.

## The one that matters: my `code` clause had zero coverage

#621 widened the vm guard to `code || message`, with tests. But the real vm error carries **both** a matching code and a matching message, so `||` short-circuits on the message and the code branch is never reached.

Mutation-verified: replacing the whole predicate with the message-only test left the file **4/4 green**.

That is exactly the pre-#613 form. So a later "simplification" back to it ships green — and then Node rewords the message, which is the precise hazard the code check was added for, and the fallback silently stops firing with nothing pointing at the guard. The test file claimed the gate was protected "in either direction". It was protected in one.

There is now a case only the code clause can satisfy: the real error, its real code, and the message replaced with something that does not match. Derived from a genuine failure like the others. **Both clauses are mutation-validated now** — deleting either fails a different test.

## The teardown guards, which were in the wrong places

| Finding | Why the previous fix did not work |
|---|---|
| `backend?.` optional chain was inert | the scenario it names is a `beforeEach` that throws before assigning `backend` — but the unguarded `backend.unknownPaths` dereference is two lines **above** it and throws first |
| `home`/`repo` unguarded | `force: true` suppresses ENOENT, **not** the argument-type check: `rmSync(undefined, …)` throws `ERR_INVALID_ARG_TYPE`, raising a second unrelated error and skipping the `repo` removal entirely — leaking the tree in exactly the case cleanup exists for |
| the comment overclaimed | it said the decoupling protects against a `stop()` that "outruns the hook timeout". It does not — on a hook timeout the promise is rejected from outside while the `await` is still pending, so no `finally` runs at all |

The last one is now fixed where it has to be: `stop()` can no longer hang. It calls `closeAllConnections()` before `close()` and races a 2s deadline, because `close()` waits for every open socket and a single stray keep-alive was enough to leave the hook pending. The comment now claims only what it delivers.

## Two smaller ones

- The loader's JSDoc had drifted onto the wrong function — the new block was inserted *after* the existing one instead of replacing it, so both attached to the predicate and `importModule` was left undocumented.
- `(await realVmFailure()) as Error` then `original.message` would crash with an opaque `TypeError` in the scenario the file explicitly anticipates (a host that gains a dynamic-import hook returns `null`). Both sites assert it first.

## Verification

- 16 tests pass across the two files
- Full `ix-cli` suite: 1736 passed; the 3 failures are the `read-containment` symlink tests that need Windows Developer Mode locally and pass on CI's `windows-2022` runner
- `tsc --noEmit` and `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5bkc5oUL4SapwDE13UgHt