### PR TITLE
test(cuda): budget the linearity guard instead of racing two parses

### DIFF
--- a/core-ingestion/src/__tests__/queries.cuda.test.ts
+++ b/core-ingestion/src/__tests__/queries.cuda.test.ts
@@ -91,21 +91,29 @@ void f(std::vector<std::vector<std::vector<int>>>& v, int a, int b) {
   it('stays linear on adversarial input', () => {
     // Ingest input is an arbitrary repository, so the blanking pass is
     // attacker-controlled. The obvious regex (`/<<<[^;]*?>>>(?=\\s*\\()/g`)
-    // is quadratic here: 16k `<` took 67ms and grew 4x per doubling.
-    const timeFor = (n: number) => {
-      const evil = `void f() { ${'<'.repeat(n)}>>>x }`;
-      const started = performance.now();
-      parseFile('/repo/evil.cu', evil);
-      return performance.now() - started;
-    };
+    // backtracks quadratically over a run of `<`; the scan in
+    // `blankCudaLaunchConfigs` never rewinds behind its cursor.
+    //
+    // This is an absolute budget rather than a small-vs-large ratio. Timing
+    // one parse against another leaves only the 4x of honest growth between
+    // pass and fail, which is thinner than the run-to-run noise on a parse
+    // this size -- that comparison failed on macos-14 at a measured 8.08x
+    // (Ix CI run 34297232151). A budget at an input size where the two
+    // implementations are seconds apart has no such overlap. Measured on a
+    // dev box at 128k `<`: this scan parses in 146-240ms over 15 runs, while
+    // the regex alone spends 8.3s backtracking. 2.5s sits ~10x above the
+    // slowest honest run and ~3x below the regression it guards. The test
+    // timeout is above the budget so a quadratic pass reports the assertion
+    // and its measured cost, not a bare vitest timeout.
+    const evil = `void f() { ${'<'.repeat(128_000)}>>>x }`;
 
-    timeFor(1_000); // warm the parser so the comparison is not first-call cost
+    parseFile('/repo/warm.cu', `void f() { ${'<'.repeat(1_000)}>>>x }`);
 
-    const small = timeFor(8_000);
-    const large = timeFor(32_000);
+    const started = performance.now();
+    parseFile('/repo/evil.cu', evil);
+    const elapsed = performance.now() - started;
 
-    // 4x the input. Quadratic would be ~16x; linear scanning stays well under.
-    expect(large).toBeLessThan(Math.max(small, 1) * 8);
-  });
+    expect(elapsed).toBeLessThan(2_500);
+  }, 30_000);
 
 });


### PR DESCRIPTION
## What failed

Run [34297232151](https://github.com/ix-infrastructure/Ix/actions/runs/34297232151) went red on `main` in one leg only — `Test (macos-14 · node 22)`:

```
FAIL src/__tests__/queries.cuda.test.ts > CUDA > stays linear on adversarial input
AssertionError: expected 37.70595800000001 to be less than 37.34300000000076
```

Nothing was merged red: #657 was green on all 25 checks at merge, including that exact leg, and so were #648–#656. Re-running the job passed on the same commit. The code was never wrong — the assertion was.

## Why it was going to fail eventually

The test timed one 8k parse against one 32k parse and required `large < small * 8`. Honest linear growth is already ~4x, so only 4x separated a pass from a failure — narrower than the run-to-run noise on a parse this size. Sampling the current assertion 20 times on a dev box reproduced it: **1 in 20 trials exceeded 8x**. Across five matrix legs per run, that is roughly the observed cadence.

It also measured mostly the wrong thing. Parsing identical source as `.cu` and as `.cpp` (the latter skips the CUDA path entirely) isolates the work the test claims to guard:

| n | `.cu` | `.cpp` | CUDA-specific |
|---|---|---|---|
| 8,000 | 8.54ms | 7.12ms | 1.42ms |
| 16,000 | 14.75ms | 16.24ms | −1.49ms |
| 32,000 | 37.42ms | 35.75ms | 1.67ms |
| 64,000 | 70.84ms | 69.90ms | 0.94ms |

The blanking pass costs ~1–2ms and stays flat; tree-sitter dominates >95% of the number being asserted on. The assertion was mostly measuring tree-sitter jitter.

## The change

An absolute budget at an input size where the correct scan and the regex it guards against are **seconds** apart rather than milliseconds. Measured at 128k `<`:

- this scan: **146–240ms** over 15 runs
- `/<<<[^;]*?>>>(?=\s*\()/g` alone: **8.3s** backtracking

2.5s sits ~10x above the slowest honest run and ~3x below the regression — noise cannot reach either side. The explicit 30s test timeout is what makes a quadratic pass report the assertion and its measured cost instead of a bare vitest timeout.

`blankCudaLaunchConfigs` itself is unchanged; it was already correct.

## Verification

- 12 consecutive runs of the file pass.
- Full `core-ingestion` suite: 389 passed, 1 skipped.
- **The guard still fires**: swapping the scan for that regex fails the test at `expected 7805.775707000001 to be less than 2500`, as an assertion rather than a timeout.
- `tsc -p tsconfig.json --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5dGybWMdHkEdbNEsSuF2G