### PR TITLE
docs(readme): drop the alpha status section

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,11 +293,6 @@ Kartr is in alpha and onboarding early users.
   </a>
 </p>
 
-## Status
-
-Alpha, and moving quickly. APIs and behavior may change. If you are running Ix on a
-large or unusual codebase, we want the bug report.
-
 ## Contributing
 
 Issues and pull requests are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for local


### PR DESCRIPTION
Ix is not alpha anymore. Removes the `## Status` section from the README:

> **Status**
>
> Alpha, and moving quickly. APIs and behavior may change. If you are running Ix on a large or unusual codebase, we want the bug report.

Nothing replaces it — the README now runs from the Kartr section straight into `## Contributing`.

## Scope

**The Kartr section stays, deliberately.** "Kartr is in alpha and onboarding early users" and the signup badge above the removed section are untouched. That is the commercial product's onboarding CTA and we want the README pointing people at it — only the claim about *this repo* being alpha is going.

**The bug-report invitation goes with the section.** The second sentence was a call for reports from large or unusual codebases. It is not being relocated; the section says nothing now rather than something shorter.

## Checks

Nothing links to the `#status` anchor and no TOC references it, so the Dead-link gate has nothing to catch. This was the only place on the OSS side that described the project itself as alpha — the remaining `alpha` hits across the plugin repos are target dates for OpenClaw and the Core Runtime, which are unrelated claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5dGybWMdHkEdbNEsSuF2G