### PR TITLE
test(parse-pool): wait for the idle fault to land, not for 120ms

### DIFF
--- a/ix-cli/src/cli/__tests__/parse-pool.test.ts
+++ b/ix-cli/src/cli/__tests__/parse-pool.test.ts
@@ -125,7 +125,17 @@ describe("ParsePool", () => {
       try {
         writeFileSync(marker, threadId + '\\n', { flag: 'wx' });
         armed = true;
-      } catch {
+      } catch (err) {
+        // EEXIST is the expected answer: another thread holds the claim.
+        // Anything else -- EPERM or EBUSY from an indexer touching the fresh
+        // mkdtemp directory, ENOSPC -- means the FIRST worker failed to arm,
+        // and a bare catch would swallow that and leave the test to time out
+        // 10s later saying the pool never reacted to a fault nobody ever
+        // scheduled. Accusing the pool of a harness failure is the exact
+        // misdiagnosis this test exists to prevent, so rethrow: the worker
+        // faults, the marker stays empty, and the arming assertion fails
+        // naming the real problem.
+        if (err.code !== 'EEXIST') throw err;
         armed = false;
       }
       if (armed) {
@@ -202,6 +212,12 @@ describe("ParsePool", () => {
     // `respawnCount()` is the pool's own signal that `onError` ran to
     // completion, so this waits on the state the test actually depends on and
     // is done as soon as it holds.
+    // `> 0` is only correct because this is the FIRST death of the run. The
+    // counter is monotonic and never resets, so a second wait written this
+    // way returns immediately -- a silent no-op, which is the same class of
+    // bug this test was fixed for. A later fault must capture a baseline
+    // first: `const before = pool.respawnCount()` then `() => pool
+    // .respawnCount() > before`.
     await waitUntil(
       () => pool.respawnCount() > 0,
       "the idle fault never reached the pool",

--- a/ix-cli/src/cli/__tests__/parse-pool.test.ts
+++ b/ix-cli/src/cli/__tests__/parse-pool.test.ts
@@ -73,13 +73,33 @@ describe("ParsePool", () => {
   `;
 
   /** Answers its first message, then faults while IDLE. */
-  const IDLE_FAULT = `
+  /**
+   * Faults ONCE per pool, not once per worker.
+   *
+   * `let served = 0` was per-thread, so the replacement armed its own fault
+   * 20ms after serving `a2.ts` -- and `b2.ts` is only posted once the parent
+   * has received a2's result and re-drained. Miss that 20ms window on a busy
+   * machine and the replacement dies with `b2.ts` in flight, which `onError`
+   * resolves to null: the exact Ix#567 signature, from the harness rather
+   * than the pool. Fixing only the first wait would have left this half of
+   * the race in place.
+   *
+   * The marker is a file because the arming has to be visible to the NEXT
+   * thread, and these fixtures share nothing else.
+   */
+  const IDLE_FAULT_ONCE = (marker: string): string => `
     import { parentPort } from 'node:worker_threads';
-    let served = 0;
+    import { existsSync, writeFileSync } from 'node:fs';
+    const marker = ${JSON.stringify(marker)};
     parentPort.on('message', (msg) => {
       if (msg && msg.__shutdown) { parentPort.close(); return; }
       parentPort.postMessage({ ok: true, result: { filePath: msg.filePath } });
-      if (++served === 1) setTimeout(() => { throw new Error('idle fault'); }, 20);
+      // Claim the fault before scheduling it, so a replacement that starts
+      // while the timer is pending still sees it taken.
+      if (!existsSync(marker)) {
+        writeFileSync(marker, 'armed');
+        setTimeout(() => { throw new Error('idle fault'); }, 20);
+      }
     });
   `;
 
@@ -136,7 +156,10 @@ describe("ParsePool", () => {
     // tasks -- and it was spliced out of `workers` but left in `idle`, so the
     // next `drain()` popped the terminated thread and posted to nothing: that
     // task's promise never settled.
-    const pool = new ParsePool(worker("idlefault", IDLE_FAULT), 1);
+    const pool = new ParsePool(
+      worker("idlefault", IDLE_FAULT_ONCE(join(dir, "idle-fault-armed"))),
+      1,
+    );
     pool.init();
 
     expect(await pool.parse("first.ts", "x")).toEqual({ filePath: "first.ts" });
@@ -162,6 +185,12 @@ describe("ParsePool", () => {
     // posts to nothing, and never settles.
     const both = await Promise.all([pool.parse("a2.ts", "x"), pool.parse("b2.ts", "x")]);
     expect(both).toEqual([{ filePath: "a2.ts" }, { filePath: "b2.ts" }]);
+    // Exactly one fault for the whole pool. This is what makes `b2.ts`
+    // deterministic rather than merely likely: a replacement that armed its
+    // own fault would make this 2, and b2 would be racing that worker's 20ms
+    // timer. Pins the fixture's once-per-pool contract, which is otherwise
+    // invisible from here.
+    expect(pool.respawnCount(), "the replacement must not fault as well").toBe(1);
 
     await pool.destroy();
   });

--- a/ix-cli/src/cli/__tests__/parse-pool.test.ts
+++ b/ix-cli/src/cli/__tests__/parse-pool.test.ts
@@ -91,54 +91,63 @@ describe("ParsePool", () => {
     import { parentPort, threadId } from 'node:worker_threads';
     import { writeFileSync } from 'node:fs';
     const marker = ${JSON.stringify(marker)};
+
+    // Claim at MODULE SCOPE, once per thread, before any message is
+    // served. The previous revision claimed inside the message handler,
+    // which put a filesystem write on the path of every parse: the
+    // replacement re-attempted it while serving \`b2.ts\`, and a transient
+    // EPERM there faulted a worker with a task in flight -- producing
+    // \`b2.ts -> null\`, which is the Ix#567 signature this whole test exists
+    // to tell apart from a harness problem. The old fixture did no I/O at
+    // all, so that was exposure this PR introduced. Here the write happens
+    // once, before the pool can dispatch anything, and the handler touches
+    // no filesystem at all.
+    //
+    // \`wx\` because it is one atomic syscall: \`existsSync\` then write is two,
+    // and two threads can both pass the check. That cannot happen at this
+    // pool's concurrency of 1, but the guarantee is stated
+    // unconditionally, and this is what makes it true at any size.
+    let isFaulter = false;
+    try {
+      writeFileSync(marker, threadId + '\\n', { flag: 'wx' });
+      isFaulter = true;
+    } catch (err) {
+      // EEXIST is the expected answer: another thread holds the claim.
+      // Anything else means THIS thread failed to claim for an unrelated
+      // reason, and if it was the first thread the next one claims
+      // successfully and the run looks entirely normal -- one arming, one
+      // respawn, green. A previous revision rethrew here and claimed that
+      // surfaced the problem; it does not, it just moves which thread
+      // faults. So record it instead, and let the test assert the absence
+      // of this file. Best-effort: if this write fails too there is
+      // nothing left to say with.
+      if (err.code !== 'EEXIST') {
+        try {
+          writeFileSync(marker + '.failed', threadId + ' ' + err.code + '\\n', { flag: 'a' });
+        } catch {}
+      }
+    }
+
+    let armed = false;
     parentPort.on('message', (msg) => {
       if (msg && msg.__shutdown) { parentPort.close(); return; }
       parentPort.postMessage({ ok: true, result: { filePath: msg.filePath } });
-      // Claim the fault before scheduling it, so a replacement that starts
-      // while the timer is pending still sees it taken. Recorded HERE rather
-      // than in the timer, because arming is what the test counts and it
-      // happens synchronously with the serve -- the throw is later and would
-      // be raced.
-      //
-      // The claim is \`wx\`, which fails if the file exists, rather than
-      // \`existsSync\` then append: those are two syscalls and two threads
-      // can both pass the check. That cannot happen at this pool's concurrency
-      // of 1, where no two workers ever serve at once -- but the guarantee is
-      // stated unconditionally above, and \`wx\` is what makes it true at any
-      // size rather than true by accident of the caller.
-      //
       // The delay exists so the parent has consumed this reply before the
-      // fault lands: 'message' and 'error' reach it on different channels, so
-      // a parent descheduled across both can process the 'error' first, find
-      // the task still in \`active\`, and resolve it null -- failing the
+      // fault lands: 'message' and 'error' reach it on different channels,
+      // so a parent descheduled across both can process the 'error' first,
+      // find the task still in \`active\`, and resolve it null -- failing the
       // first.ts assertion with the very signature this test is meant to
-      // distinguish. It was 20ms, which is the same order as the scheduling
-      // delays that caused the original flake; it is 250ms now.
+      // distinguish. It was 20ms, the same order as the scheduling delays
+      // that caused the original flake; it is 250ms now.
       //
       // What this does NOT do is remove the ordering dependency, and it
       // cannot: the worker has no way to learn that its reply was consumed,
       // and a fault raised while a task IS in flight never leaves a stale
       // entry in \`idle\`, which is the whole bug. So the premise needs an
-      // idle fault, and an idle fault needs a delay. This only makes the
+      // idle fault, an idle fault needs a delay, and this only makes the
       // required parent stall implausible rather than merely unlikely.
-      let armed = false;
-      try {
-        writeFileSync(marker, threadId + '\\n', { flag: 'wx' });
+      if (isFaulter && !armed) {
         armed = true;
-      } catch (err) {
-        // EEXIST is the expected answer: another thread holds the claim.
-        // Anything else -- EPERM or EBUSY from an indexer touching the fresh
-        // mkdtemp directory, ENOSPC -- means the FIRST worker failed to arm,
-        // and a bare catch would swallow that and leave the test to time out
-        // 10s later saying the pool never reacted to a fault nobody ever
-        // scheduled. Accusing the pool of a harness failure is the exact
-        // misdiagnosis this test exists to prevent, so rethrow: the worker
-        // faults, the marker stays empty, and the arming assertion fails
-        // naming the real problem.
-        if (err.code !== 'EEXIST') throw err;
-        armed = false;
-      }
-      if (armed) {
         setTimeout(() => { throw new Error('idle fault'); }, 250);
       }
     });
@@ -151,10 +160,20 @@ describe("ParsePool", () => {
    * passes on a runner that is thrashing. The timeout only decides how long
    * to wait before calling it a failure, so it can be generous.
    */
-  const waitUntil = async (cond: () => boolean, what: string, timeoutMs = 10000): Promise<void> => {
+  const waitUntil = async (
+    cond: () => boolean,
+    // A thunk, not just a string, so the message can be built when the wait
+    // FAILS. A caller waiting on something the fixture arranges needs to say
+    // "the fixture never armed" rather than "the pool never reacted", and it
+    // can only tell them apart at that moment.
+    what: string | (() => string),
+    timeoutMs = 10000,
+  ): Promise<void> => {
     const deadline = Date.now() + timeoutMs;
     while (!cond()) {
-      if (Date.now() > deadline) throw new Error(`waitUntil timed out: ${what}`);
+      if (Date.now() > deadline) {
+        throw new Error(`waitUntil timed out: ${typeof what === "string" ? what : what()}`);
+      }
       await new Promise((resolve) => setTimeout(resolve, 5));
     }
   };
@@ -220,7 +239,16 @@ describe("ParsePool", () => {
     // .respawnCount() > before`.
     await waitUntil(
       () => pool.respawnCount() > 0,
-      "the idle fault never reached the pool",
+      // Ask the fixture first. If its claim failed there is no fault to wait
+      // for, and reporting that the pool never reacted would blame the pool
+      // for a harness problem -- the misdiagnosis this whole test exists to
+      // prevent. At concurrency 1 that is the ONLY worker, so nothing
+      // respawns and this wait is where it surfaces; the `.failed` assertion
+      // below never gets to run.
+      () =>
+        existsSync(`${marker}.failed`)
+          ? `the fixture could not claim the fault: ${readFileSync(`${marker}.failed`, "utf8").trim()}`
+          : "the idle fault never reached the pool",
     );
 
     // TWO at once, deliberately. `drain()` pops the free list, so a single
@@ -252,6 +280,13 @@ describe("ParsePool", () => {
     // only proves SOME respawn happened -- a fixture that died during module
     // evaluation would satisfy it and never arm -- and the ENOENT would then
     // point at this line instead of at the contract.
+    // No thread failed to claim for an unrelated reason. Without this, a
+    // first-thread EPERM is invisible: the second thread claims successfully,
+    // arms, and every other assertion here stays green.
+    expect(
+      existsSync(`${marker}.failed`) ? readFileSync(`${marker}.failed`, "utf8") : "",
+      "a worker failed to claim the fault for a reason other than EEXIST",
+    ).toBe("");
     const armings = (existsSync(marker) ? readFileSync(marker, "utf8") : "")
       .split("\n")
       // `.filter(Boolean)`, not `.trim()`: an empty file trims to "" and then

--- a/ix-cli/src/cli/__tests__/parse-pool.test.ts
+++ b/ix-cli/src/cli/__tests__/parse-pool.test.ts
@@ -94,13 +94,28 @@ describe("ParsePool", () => {
       if (msg && msg.__shutdown) { parentPort.close(); return; }
       parentPort.postMessage({ ok: true, result: { filePath: msg.filePath } });
       // Claim the fault before scheduling it, so a replacement that starts
-      // while the timer is pending still sees it taken. Recorded, and
-      // recorded HERE rather than in the timer, because arming is what the
-      // test needs to count and it happens synchronously with the serve --
-      // the throw is 20ms later and would be raced.
+      // while the timer is pending still sees it taken. Recorded HERE rather
+      // than in the timer, because arming is what the test counts and it
+      // happens synchronously with the serve -- the throw is later and would
+      // be raced.
+      //
+      // The delay exists so the parent has consumed this reply before the
+      // fault lands: 'message' and 'error' reach it on different channels, so
+      // a parent descheduled across both can process the 'error' first, find
+      // the task still in \`active\`, and resolve it null -- failing the
+      // first.ts assertion with the very signature this test is meant to
+      // distinguish. It was 20ms, which is the same order as the scheduling
+      // delays that caused the original flake.
+      //
+      // What this does NOT do is remove the ordering dependency, and it
+      // cannot: the worker has no way to learn that its reply was consumed,
+      // and a fault raised while a task IS in flight never leaves a stale
+      // entry in \`idle\`, which is the whole bug. So the premise needs an
+      // idle fault, and an idle fault needs a delay. This only makes the
+      // required parent stall implausible rather than merely unlikely.
       if (!existsSync(marker)) {
         appendFileSync(marker, threadId + '\\n');
-        setTimeout(() => { throw new Error('idle fault'); }, 20);
+        setTimeout(() => { throw new Error('idle fault'); }, 250);
       }
     });
   `;
@@ -195,7 +210,15 @@ describe("ParsePool", () => {
     // revision asserted `respawnCount()` for this and claimed it pinned the
     // contract; it does not. Reverting the fixture to per-thread arming
     // passes that assertion 5 runs out of 5.
-    const armings = readFileSync(join(dir, "idle-fault-armed"), "utf8").trim().split("\n");
+    const armings = readFileSync(join(dir, "idle-fault-armed"), "utf8")
+      .split("\n")
+      // `.filter(Boolean)`, not `.trim()`: an empty file trims to "" and then
+      // splits to [""], so ZERO armings would satisfy `toHaveLength(1)` and
+      // this check would be inert. Unreachable today only because the fault
+      // demonstrably landed above -- but the obvious future fix for the
+      // ENOENT path is to pre-create the marker, which would walk straight
+      // into it.
+      .filter(Boolean);
     expect(armings, "the fixture must arm exactly one fault for the whole pool").toHaveLength(1);
 
     // Kept, but for what it is: a cheap check that no EXTRA fault landed

--- a/ix-cli/src/cli/__tests__/parse-pool.test.ts
+++ b/ix-cli/src/cli/__tests__/parse-pool.test.ts
@@ -214,14 +214,23 @@ describe("ParsePool", () => {
     // posts to nothing, and never settles.
     const both = await Promise.all([pool.parse("a2.ts", "x"), pool.parse("b2.ts", "x")]);
     expect(both).toEqual([{ filePath: "a2.ts" }, { filePath: "b2.ts" }]);
-    // The once-per-pool contract, asserted on the ARMING rather than on the
-    // fault. Arming is synchronous with the serve; the throw is 250ms behind
-    // it. So a replacement that armed its own would have written its line
-    // here by now, while `respawnCount()` would still read 1 -- its timer has
-    // not fired, and the parses above take a few ms against that 250ms of
-    // slack. An earlier revision asserted `respawnCount()` for this and
-    // claimed it pinned the contract; it does not. Reverting the fixture to
-    // per-thread arming passes that assertion 5 runs out of 5.
+    // The once-per-pool contract is ENFORCED by the fixture's `wx` flag, which
+    // makes a second arming impossible rather than detectable. This asserts
+    // that the enforcement is still there and did its job: exactly one thread
+    // armed, so `b2.ts` was never racing a replacement's timer.
+    //
+    // Be precise about what it can and cannot fail on, because two earlier
+    // revisions got this wrong in opposite directions. It fails if the `wx`
+    // claim is weakened to an append, and if the marker mechanism is replaced
+    // by per-thread counting (both verified by mutation, 3 of 3). It does NOT
+    // independently detect "a replacement armed too" -- with `wx` in place
+    // that cannot happen, so adding a redundant per-thread guard leaves this
+    // green, which is correct and not a gap.
+    //
+    // What it replaced was an assertion on `respawnCount()`, which pinned
+    // nothing: the replacement's fault is a 250ms timer and the parses above
+    // take a few ms, so the count still reads 1 either way. Reverting the
+    // fixture passed that one 5 runs out of 5.
     // Read through `existsSync`, so a marker that was never written fails as
     // "arm exactly one fault" rather than as a raw ENOENT. `waitUntil` above
     // only proves SOME respawn happened -- a fixture that died during module

--- a/ix-cli/src/cli/__tests__/parse-pool.test.ts
+++ b/ix-cli/src/cli/__tests__/parse-pool.test.ts
@@ -83,6 +83,21 @@ describe("ParsePool", () => {
     });
   `;
 
+  /**
+   * Poll until `cond` holds. Deliberately not a fixed sleep: every wait in
+   * this file that is really "wait for the pool to observe something" should
+   * be bounded by the observation, so it costs a few ms when idle and still
+   * passes on a runner that is thrashing. The timeout only decides how long
+   * to wait before calling it a failure, so it can be generous.
+   */
+  const waitUntil = async (cond: () => boolean, what: string, timeoutMs = 10000): Promise<void> => {
+    const deadline = Date.now() + timeoutMs;
+    while (!cond()) {
+      if (Date.now() > deadline) throw new Error(`waitUntil timed out: ${what}`);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+  };
+
   it("parses through the pool and shuts down without hanging", async () => {
     const pool = new ParsePool(worker("echo", ECHO), 2);
     pool.init();
@@ -125,8 +140,20 @@ describe("ParsePool", () => {
     pool.init();
 
     expect(await pool.parse("first.ts", "x")).toEqual({ filePath: "first.ts" });
-    // Let the fault land while the pool is idle.
-    await new Promise((resolve) => setTimeout(resolve, 120));
+    // Wait for the fault to LAND, not for a duration. The fixture throws 20ms
+    // after serving, and this was `setTimeout(120)` -- which is ample when the
+    // machine is idle (0 failures in 10 runs) and is not when it is busy: 1 of
+    // 8 runs under saturating CPU load, where the 'error' event had not been
+    // delivered before the two parses below went out. The test then failed on
+    // `b2.ts` coming back null, which looks exactly like the bug it guards.
+    //
+    // `respawnCount()` is the pool's own signal that `onError` ran to
+    // completion, so this waits on the state the test actually depends on and
+    // is done as soon as it holds.
+    await waitUntil(
+      () => pool.respawnCount() > 0,
+      "the idle fault never reached the pool",
+    );
 
     // TWO at once, deliberately. `drain()` pops the free list, so a single
     // parse takes the replacement worker that `onError` just pushed and never

--- a/ix-cli/src/cli/__tests__/parse-pool.test.ts
+++ b/ix-cli/src/cli/__tests__/parse-pool.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { tmpdir } from "node:os";
@@ -72,7 +72,6 @@ describe("ParsePool", () => {
     process.exit(1);
   `;
 
-  /** Answers its first message, then faults while IDLE. */
   /**
    * Faults ONCE per pool, not once per worker.
    *
@@ -88,16 +87,19 @@ describe("ParsePool", () => {
    * thread, and these fixtures share nothing else.
    */
   const IDLE_FAULT_ONCE = (marker: string): string => `
-    import { parentPort } from 'node:worker_threads';
-    import { existsSync, writeFileSync } from 'node:fs';
+    import { parentPort, threadId } from 'node:worker_threads';
+    import { existsSync, appendFileSync } from 'node:fs';
     const marker = ${JSON.stringify(marker)};
     parentPort.on('message', (msg) => {
       if (msg && msg.__shutdown) { parentPort.close(); return; }
       parentPort.postMessage({ ok: true, result: { filePath: msg.filePath } });
       // Claim the fault before scheduling it, so a replacement that starts
-      // while the timer is pending still sees it taken.
+      // while the timer is pending still sees it taken. Recorded, and
+      // recorded HERE rather than in the timer, because arming is what the
+      // test needs to count and it happens synchronously with the serve --
+      // the throw is 20ms later and would be raced.
       if (!existsSync(marker)) {
-        writeFileSync(marker, 'armed');
+        appendFileSync(marker, threadId + '\\n');
         setTimeout(() => { throw new Error('idle fault'); }, 20);
       }
     });
@@ -185,12 +187,20 @@ describe("ParsePool", () => {
     // posts to nothing, and never settles.
     const both = await Promise.all([pool.parse("a2.ts", "x"), pool.parse("b2.ts", "x")]);
     expect(both).toEqual([{ filePath: "a2.ts" }, { filePath: "b2.ts" }]);
-    // Exactly one fault for the whole pool. This is what makes `b2.ts`
-    // deterministic rather than merely likely: a replacement that armed its
-    // own fault would make this 2, and b2 would be racing that worker's 20ms
-    // timer. Pins the fixture's once-per-pool contract, which is otherwise
-    // invisible from here.
-    expect(pool.respawnCount(), "the replacement must not fault as well").toBe(1);
+    // The once-per-pool contract, asserted on the ARMING rather than on the
+    // fault. Arming is synchronous with the serve; the throw is 20ms behind
+    // it. So a replacement that armed its own would have appended a second
+    // line here by now, while `respawnCount()` would still read 1 -- its
+    // timer has not fired, and the parses above take a few ms. An earlier
+    // revision asserted `respawnCount()` for this and claimed it pinned the
+    // contract; it does not. Reverting the fixture to per-thread arming
+    // passes that assertion 5 runs out of 5.
+    const armings = readFileSync(join(dir, "idle-fault-armed"), "utf8").trim().split("\n");
+    expect(armings, "the fixture must arm exactly one fault for the whole pool").toHaveLength(1);
+
+    // Kept, but for what it is: a cheap check that no EXTRA fault landed
+    // during the two parses. It is not the guard for the line above.
+    expect(pool.respawnCount(), "no further worker died during the parses").toBe(1);
 
     await pool.destroy();
   });

--- a/ix-cli/src/cli/__tests__/parse-pool.test.ts
+++ b/ix-cli/src/cli/__tests__/parse-pool.test.ts
@@ -76,9 +76,10 @@ describe("ParsePool", () => {
    * Faults ONCE per pool, not once per worker.
    *
    * `let served = 0` was per-thread, so the replacement armed its own fault
-   * 20ms after serving `a2.ts` -- and `b2.ts` is only posted once the parent
-   * has received a2's result and re-drained. Miss that 20ms window on a busy
-   * machine and the replacement dies with `b2.ts` in flight, which `onError`
+   * shortly after serving `a2.ts` -- and `b2.ts` is only posted once the
+   * parent has received a2's result and re-drained. Miss that window on a
+   * busy machine and the replacement dies with `b2.ts` in flight, which
+   * `onError`
    * resolves to null: the exact Ix#567 signature, from the harness rather
    * than the pool. Fixing only the first wait would have left this half of
    * the race in place.
@@ -88,7 +89,7 @@ describe("ParsePool", () => {
    */
   const IDLE_FAULT_ONCE = (marker: string): string => `
     import { parentPort, threadId } from 'node:worker_threads';
-    import { existsSync, appendFileSync } from 'node:fs';
+    import { writeFileSync } from 'node:fs';
     const marker = ${JSON.stringify(marker)};
     parentPort.on('message', (msg) => {
       if (msg && msg.__shutdown) { parentPort.close(); return; }
@@ -99,13 +100,20 @@ describe("ParsePool", () => {
       // happens synchronously with the serve -- the throw is later and would
       // be raced.
       //
+      // The claim is \`wx\`, which fails if the file exists, rather than
+      // \`existsSync\` then append: those are two syscalls and two threads
+      // can both pass the check. That cannot happen at this pool's concurrency
+      // of 1, where no two workers ever serve at once -- but the guarantee is
+      // stated unconditionally above, and \`wx\` is what makes it true at any
+      // size rather than true by accident of the caller.
+      //
       // The delay exists so the parent has consumed this reply before the
       // fault lands: 'message' and 'error' reach it on different channels, so
       // a parent descheduled across both can process the 'error' first, find
       // the task still in \`active\`, and resolve it null -- failing the
       // first.ts assertion with the very signature this test is meant to
       // distinguish. It was 20ms, which is the same order as the scheduling
-      // delays that caused the original flake.
+      // delays that caused the original flake; it is 250ms now.
       //
       // What this does NOT do is remove the ordering dependency, and it
       // cannot: the worker has no way to learn that its reply was consumed,
@@ -113,8 +121,14 @@ describe("ParsePool", () => {
       // entry in \`idle\`, which is the whole bug. So the premise needs an
       // idle fault, and an idle fault needs a delay. This only makes the
       // required parent stall implausible rather than merely unlikely.
-      if (!existsSync(marker)) {
-        appendFileSync(marker, threadId + '\\n');
+      let armed = false;
+      try {
+        writeFileSync(marker, threadId + '\\n', { flag: 'wx' });
+        armed = true;
+      } catch {
+        armed = false;
+      }
+      if (armed) {
         setTimeout(() => { throw new Error('idle fault'); }, 250);
       }
     });
@@ -173,15 +187,13 @@ describe("ParsePool", () => {
     // tasks -- and it was spliced out of `workers` but left in `idle`, so the
     // next `drain()` popped the terminated thread and posted to nothing: that
     // task's promise never settled.
-    const pool = new ParsePool(
-      worker("idlefault", IDLE_FAULT_ONCE(join(dir, "idle-fault-armed"))),
-      1,
-    );
+    const marker = join(dir, "idle-fault-armed");
+    const pool = new ParsePool(worker("idlefault", IDLE_FAULT_ONCE(marker)), 1);
     pool.init();
 
     expect(await pool.parse("first.ts", "x")).toEqual({ filePath: "first.ts" });
-    // Wait for the fault to LAND, not for a duration. The fixture throws 20ms
-    // after serving, and this was `setTimeout(120)` -- which is ample when the
+    // Wait for the fault to LAND, not for a duration. The fixture throws
+    // 250ms after serving, and this was `setTimeout(120)` -- ample when the
     // machine is idle (0 failures in 10 runs) and is not when it is busy: 1 of
     // 8 runs under saturating CPU load, where the 'error' event had not been
     // delivered before the two parses below went out. The test then failed on
@@ -203,14 +215,19 @@ describe("ParsePool", () => {
     const both = await Promise.all([pool.parse("a2.ts", "x"), pool.parse("b2.ts", "x")]);
     expect(both).toEqual([{ filePath: "a2.ts" }, { filePath: "b2.ts" }]);
     // The once-per-pool contract, asserted on the ARMING rather than on the
-    // fault. Arming is synchronous with the serve; the throw is 20ms behind
-    // it. So a replacement that armed its own would have appended a second
-    // line here by now, while `respawnCount()` would still read 1 -- its
-    // timer has not fired, and the parses above take a few ms. An earlier
-    // revision asserted `respawnCount()` for this and claimed it pinned the
-    // contract; it does not. Reverting the fixture to per-thread arming
-    // passes that assertion 5 runs out of 5.
-    const armings = readFileSync(join(dir, "idle-fault-armed"), "utf8")
+    // fault. Arming is synchronous with the serve; the throw is 250ms behind
+    // it. So a replacement that armed its own would have written its line
+    // here by now, while `respawnCount()` would still read 1 -- its timer has
+    // not fired, and the parses above take a few ms against that 250ms of
+    // slack. An earlier revision asserted `respawnCount()` for this and
+    // claimed it pinned the contract; it does not. Reverting the fixture to
+    // per-thread arming passes that assertion 5 runs out of 5.
+    // Read through `existsSync`, so a marker that was never written fails as
+    // "arm exactly one fault" rather than as a raw ENOENT. `waitUntil` above
+    // only proves SOME respawn happened -- a fixture that died during module
+    // evaluation would satisfy it and never arm -- and the ENOENT would then
+    // point at this line instead of at the contract.
+    const armings = (existsSync(marker) ? readFileSync(marker, "utf8") : "")
       .split("\n")
       // `.filter(Boolean)`, not `.trim()`: an empty file trims to "" and then
       // splits to [""], so ZERO armings would satisfy `toHaveLength(1)` and

--- a/ix-cli/src/cli/commands/parse-pool.ts
+++ b/ix-cli/src/cli/commands/parse-pool.ts
@@ -405,20 +405,15 @@ export class ParsePool {
    * `onResult` clears it on every successful round trip, so a run that lost a
    * dozen workers -- each replacement then parsing a file -- ends with
    * `respawns === 0` and is indistinguishable from a run that lost none. That
-   * is the right behaviour for the cap and the wrong number for a reader.
+   * is the right behaviour for the cap and the wrong number for a reader, and
+   * it makes `respawns` useless to wait on: any completed parse resets it.
    *
-   * What it gives a test is a LEVEL, not an edge. `onError` increments this
-   * and pushes the replacement in the same synchronous handler, so once it is
-   * non-zero the pool has finished reacting to a worker death -- including one
-   * that faulted with no task in flight, which `crashedTasks()` deliberately
-   * does not count because no file was lost. That was the gap: an idle fault
-   * moved no other counter, so a test waiting for one had nothing to wait on
-   * and used a fixed sleep. It failed 1 of 8 local runs under saturating CPU
-   * load, and separately took down the `Test (windows-2022 - node 22)` leg of
-   * an unrelated PR -- Actions run 34179642182, `parse-pool.test.ts:137`.
-   * That CI hit is one observation, not a second measurement of the rate.
-   * Polling `respawns` instead would have been a latent trap, since any
-   * completed parse resets it to zero.
+   * This one is a LEVEL. `onError` increments it and pushes the replacement in
+   * the same synchronous handler, so once it is non-zero the pool has finished
+   * reacting to a worker death -- including one that faulted with no task in
+   * flight, which `crashedTasks()` deliberately does not count because no file
+   * was lost. That combination is otherwise unobservable from outside, which
+   * is what this exists for.
    */
   respawnCount(): number {
     return this.respawnsTotal;

--- a/ix-cli/src/cli/commands/parse-pool.ts
+++ b/ix-cli/src/cli/commands/parse-pool.ts
@@ -398,6 +398,25 @@ export class ParsePool {
     return this.crashed;
   }
 
+  /**
+   * Replacement workers spawned so far.
+   *
+   * The observable edge of `onError`: it increments here and pushes the
+   * replacement in the same synchronous handler, so a non-zero count means
+   * the pool has FINISHED reacting to a worker death -- including one that
+   * faulted with no task in flight, which `crashedTasks()` deliberately does
+   * not count because no file was lost.
+   *
+   * That distinction is the whole reason this exists. A test waiting for an
+   * idle fault to land had nothing to wait ON and used a fixed sleep, which
+   * failed roughly one run in eight on a loaded machine. Diagnostic value on
+   * its own too: a run that quietly respawned a dozen workers looks identical
+   * to a healthy one in every other counter.
+   */
+  respawnCount(): number {
+    return this.respawns;
+  }
+
   private onResult(w: Worker, msg: { ok: boolean; result: unknown }): void {
     const task = this.active.get(w);
     if (!task) return;

--- a/ix-cli/src/cli/commands/parse-pool.ts
+++ b/ix-cli/src/cli/commands/parse-pool.ts
@@ -414,6 +414,11 @@ export class ParsePool {
    * flight, which `crashedTasks()` deliberately does not count because no file
    * was lost. That combination is otherwise unobservable from outside, which
    * is what this exists for.
+   *
+   * Test observability, and only that today -- nothing in `ingest.ts` reads
+   * it, so a run that respawned a dozen workers still prints the same summary
+   * as a healthy one. Surfacing it there is a reasonable thing to want and a
+   * different change; do not read this comment as saying it already happens.
    */
   respawnCount(): number {
     return this.respawnsTotal;

--- a/ix-cli/src/cli/commands/parse-pool.ts
+++ b/ix-cli/src/cli/commands/parse-pool.ts
@@ -413,9 +413,12 @@ export class ParsePool {
    * that faulted with no task in flight, which `crashedTasks()` deliberately
    * does not count because no file was lost. That was the gap: an idle fault
    * moved no other counter, so a test waiting for one had nothing to wait on
-   * and used a fixed sleep, which failed about one run in eight on a loaded
-   * machine and on `windows-2022`. Polling `respawns` instead would have been
-   * a latent trap, since any completed parse resets it to zero.
+   * and used a fixed sleep. It failed 1 of 8 local runs under saturating CPU
+   * load, and separately took down the `Test (windows-2022 - node 22)` leg of
+   * an unrelated PR -- Actions run 34179642182, `parse-pool.test.ts:137`.
+   * That CI hit is one observation, not a second measurement of the rate.
+   * Polling `respawns` instead would have been a latent trap, since any
+   * completed parse resets it to zero.
    */
   respawnCount(): number {
     return this.respawnsTotal;
@@ -442,9 +445,11 @@ export class ParsePool {
   private destroyed = false;
 
   /**
-   * Remaining respawn BUDGET, not a tally: `onResult` resets it to zero on any
-   * successful round trip. Read `respawnsTotal` for "how many did this run
-   * spawn?" -- see `respawnCount()`.
+   * Respawns CONSUMED since the last successful round trip, capped at
+   * `MAX_RESPAWNS` -- so 0 means the full budget is available and 16 means it
+   * is exhausted, which is the opposite of how "budget" usually reads.
+   * `onResult` clears it on any success, so it is not a tally either: read
+   * `respawnsTotal` for "how many did this run spawn?".
    */
   private respawns = 0;
 

--- a/ix-cli/src/cli/commands/parse-pool.ts
+++ b/ix-cli/src/cli/commands/parse-pool.ts
@@ -419,6 +419,13 @@ export class ParsePool {
    * it, so a run that respawned a dozen workers still prints the same summary
    * as a healthy one. Surfacing it there is a reasonable thing to want and a
    * different change; do not read this comment as saying it already happens.
+   *
+   * Waiting on it means waiting on a BASELINE, not on `> 0`. The count
+   * latches for the life of the run, so `> 0` answers "has any worker ever
+   * died", which is true forever after the first one -- correct only for a
+   * test observing that first death. Anything later wants
+   * `const before = pool.respawnCount()` and then `> before`, or it is a
+   * poll that returns immediately and waits for nothing.
    */
   respawnCount(): number {
     return this.respawnsTotal;

--- a/ix-cli/src/cli/commands/parse-pool.ts
+++ b/ix-cli/src/cli/commands/parse-pool.ts
@@ -399,22 +399,26 @@ export class ParsePool {
   }
 
   /**
-   * Replacement workers spawned so far.
+   * Replacement workers spawned over the whole run. Monotonic.
    *
-   * The observable edge of `onError`: it increments here and pushes the
-   * replacement in the same synchronous handler, so a non-zero count means
-   * the pool has FINISHED reacting to a worker death -- including one that
-   * faulted with no task in flight, which `crashedTasks()` deliberately does
-   * not count because no file was lost.
+   * Deliberately NOT `respawns`, which is a budget rather than a tally:
+   * `onResult` clears it on every successful round trip, so a run that lost a
+   * dozen workers -- each replacement then parsing a file -- ends with
+   * `respawns === 0` and is indistinguishable from a run that lost none. That
+   * is the right behaviour for the cap and the wrong number for a reader.
    *
-   * That distinction is the whole reason this exists. A test waiting for an
-   * idle fault to land had nothing to wait ON and used a fixed sleep, which
-   * failed roughly one run in eight on a loaded machine. Diagnostic value on
-   * its own too: a run that quietly respawned a dozen workers looks identical
-   * to a healthy one in every other counter.
+   * What it gives a test is a LEVEL, not an edge. `onError` increments this
+   * and pushes the replacement in the same synchronous handler, so once it is
+   * non-zero the pool has finished reacting to a worker death -- including one
+   * that faulted with no task in flight, which `crashedTasks()` deliberately
+   * does not count because no file was lost. That was the gap: an idle fault
+   * moved no other counter, so a test waiting for one had nothing to wait on
+   * and used a fixed sleep, which failed about one run in eight on a loaded
+   * machine and on `windows-2022`. Polling `respawns` instead would have been
+   * a latent trap, since any completed parse resets it to zero.
    */
   respawnCount(): number {
-    return this.respawns;
+    return this.respawnsTotal;
   }
 
   private onResult(w: Worker, msg: { ok: boolean; result: unknown }): void {
@@ -437,8 +441,15 @@ export class ParsePool {
   /** True once `destroy()` has begun, so a deliberate exit is not read as a crash. */
   private destroyed = false;
 
-  /** Replacements spawned for crashed workers. Capped -- see `onError`. */
+  /**
+   * Remaining respawn BUDGET, not a tally: `onResult` resets it to zero on any
+   * successful round trip. Read `respawnsTotal` for "how many did this run
+   * spawn?" -- see `respawnCount()`.
+   */
   private respawns = 0;
+
+  /** Every replacement this run has spawned. Never reset. */
+  private respawnsTotal = 0;
 
   /**
    * True once the pool is out of workers AND out of replacements.
@@ -498,6 +509,7 @@ export class ParsePool {
 
     if (this.respawns < ParsePool.MAX_RESPAWNS) {
       this.respawns++;
+      this.respawnsTotal++;
       this.spawnWorker();
     } else if (this.workers.length === 0) {
       // Out of workers and out of replacements. Nothing queued can ever be


### PR DESCRIPTION
## What

`takes a worker that faults while IDLE out of the free list` is load-flaky. It failed a full-suite run on a busy machine with `b2.ts` returning `null` — **indistinguishable from the Ix#567 bug it guards**, which is the worst way for a flake to present: whoever sees it red next has no reason to suspect the harness.

## Reproduction

The fixture throws 20ms after serving the first task; the test slept a flat 120ms waiting for the `'error'` event before dispatching two parses.

| condition | result |
|---|---|
| idle | 0 of 10 runs failed |
| saturating CPU load | **1 of 8 runs failed** |

Under load the event had not been delivered, so the second parse reached an already-dying worker and resolved `null`.

## Fix

Wait on the condition, not a duration. `onError` increments `respawns` and pushes the replacement in the same synchronous handler, so a non-zero count means the pool has *finished* reacting — including to a fault with no task in flight, which `crashedTasks()` deliberately does not count because no file was lost.

That distinction is precisely why there was nothing to wait on, and why this adds `respawnCount()` rather than reusing a counter. It earns its place outside the test as well: a run that quietly respawned a dozen workers looks identical to a healthy one in every other counter the pool exposes.

## What I am *not* claiming

Post-fix loaded runs were 0 of 8. **That is not strong evidence** — under the observed 1-in-8 rate, zero in eight happens 34% of the time. The argument is structural: the test waits on the pool's own state instead of on an event arriving inside a fixed window.

**Correction (round 4):** an earlier revision of this section claimed the test is *faster* than the sleep it replaces. That was true of the original 20ms fault and stopped being true when round 3 widened it to 250ms to close a second ordering window — the test now waits on a 250ms timer where it previously slept 120ms, so it is somewhat slower, not faster. The wait-on-condition change is still the right one; it is not a speedup.

The same round also has to qualify "removed rather than made less likely": the *first* window (waiting for the fault to land) is genuinely removed, but the ordering dependency cannot be eliminated — the worker has no way to learn its reply was consumed, and a fault raised while a task is in flight never leaves a stale entry in `idle`, which is the whole bug. So the premise needs an idle fault, an idle fault needs a delay, and 250ms only makes the required parent stall implausible.

## The test still catches the bug

With the `idle.splice` in `onError` deleted — Ix#567 restored — the test fails, hanging until the 20s timeout, which is the "promise never settles" symptom exactly. The poll signal increments *after* that splice, so it does not depend on the fix being present and cannot mask its absence.

The other five fixed sleeps in this file wait for a parse to be *dispatched* rather than for an error to be *delivered*, and none has been observed to fail. Left alone rather than rewritten on speculation.

## Verification

- 13 pool tests pass; full suite 1791 (3 known Windows symlink failures, unrelated, pass on CI's `windows-2022`)
- typecheck and lint clean
- mutation-tested as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5bkc5oUL4SapwDE13UgHt
