### PR TITLE
fix(rank,inventory): accept Windows separators in --path

### DIFF
--- a/ix-cli/src/cli/__tests__/path-separator-normalization.test.ts
+++ b/ix-cli/src/cli/__tests__/path-separator-normalization.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { applyPathFilters } from "../commands/rank.js";
+import { normalizePathSeparators } from "../path-match.js";
+
+/**
+ * Ix#636: `--path` accepted only POSIX separators in `rank` and `inventory`,
+ * while every stored source_uri is POSIX by construction
+ * (`ingest.ts` → `toWorkspaceRelative` → `rel.split(nodePath.sep).join('/')`).
+ * So on Windows the natural `--path src\cli` matched nothing at all, silently.
+ *
+ * These pin the separator half only. Case is deliberately NOT normalized here:
+ * the resolver lowercases and rank/inventory/backend do not, and reconciling
+ * that is a separate product decision tracked in the same issue.
+ */
+const node = (sourceUri: string) => ({ provenance: { sourceUri } });
+
+describe("normalizePathSeparators", () => {
+  it("converts Windows separators and leaves POSIX alone", () => {
+    expect(normalizePathSeparators("src\\cli\\rank.ts")).toBe("src/cli/rank.ts");
+    expect(normalizePathSeparators("src/cli/rank.ts")).toBe("src/cli/rank.ts");
+  });
+
+  it("does not touch case", () => {
+    expect(normalizePathSeparators("IX-Memory\\Src")).toBe("IX-Memory/Src");
+  });
+
+  it("treats null and undefined as empty", () => {
+    expect(normalizePathSeparators(undefined)).toBe("");
+    expect(normalizePathSeparators(null)).toBe("");
+  });
+});
+
+describe("rank --path separator handling", () => {
+  const nodes = [node("ix-cli/src/cli/commands/rank.ts"), node("ix-cli/src/api/client.ts")];
+
+  it("matches a Windows-style --path against POSIX source_uris", () => {
+    // The regression: this returned [] before the fix.
+    expect(applyPathFilters(nodes, "src\\cli")).toHaveLength(1);
+    expect(applyPathFilters(nodes, "src\\cli")[0].provenance.sourceUri)
+      .toBe("ix-cli/src/cli/commands/rank.ts");
+  });
+
+  it("still matches a POSIX --path exactly as before", () => {
+    expect(applyPathFilters(nodes, "src/cli")).toHaveLength(1);
+  });
+
+  it("applies the same normalization to --exclude-path", () => {
+    expect(applyPathFilters(nodes, undefined, "src\\cli")).toHaveLength(1);
+    expect(applyPathFilters(nodes, undefined, "src\\cli")[0].provenance.sourceUri)
+      .toBe("ix-cli/src/api/client.ts");
+  });
+
+  it("normalizes a backslash-bearing source_uri too", () => {
+    // Defensive: github/transform.ts builds its own source_uris, and graphs
+    // ingested before toWorkspaceRelative normalized separators can hold them.
+    expect(applyPathFilters([node("legacy\\src\\cli\\old.ts")], "src/cli")).toHaveLength(1);
+  });
+
+  it("leaves case-sensitivity unchanged (still case-SENSITIVE here)", () => {
+    // Pins the deliberate non-change: flipping this is the open half of #636.
+    expect(applyPathFilters([node("IX-Memory/src/a.ts")], "ix-memory")).toHaveLength(0);
+    expect(applyPathFilters([node("IX-Memory/src/a.ts")], "IX-Memory")).toHaveLength(1);
+  });
+});

--- a/ix-cli/src/cli/commands/inventory.ts
+++ b/ix-cli/src/cli/commands/inventory.ts
@@ -6,6 +6,7 @@ import { resolveWorkspaceId } from "../bootstrap.js";
 import { resolveReadSystemId } from "../resolve.js";
 import { relativePath } from "../format.js";
 import { llmLine } from "../llm.js";
+import { normalizePathSeparators } from "../path-match.js";
 
 /**
  * Render `ix inventory` as llm records: a header line then one `file` row per
@@ -64,17 +65,22 @@ Examples:
       // the client-side filter below ever sees it). The client-side filter is
       // kept as a fallback for older servers that ignore the scope field.
       const systemId = await resolveReadSystemId(client);
-      let nodes = await client.listByKind(opts.kind, { limit, workspaceId: systemId ? undefined : resolveWorkspaceId(), scope: opts.path, systemId });
+      // Separators only, on both the scope sent to the backend and the
+      // client-side fallback below. source_uris are always POSIX, so a Windows
+      // `--path src\cli` matched nothing in either place (Ix#636). Case is
+      // untouched — see path-match.ts.
+      const pathNeedle = opts.path ? normalizePathSeparators(opts.path) : undefined;
+      let nodes = await client.listByKind(opts.kind, { limit, workspaceId: systemId ? undefined : resolveWorkspaceId(), scope: pathNeedle, systemId });
 
-      if (opts.path) {
+      if (pathNeedle) {
         nodes = nodes.filter((n) => {
-          const uri = String(
+          const uri = normalizePathSeparators(String(
             (n as any).provenance?.source_uri ??
             n.provenance?.sourceUri ??
             n.attrs?.path ??
             ""
-          );
-          return uri.includes(opts.path!);
+          ));
+          return uri.includes(pathNeedle);
         });
       }
 

--- a/ix-cli/src/cli/commands/rank.ts
+++ b/ix-cli/src/cli/commands/rank.ts
@@ -4,6 +4,7 @@ import { IxClient } from "../../client/api.js";
 import { getEndpoint } from "../config.js";
 import { activeReadScope, ensureReadScope } from "../resolve.js";
 import { llmLine } from "../llm.js";
+import { normalizePathSeparators } from "../path-match.js";
 
 type Metric = "dependents" | "callers" | "importers" | "members";
 
@@ -44,7 +45,13 @@ export function getSourceUri(node: any): string {
   );
 }
 
-/** Apply path inclusion and exclusion filters to a list of nodes */
+/**
+ * Apply path inclusion and exclusion filters to a list of nodes.
+ *
+ * Both sides go through `normalizePathSeparators`, so `--path src\cli` (what a
+ * Windows user types) matches the `src/cli` that is actually stored. Case is
+ * left alone — see `path-match.ts` and Ix#636.
+ */
 export function applyPathFilters(
   nodes: any[],
   includePath?: string,
@@ -52,10 +59,12 @@ export function applyPathFilters(
 ): any[] {
   let result = nodes;
   if (includePath) {
-    result = result.filter((node: any) => getSourceUri(node).includes(includePath));
+    const needle = normalizePathSeparators(includePath);
+    result = result.filter((node: any) => normalizePathSeparators(getSourceUri(node)).includes(needle));
   }
   if (excludePath) {
-    result = result.filter((node: any) => !getSourceUri(node).includes(excludePath));
+    const needle = normalizePathSeparators(excludePath);
+    result = result.filter((node: any) => !normalizePathSeparators(getSourceUri(node)).includes(needle));
   }
   return result;
 }
@@ -173,7 +182,11 @@ export function registerRankCommand(program: Command): void {
 
         // 1. Fetch all entities of the given kind
         await ensureReadScope(client); // fold in a Path-2 stitched system (Ix#225 Half B)
-        const allNodes = await client.listByKind(opts.kind, { limit: 2000, scope: opts.path || undefined, ...activeReadScope() });
+        // The backend's scope is a raw AQL CONTAINS against source_uri, which is
+        // always POSIX — send the separator-normalized needle or a Windows-style
+        // --path silently matches nothing server-side too (Ix#636).
+        const scopeNeedle = opts.path ? normalizePathSeparators(opts.path) : undefined;
+        const allNodes = await client.listByKind(opts.kind, { limit: 2000, scope: scopeNeedle, ...activeReadScope() });
 
         if (allNodes.length === 0) {
           if (opts.format === "llm") {
@@ -238,7 +251,7 @@ export function registerRankCommand(program: Command): void {
           console.log(JSON.stringify({
             metric,
             kind: opts.kind,
-            scope: opts.path || undefined,
+            scope: scopeNeedle,
             results: results.map(r => ({ name: r.name, kind: r.kind, score: r.score })),
             summary: { evaluated: candidates.length, returned: results.length },
             diagnostics: diagnostics.length > 0 ? diagnostics : undefined,

--- a/ix-cli/src/cli/path-match.ts
+++ b/ix-cli/src/cli/path-match.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared `--path` matching helpers.
+ *
+ * `--path` is a substring match against a node's `provenance.source_uri`, and
+ * source_uris are always POSIX: `ingest.ts`'s `toWorkspaceRelative` ends with
+ * `rel.split(nodePath.sep).join('/')`, so a graph ingested on Windows stores
+ * `src/cli/rank.ts` exactly as one ingested on Linux does.
+ *
+ * The user's input is not normalized anywhere, which is the bug: on Windows
+ * `--path src\cli` is the natural thing to type (it is what tab-completion and
+ * every error message give you) and it matched nothing at all in `rank` and
+ * `inventory`, and nothing on the backend either, because no stored source_uri
+ * ever contains a backslash. See Ix#636.
+ *
+ * Separators only — case is deliberately left alone. `--path` is
+ * case-INSENSITIVE in the resolver (`read`, `explain`, `locate`, …) and
+ * case-SENSITIVE in `rank`, `inventory` and the backend's AQL `CONTAINS`.
+ * Reconciling that is a product decision with an index cost on the backend
+ * side, and is tracked separately in Ix#636; this helper changes no case
+ * behaviour in either direction.
+ */
+
+/**
+ * Convert Windows separators to POSIX for substring matching.
+ *
+ * Applied to BOTH sides of every comparison. The stored side is POSIX by
+ * construction today, but `github/transform.ts` builds source_uris of its own
+ * and graphs ingested before the `toWorkspaceRelative` normalization landed can
+ * still hold backslashes, so normalizing the node side too costs one pass and
+ * removes the assumption.
+ */
+export function normalizePathSeparators(value: string | undefined | null): string {
+  return (value ?? "").replace(/\\/g, "/");
+}


### PR DESCRIPTION
Refs #636 — implements the third option that issue lays out, and only that one.

## The bug

`--path` is a substring match against `provenance.source_uri`. Every source_uri is POSIX **by construction**: `ingest.ts`'s `toWorkspaceRelative` ends with

```ts
return rel.split(nodePath.sep).join('/');
```

so a graph ingested on Windows stores `src/cli/rank.ts` exactly as one ingested on Linux does.

Nothing normalized the user's **input**. On Windows `--path src\cli` is the natural thing to type — it is what tab-completion and every error message hand you — and it matched nothing at all in `rank` and `inventory`, and nothing on the backend either, since no stored source_uri ever contains a backslash. Zero results, exit 0, no diagnostic.

## Changes

- New `ix-cli/src/cli/path-match.ts` with `normalizePathSeparators` and the reasoning at the definition.
- `rank`: `applyPathFilters` normalizes both sides of `--path` and `--exclude-path`.
- `inventory`: normalizes the client-side fallback filter.
- Both: normalize the `scope` pushed to the backend, whose AQL `CONTAINS` is a raw substring match against the same POSIX values.

The node side is POSIX today, but `github/transform.ts` builds source_uris of its own and graphs ingested before that normalization landed can still hold backslashes, so normalizing both sides costs one pass and removes the assumption.

## What this deliberately does NOT do

**Case is untouched.** `--path` is case-INSENSITIVE in the resolver (`read`, `explain`, `locate`, …) and case-SENSITIVE in `rank`, `inventory` and the backend. Reconciling that needs `LOWER()` in `scopeNodeFilter` — `LOWER()` on every row is exactly the shape that has defeated an index in this repo before — and it changes behaviour in ten commands. That is a product decision, and **that half of #636 stays open.**

This half needs no decision: it fixes the Windows failure with no index cost and no case-behaviour change in either direction.

**No backend change and no release needed.** Normalizing the needle CLI-side is sufficient because the haystack was already POSIX.

The two `scope: opts.path ?? null` sites in rank's JSON output are left raw on purpose — they echo what the user asked for, not what was queried.

## Validation

- ix-cli suite: **101 files, 1832 passed / 2 skipped**
- `tsc --noEmit` clean; `eslint` **0 errors** (41 pre-existing warnings)
- Mutation-checked: 3 of the 6 new `rank` cases fail against `main`. The POSIX case and the case-sensitivity case pass on both — deliberate negative controls, the second pinning the non-change so flipping it is a visible edit.

Not exercised against a live Windows shell in this session; the mechanism is a pure string normalization and is covered by the unit tests above.