### PR TITLE
fix(readme): point the logo at the file, and scan HTML refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./assets/logo.png" width="40%" />
+  <img src="./ix-cli/assets/logo.png" width="40%" />
 </p>
 
 <h1 align="center">Understand any codebase instantly.</h1>

--- a/ix-cli/scripts/check-links.mjs
+++ b/ix-cli/scripts/check-links.mjs
@@ -2,7 +2,8 @@
 // check-links.mjs — verify every reference in the repo's markdown:
 //   * absolute URLs resolve (fail on 404/410),
 //   * relative links point at a tracked file (fail when the file is renamed
-//     or removed — same breakage class as a dead URL).
+//     or removed — same breakage class as a dead URL), in markdown link
+//     syntax and in HTML src/href attributes alike.
 // Zero dependencies (Node 22+ global fetch). Mirror of the api-parity gate:
 // same shape, same exit discipline — `ok` is not assumed, it is measured.
 //
@@ -69,19 +70,27 @@ function extractUrls(text) {
   return [...out];
 }
 
-// Relative markdown link targets: `[text](path)` and `[ref]: path`.
+// Relative link targets, in the three forms this repo's markdown uses:
+// `[text](path)`, `[ref]: path`, and HTML attributes — `<img src="path">`,
+// `<a href="path">`.
+//
+// The HTML form is not a nicety. A README opens with a centred `<p>` block
+// because markdown cannot centre an image, so every banner, logo and demo in
+// this repo is an HTML `src` and none of them were scanned: Ix#605 moved
+// assets/logo.png into ix-cli/ and the README's logo 404'd on the front page
+// of the project while this gate stayed green. Absolute URLs inside these
+// attributes were always covered — extractUrls() matches on `https?://`
+// wherever it appears — so this closes the relative half only.
 function extractRelativeTargets(text) {
   const targets = [];
-  for (const m of text.matchAll(/\]\(([^)]+)\)/g)) {
-    const t = m[1].trim();
-    if (isExternal(t) || t.startsWith('#')) continue;
+  const take = (raw) => {
+    const t = raw.trim();
+    if (isExternal(t) || t.startsWith('#')) return;
     targets.push(t);
-  }
-  for (const m of text.matchAll(/^\[[^\]]*\]:\s*(\S+)/gm)) {
-    const t = m[1].replace(/^<|>$/g, '').trim();
-    if (isExternal(t) || t.startsWith('#')) continue;
-    targets.push(t);
-  }
+  };
+  for (const m of text.matchAll(/\]\(([^)]+)\)/g)) take(m[1]);
+  for (const m of text.matchAll(/^\[[^\]]*\]:\s*(\S+)/gm)) take(m[1].replace(/^<|>$/g, ''));
+  for (const m of text.matchAll(/<[a-zA-Z][^>]*?\s(?:src|href)\s*=\s*["']([^"']+)["']/g)) take(m[1]);
   return targets;
 }
 function isExternal(t) {


### PR DESCRIPTION
The logo has been 404'ing on the front page of the project since 2026-09-06.

## The break

#605 moved `assets/logo.png` to `ix-cli/assets/logo.png` so the setup-notice
banner could render it. The move is right — the logo is a CLI build input now —
but `README.md:2` still pointed at the old path:

```html
<img src="./assets/logo.png" width="40%" />
```

`assets/` still holds `arch.png` and `demo.gif`, plus a `logo.jpg` that is the
pre-#605 original and is now referenced by nothing.

## Why the dead-link gate was green

This is the part worth fixing. `check-links.mjs` says in its own header that it
exists to catch a reference that breaks "when the file is renamed or removed."
It never saw this one.

It extracted markdown link syntax only — `](path)` and `[ref]: path`. A README
opens with a centred `<p>` block, because markdown cannot centre an image, so
**every image in this README is an HTML `src` attribute**: the logo, the
architecture diagram and the demo gif. None of the three were ever scanned. The
gate was blind in exactly the place a README puts its images.

## The change

1. Repoint the README at `./ix-cli/assets/logo.png` — one copy of the binary, no
   duplication and no drift, and it keeps the deliberate JPG→PNG switch from
   `4e470bf`.
2. Teach `extractRelativeTargets()` to read `src`/`href` out of HTML tags.

Absolute URLs inside those attributes were always covered — `extractUrls()`
matches `https?://` wherever it appears — so this closes the relative half only.

## Verification

Checked in both directions, because a gate that has never been shown to fail has
not been shown to work.

With the old path restored, the patched gate fails and names it:

```
ERROR  ./assets/logo.png (relative, in README.md)
checked 91 references — 1 broken, 1 warnings
```

With the fix applied:

```
checked 91 references — 0 broken, 1 warnings
```

The remaining warning is `desktop.docker.com` answering 403 to a non-browser,
which the script's header already documents as expected.

The new extractor finds exactly three HTML relative refs repo-wide — the logo,
`arch.png` and `demo.gif` — so this adds coverage without adding noise.

## Note for review

`Formula/ix.rb:46` also references `assets/logo.png`, but that one is correct:
it resolves inside a `cd "ix-cli"` block. No change needed there.

#605 has now missed four consumers of that one moved file — the npm tarball, the
release staging (#625), Homebrew (#630) and the README. The first three were
each caught by a person looking at it. This one is gated.
